### PR TITLE
MCR-1497 MCRJPATestCase dropSchema Fix

### DIFF
--- a/mycore-base/src/test/java/org/mycore/backend/jpa/access/MCRJPAAccessStoreTest.java
+++ b/mycore-base/src/test/java/org/mycore/backend/jpa/access/MCRJPAAccessStoreTest.java
@@ -37,14 +37,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mycore.access.mcrimpl.MCRRuleMapping;
 import org.mycore.backend.hibernate.MCRHIBConnection;
-import org.mycore.common.MCRHibTestCase;
+import org.mycore.common.MCRJPATestCase;
 
 /**
  * @author Thomas Scheffler (yagee)
  * 
  * @version $Revision$ $Date$
  */
-public class MCRJPAAccessStoreTest extends MCRHibTestCase {
+public class MCRJPAAccessStoreTest extends MCRJPATestCase {
 
     private static final MCRACCESSRULE TRUE_RULE = getTrueRule();
 

--- a/mycore-base/src/test/java/org/mycore/common/MCRHibTestCase.java
+++ b/mycore-base/src/test/java/org/mycore/common/MCRHibTestCase.java
@@ -24,14 +24,7 @@
 package org.mycore.common;
 
 /**
- * @author Thomas Scheffler (yagee) Need to insert some things here
+ * @author Thomas Scheffler (yagee)
  */
-public abstract class MCRHibTestCase extends MCRJPATestCase {
-
-
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-    }
-
-}
+@Deprecated
+public abstract class MCRHibTestCase extends MCRJPATestCase{}

--- a/mycore-base/src/test/java/org/mycore/common/MCRJPATestCase.java
+++ b/mycore-base/src/test/java/org/mycore/common/MCRJPATestCase.java
@@ -17,7 +17,6 @@ import javax.persistence.Persistence;
 import javax.persistence.Query;
 import javax.persistence.RollbackException;
 
-import org.apache.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.junit.After;
 import org.junit.Before;
@@ -63,7 +62,7 @@ public class MCRJPATestCase extends MCRTestCase {
     public void setUp() throws Exception {
         // Configure logging etc.
         super.setUp();
-        Logger.getLogger(MCRHibTestCase.class).debug("Setup JPA");
+        LogManager.getLogger().debug("Setup JPA");
         MCRJPABootstrapper.initializeJPA();
         exportSchema();
         MCRHibernateConfigHelper
@@ -104,7 +103,7 @@ public class MCRJPATestCase extends MCRTestCase {
         }
     }
 
-    private Optional<String> getDefaultSchema() {
+    protected Optional<String> getDefaultSchema() {
         return Optional.ofNullable(MCREntityManagerProvider
             .getEntityManagerFactory()
             .getProperties()
@@ -123,11 +122,14 @@ public class MCRJPATestCase extends MCRTestCase {
 
     @After
     public void tearDown() throws Exception {
-        endTransaction();
-        entityManager.close();
-        dropSchema();
-        super.tearDown();
-        entityManager = null;
+        try {
+            endTransaction();
+        } finally {
+            entityManager.close();
+            dropSchema();
+            super.tearDown();
+            entityManager = null;
+        }
     }
 
     protected void beginTransaction() {

--- a/mycore-base/src/test/java/org/mycore/common/MCRStoreTestCase.java
+++ b/mycore-base/src/test/java/org/mycore/common/MCRStoreTestCase.java
@@ -8,7 +8,7 @@ import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.mycore.datamodel.common.MCRXMLMetadataManager;
 
-public abstract class MCRStoreTestCase extends MCRHibTestCase {
+public abstract class MCRStoreTestCase extends MCRJPATestCase {
 
     private static MCRXMLMetadataManager store;
 

--- a/mycore-base/src/test/java/org/mycore/datamodel/classifications2/impl/MCRCategLinkServiceImplTest.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/classifications2/impl/MCRCategLinkServiceImplTest.java
@@ -35,7 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mycore.backend.jpa.MCREntityManagerProvider;
 import org.mycore.common.MCRException;
-import org.mycore.common.MCRHibTestCase;
+import org.mycore.common.MCRJPATestCase;
 import org.mycore.common.content.MCRVFSContent;
 import org.mycore.common.xml.MCRXMLParserFactory;
 import org.mycore.datamodel.classifications2.MCRCategLinkReference;
@@ -47,7 +47,7 @@ import org.xml.sax.SAXParseException;
 /**
  * @author Thomas Scheffler (yagee) Need to insert some things here
  */
-public class MCRCategLinkServiceImplTest extends MCRHibTestCase {
+public class MCRCategLinkServiceImplTest extends MCRJPATestCase {
     private static final MCRCategLinkReference ENGLAND_REFERENCE = new MCRCategLinkReference("England", "state");
 
     private static final MCRCategLinkReference LONDON_REFERENCE = new MCRCategLinkReference("London", "city");

--- a/mycore-base/src/test/java/org/mycore/datamodel/classifications2/impl/MCRCategoryDAOImplTest.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/classifications2/impl/MCRCategoryDAOImplTest.java
@@ -59,7 +59,7 @@ import org.junit.Test;
 import org.mycore.backend.hibernate.MCRHIBConnection;
 import org.mycore.backend.jpa.MCREntityManagerProvider;
 import org.mycore.common.MCRException;
-import org.mycore.common.MCRHibTestCase;
+import org.mycore.common.MCRJPATestCase;
 import org.mycore.common.MCRStreamUtils;
 import org.mycore.common.content.MCRURLContent;
 import org.mycore.common.content.MCRVFSContent;
@@ -73,7 +73,7 @@ import org.mycore.datamodel.classifications2.utils.MCRStringTransformer;
 import org.mycore.datamodel.classifications2.utils.MCRXMLTransformer;
 import org.xml.sax.SAXParseException;
 
-public class MCRCategoryDAOImplTest extends MCRHibTestCase {
+public class MCRCategoryDAOImplTest extends MCRJPATestCase {
 
     static final String WORLD_CLASS_RESOURCE_NAME = "/worldclass.xml";
 
@@ -718,7 +718,8 @@ public class MCRCategoryDAOImplTest extends MCRHibTestCase {
             try {
                 Statement statement = connection.createStatement();
                 try {
-                    ResultSet resultSet = statement.executeQuery("SELECT * FROM MCRCategory");
+                    String tableName = getDefaultSchema().map(s -> s + ".").orElse("") + "MCRCategory";
+                    ResultSet resultSet = statement.executeQuery("SELECT * FROM " + tableName);
                     printResultSet(resultSet, System.out);
                 } catch (SQLException e1) {
                     LogManager.getLogger().warn("Error while querying MCRCategory", e1);

--- a/mycore-base/src/test/java/org/mycore/services/packaging/MCRPackerManagerTest.java
+++ b/mycore-base/src/test/java/org/mycore/services/packaging/MCRPackerManagerTest.java
@@ -7,11 +7,11 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mycore.common.MCRHibTestCase;
+import org.mycore.common.MCRJPATestCase;
 import org.mycore.common.config.MCRConfiguration;
 import org.mycore.services.queuedjob.MCRJob;
 
-public class MCRPackerManagerTest extends MCRHibTestCase {
+public class MCRPackerManagerTest extends MCRJPATestCase {
 
     public static final String TEST_PACKER_ID = "testPacker";
 

--- a/mycore-base/src/test/java/org/mycore/services/queuedjob/MCRJobQueueTest.java
+++ b/mycore-base/src/test/java/org/mycore/services/queuedjob/MCRJobQueueTest.java
@@ -29,13 +29,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
-import org.mycore.common.MCRHibTestCase;
+import org.mycore.common.MCRJPATestCase;
 
 /**
  * @author Ren\u00E9 Adler (eagle)
  *
  */
-public class MCRJobQueueTest extends MCRHibTestCase {
+public class MCRJobQueueTest extends MCRJPATestCase {
 
     @Test
     public void testOffer() throws InterruptedException {

--- a/mycore-mods/src/test/java/org/mycore/mods/MCRMODSLinkedMetadataTest.java
+++ b/mycore-mods/src/test/java/org/mycore/mods/MCRMODSLinkedMetadataTest.java
@@ -21,7 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mycore.access.MCRAccessException;
 import org.mycore.common.MCRConstants;
-import org.mycore.common.MCRHibTestCase;
+import org.mycore.common.MCRJPATestCase;
 import org.mycore.common.MCRPersistenceException;
 import org.mycore.common.MCRSessionMgr;
 import org.mycore.common.MCRSystemUserInformation;
@@ -40,7 +40,7 @@ import org.xml.sax.SAXException;
  * 
  * @author Thomas Scheffler (yagee)
  */
-public class MCRMODSLinkedMetadataTest extends MCRHibTestCase {
+public class MCRMODSLinkedMetadataTest extends MCRJPATestCase {
 
     MCRObjectID seriesID, bookID;
 

--- a/mycore-mods/src/test/java/org/mycore/mods/classification/MCRClassificationMappingEventHandlerTest.java
+++ b/mycore-mods/src/test/java/org/mycore/mods/classification/MCRClassificationMappingEventHandlerTest.java
@@ -14,7 +14,7 @@ import org.jdom2.xpath.XPathFactory;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mycore.common.MCRConstants;
-import org.mycore.common.MCRHibTestCase;
+import org.mycore.common.MCRJPATestCase;
 import org.mycore.common.MCRSessionMgr;
 import org.mycore.datamodel.classifications2.MCRCategory;
 import org.mycore.datamodel.classifications2.MCRCategoryDAO;
@@ -25,7 +25,7 @@ import org.mycore.mods.MCRMODSWrapper;
 import org.xml.sax.SAXParseException;
 
 
-public class MCRClassificationMappingEventHandlerTest extends MCRHibTestCase {
+public class MCRClassificationMappingEventHandlerTest extends MCRJPATestCase {
 
     public static final String TEST_DIRECTORY = "MCRClassificationMappingEventHandlerTest/";
     private static final Logger LOGGER = Logger.getLogger(MCRClassificationMappingEventHandlerTest.class);

--- a/mycore-urn/src/test/java/org/mycore/urn/MCRURNGeneratorTest.java
+++ b/mycore-urn/src/test/java/org/mycore/urn/MCRURNGeneratorTest.java
@@ -7,12 +7,12 @@ import java.util.Map;
 
 import org.junit.Test;
 import org.mycore.common.MCRException;
-import org.mycore.common.MCRHibTestCase;
+import org.mycore.common.MCRJPATestCase;
 import org.mycore.common.config.MCRConfiguration;
 import org.mycore.urn.services.MCRURN;
 import org.mycore.urn.services.MCRURNManager;
 
-public class MCRURNGeneratorTest extends MCRHibTestCase {
+public class MCRURNGeneratorTest extends MCRJPATestCase {
     @Test
     public void testChecksum() {
         assertEquals(true, MCRURN.isValid("urn:nbn:de:gbv:28-diss2015-0237-9"));

--- a/mycore-user2/src/test/java/org/mycore/user2/MCRUserTestCase.java
+++ b/mycore-user2/src/test/java/org/mycore/user2/MCRUserTestCase.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Ignore;
-import org.mycore.common.MCRHibTestCase;
+import org.mycore.common.MCRJPATestCase;
 import org.mycore.datamodel.classifications2.MCRCategory;
 import org.mycore.datamodel.classifications2.MCRCategoryDAO;
 import org.mycore.datamodel.classifications2.MCRCategoryDAOFactory;
@@ -38,7 +38,7 @@ import org.mycore.datamodel.classifications2.impl.MCRCategoryDAOImplTest;
  *
  */
 @Ignore
-public class MCRUserTestCase extends MCRHibTestCase {
+public class MCRUserTestCase extends MCRJPATestCase {
 
     @Before
     @Override


### PR DESCRIPTION
dropSchema() is now called in a finally block to make sure it runs even if endTransaction() may fail before. Also marked MCRHibTestCase deprecated.