### PR TITLE
MCR-1400 MCRUserInformation security add check for privilege escalation

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/MCRSession.java
+++ b/mycore-base/src/main/java/org/mycore/common/MCRSession.java
@@ -455,10 +455,29 @@ public class MCRSession implements Cloneable {
     /**
      * @param userSystemAdapter
      *            the userInformation to set
+     * @throws IllegalArgumentException if transition to new user information is forbidden (privilege escalation)
      */
     public void setUserInformation(MCRUserInformation userSystemAdapter) {
+        //check for MCR-1400
+        if (!isTransitionAllowed(userSystemAdapter)) {
+            throw new IllegalArgumentException("User transition from "
+                + getUserInformation().getUserID()
+                + " to " + userSystemAdapter.getUserID()
+                + " is not permitted within the same session.");
+        }
         this.userInformation = userSystemAdapter;
         setLoginTime();
+    }
+
+    private boolean isTransitionAllowed(MCRUserInformation userSystemAdapter) {
+        //allow if current user super user or not logged in
+        if (MCRSystemUserInformation.getSuperUserInstance().equals(userInformation)
+            || MCRSystemUserInformation.getGuestInstance().equals(userInformation))
+            return true;
+        //allow if new user information has default rights of guest user
+        //or userID equals old userID
+        return MCRSystemUserInformation.getGuestInstance().equals(userSystemAdapter)
+            || userInformation.getUserID().equals(userSystemAdapter.getUserID());
     }
 
 }

--- a/mycore-base/src/test/java/org/mycore/common/MCRSessionTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/MCRSessionTest.java
@@ -1,0 +1,89 @@
+/**
+ * 
+ */
+package org.mycore.common;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Thomas Scheffler (yagee)
+ *
+ */
+public class MCRSessionTest extends MCRTestCase {
+
+    private static final MCRSystemUserInformation SUPER_USER_INSTANCE = MCRSystemUserInformation.getSuperUserInstance();
+
+    private static final MCRSystemUserInformation GUEST_INSTANCE = MCRSystemUserInformation.getGuestInstance();
+
+    private MCRSession session;
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.session = new MCRSession();
+    }
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @After
+    public void tearDown() throws Exception {
+        this.session.close();
+        super.tearDown();
+    }
+
+    @Test
+    public void testIsGuestDefault() {
+        assertEquals(GUEST_INSTANCE, session.getUserInformation());
+    }
+
+    @Test
+    public void loginSuperUser() {
+        session.setUserInformation(SUPER_USER_INSTANCE);
+        assertEquals(SUPER_USER_INSTANCE, session.getUserInformation());
+    }
+
+    @Test
+    public void downGradeUser() {
+        MCRUserInformation otherUser = getSimpleUserInformation("JUnit");
+        session.setUserInformation(SUPER_USER_INSTANCE);
+        session.setUserInformation(otherUser);
+        assertEquals(otherUser, session.getUserInformation());
+        session.setUserInformation(GUEST_INSTANCE);
+        assertEquals(GUEST_INSTANCE, session.getUserInformation());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void upgradeFail() {
+        MCRUserInformation otherUser = getSimpleUserInformation("JUnit");
+        session.setUserInformation(otherUser);
+        session.setUserInformation(SUPER_USER_INSTANCE);
+    }
+
+    private static MCRUserInformation getSimpleUserInformation(String userID) {
+        return new MCRUserInformation() {
+            @Override
+            public boolean isUserInRole(String role) {
+                return false;
+            }
+
+            @Override
+            public String getUserID() {
+                return userID;
+            }
+
+            @Override
+            public String getUserAttribute(String attribute) {
+                return null;
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
Once a user is logged in, we must ensure that the UserID does not change during
the sessions lifetime. Exceptions are for the super user and if the userID does not
change (MCRTransientUser becomes MCRUser instance).
