### PR TITLE
MCR-1590 MCRClassificationMappingEventHandler only adds mapping of last entry

### DIFF
--- a/mycore-mods/src/main/java/org/mycore/mods/classification/MCRClassificationMappingEventHandler.java
+++ b/mycore-mods/src/main/java/org/mycore/mods/classification/MCRClassificationMappingEventHandler.java
@@ -84,7 +84,7 @@ public class MCRClassificationMappingEventHandler extends MCREventHandlerBase {
             return;
         }
         // vorher alle mit generator *-mycore löschen
-        mcrmodsWrapper.getElements("//classification[contains(@generator, '" + GENERATOR_SUFFIX + "')]")
+        mcrmodsWrapper.getElements("mods:classification[contains(@generator, '" + GENERATOR_SUFFIX + "')]")
                 .stream().forEach(Element::detach);
 
         LOGGER.info("check mappings " + obj.getId().toString());


### PR DESCRIPTION
Fixed xpath of auto generated classifications. You need to run a repair
if you had this branch in your mods application.