### PR TITLE
MCR-1547 MCRCompressServlet throws NPE

### DIFF
--- a/mycore-base/src/main/java/org/mycore/services/zipper/MCRCompressServlet.java
+++ b/mycore-base/src/main/java/org/mycore/services/zipper/MCRCompressServlet.java
@@ -135,6 +135,9 @@ public abstract class MCRCompressServlet<T extends AutoCloseable> extends MCRSer
             //we cannot handle it ourself
             throw ex;
         }
+        if (job.getResponse().isCommitted()) {
+            return;
+        }
         MCRObjectID id = (MCRObjectID) job.getRequest().getAttribute(KEY_OBJECT_ID);
         String path = (String) job.getRequest().getAttribute(KEY_PATH);
         try (ServletOutputStream sout = job.getResponse().getOutputStream()) {


### PR DESCRIPTION
If a error document is send there is no information about the object or derivate.
We should check if the response is already committed.