### PR TITLE
MCR-1374 fix-conf-exc

### DIFF
--- a/mycore-oai/src/main/java/org/mycore/oai/MCROAISetManager.java
+++ b/mycore-oai/src/main/java/org/mycore/oai/MCROAISetManager.java
@@ -139,7 +139,7 @@ public class MCROAISetManager {
     protected void updateURIs() {
         this.setConfigurationMap = Collections.synchronizedMap(new HashMap<>());
         MCRConfiguration config = MCRConfiguration.instance();
-        String setIds = config.getString(this.configPrefix + "Sets");
+        String setIds = config.getString(this.configPrefix + "Sets", "");
         for (String setId : setIds.split(",")) {
             setId = setId.trim();
             MCROAISetConfiguration<?> setConf = new MCROAISolrSetConfiguration(this.configPrefix, setId);


### PR DESCRIPTION
fixing configuration exception if there is no MCR.OAIDataProvider.XXX.Sets property. this should not lead to an invalid oai error site.