### PR TITLE
MCR-1634 non complete remove of derivates

### DIFF
--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetadataManager.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetadataManager.java
@@ -377,8 +377,7 @@ public final class MCRMetadataManager {
                 deleteDerivate(id.toString());
                 LOGGER.info("IFS entries for MCRDerivate " + id.toString() + " are deleted.");
             } catch (final Exception e) {
-                throw new MCRPersistenceException("Error while delete for ID " + id.toString()
-                    + " from IFS with ID " + mcrDerivate.getDerivate().getInternals().getIFSID(), e);
+                throw new MCRPersistenceException("Error while delete MCRDerivate " + id.toString() + " in IFS", e);
             }
         }
 

--- a/mycore-ifs/src/main/java/org/mycore/datamodel/ifs/MCRDirectory.java
+++ b/mycore-ifs/src/main/java/org/mycore/datamodel/ifs/MCRDirectory.java
@@ -356,6 +356,16 @@ public class MCRDirectory extends MCRFilesystemNode {
             .directory(getID(), getSize(), FileTime.fromMillis(getLastModified().getTimeInMillis()));
     }
 
+    @Override
+    /**
+     * Returns 0 as number of bytes for a directory
+     */
+    public long getSize() {
+        ensureNotDeleted();
+
+        return 0;
+    }
+
     /** Constant for choosing file nodes * */
     public final static int FILES = 1;
 


### PR DESCRIPTION
Add a method to return the size of a MCRDirectory each time to 0. This is the value which should set in the MCRFSNODES.
This change solve the bug with wrong directory entry after using METS editor too.
Fix a little log text bug in MCRMetadataManager.