### PR TITLE
MCR-1460 IFS checks throw more IOExceptions

### DIFF
--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetadataManager.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetadataManager.java
@@ -271,6 +271,7 @@ public final class MCRMetadataManager {
         MCRPath rootPath = MCRPath.getPath(derivateID, "/");
         if (!Files.exists(rootPath)) {
             LOGGER.info("Derivate does not exist: " + derivateID);
+            return;
         }
         Files.walkFileTree(rootPath, MCRRecursiveDeleter.instance());
         rootPath.getFileSystem().removeRoot(derivateID);


### PR DESCRIPTION
which is a good thing, as we already urge the user to catch
IOException. They should not check for 'null' then...