### PR TITLE
MCR-1507 MCRURIResolver.resolveURI() fix

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/xml/MCRURIResolver.java
+++ b/mycore-base/src/main/java/org/mycore/common/xml/MCRURIResolver.java
@@ -375,7 +375,7 @@ public final class MCRURIResolver implements URIResolver {
     static URI resolveURI(String href, String base) {
         URI hrefURI = Optional.ofNullable(base)
             .map(URI::create)
-            .map(u -> u.resolve(base))
+            .map(u -> u.resolve(href))
             .orElse(URI.create(href));
         return hrefURI;
     }


### PR DESCRIPTION
if 'base' was given 'base' and not 'href' was always resolved against base.