### PR TITLE
MCR-1597 refactored MCRGoogleSitemap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_script:
   - |
    echo "BUILD START: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 script:
-  - mkdir ${HOME}/tmp 
+  - mkdir ${HOME}/tmp
   - export TMPDIR="${HOME}/tmp"
   - mvn -B -Plocal-testing,!standard-with-extra-repos clean install -DDriverProvider=org.mycore.common.selenium.drivers.MCRChromeDriverFactory && mvn -P!standard-with-extra-repos -B javadoc:javadoc && mvn -P!standard-with-extra-repos com.gavinmogan:codacy-maven-plugin:coverage -DcoverageReportFile=target/site/jacoco/jacoco.xml -DfailOnMissingReportFile=false
 after_failure:

--- a/mycore-base/src/main/resources/config/mycore.properties
+++ b/mycore-base/src/main/resources/config/mycore.properties
@@ -28,12 +28,6 @@
   MCR.baseurl=http://localhost:8291
 
 ##############################################################################
-# Google Sitemap                                                             #
-##############################################################################
-# Sets the filter for the Solr query
-  MCR.GoogleSitemap.SolrQuery=(objectType:mods AND -state:*) OR (objectType:mods AND state:published)
-
-##############################################################################
 # The XML parser configuration
 ##############################################################################
 

--- a/mycore-base/src/main/resources/deprecated.properties
+++ b/mycore-base/src/main/resources/deprecated.properties
@@ -56,6 +56,7 @@ MCR.classifications_classification_cache_size=MCR.Persistence.Classification.Sto
 MCR.classifications_category_cache_size=MCR.Persistence.Classification.Store.CacheSize.Categ
 
 MCR.googlesitemap.types=MCR.GoogleSitemap.Types
+MCR.GoogleSitemap.Types=MCR.GoogleSitemap.SolrQuery
 MCR.googlesitemap.freq=MCR.GoogleSitemap.Freq
 
 MCR.UriResolver.classification.format.textcounter=MCR.URIResolver.Classification.Format.TextCounter

--- a/mycore-indexing/src/main/resources/components/indexing/config/mycore.properties
+++ b/mycore-indexing/src/main/resources/components/indexing/config/mycore.properties
@@ -3,8 +3,8 @@
 # The configuration for component indexing
 ##############################################################################
 
-# MyCoRe types for indexing objects, document is default
-  MCR.GoogleSitemap.Types=test
+# MyCoRe types for indexing objects, list all mycore objects is default
+  MCR.GoogleSitemap.SolrQuery=objectKind:mycoreobject
 
 # frequence for google access
 # allways - hourly - daily - weekly - monthly - yearly - never


### PR DESCRIPTION
use Solr instead of MetadataStore.use property MCR.GoogleSitemap.SolrQuery to define Solr query.
default query delivers only published and stateless MODSObjects