### PR TITLE
MCR-1735 make oai_datacite metadata format extendable

### DIFF
--- a/mycore-mods/src/main/resources/components/mods/config/mycore.properties
+++ b/mycore-mods/src/main/resources/components/mods/config/mycore.properties
@@ -74,6 +74,7 @@ MCR.DOI.NISSPattern=yyyyMMdd-HHmmss
 
 MCR.CLI.Classes.Internal=%MCR.CLI.Classes.Internal%,org.mycore.mods.MCRMODSCommands
 MCR.URIResolver.xslIncludes.objectTypes=%MCR.URIResolver.xslIncludes.objectTypes%,mods.xsl
+MCR.URIResolver.xslIncludes.datacite=mycoreobject-datacite.xsl
 MCR.URIResolver.xslImports.solr-document=%MCR.URIResolver.xslImports.solr-document%,mods-solr.xsl
 MCR.URIResolver.redirect.editor-mods-external=webapp:editor/editor-mods-external.xml
 

--- a/mycore-mods/src/main/resources/xsl/mods2oai_datacite.xsl
+++ b/mycore-mods/src/main/resources/xsl/mods2oai_datacite.xsl
@@ -1,41 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <xsl:stylesheet version="1.0"
-  xmlns="http://www.openarchives.org/OAI/2.0/"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:mods="http://www.loc.gov/mods/v3"
   xmlns:oai_datacite="http://schema.datacite.org/oai/oai-1.0/"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:mcrurn="xalan://org.mycore.urn.MCRXMLFunctions"
-  xmlns:xlink="http://www.w3.org/1999/xlink"
-  xmlns:mcr="xalan://org.mycore.common.xml.MCRXMLFunctions"
-  exclude-result-prefixes="xsl xlink mods mcrurn mcr"
->
+  exclude-result-prefixes="xsl" >
+  
+  <xsl:include href="xslInclude:datacite" />
 
-  <xsl:param name="ServletsBaseURL" select="''" />
-  <xsl:param name="WebApplicationBaseURL" select="''" />
-  <xsl:param name="HttpSession" select="''" />
-  <xsl:param name="MCR.URN.Resolver.MasterURL" select="''" />
-
-  <xsl:include href="mycoreobject-datacite.xsl" />
-  <xsl:include href="mods2record.xsl" />
-  <xsl:include href="mods-utils.xsl" />
-
-  <xsl:template match="mycoreobject" mode="metadata">
-
+  <xsl:template match="mycoreobject">
     <oai_datacite:oai_datacite
-      xmlns="http://schema.datacite.org/oai/oai-1.0/"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://schema.datacite.org/oai/oai-1.0/ oai_datacite.xsd">
+      xsi:schemaLocation="http://schema.datacite.org/oai/oai-1.0/ http://schema.datacite.org/oai/oai-1.0/oai.xsd">
       <oai_datacite:isReferenceQuality>true</oai_datacite:isReferenceQuality>
       <oai_datacite:schemaVersion>3.1</oai_datacite:schemaVersion>
       <oai_datacite:payload>
-
-        <xsl:apply-templates select="//mods:mods" />
-
+        <xsl:apply-templates select="metadata/def.modsContainer/modsContainer/mods:mods" />
       </oai_datacite:payload>
     </oai_datacite:oai_datacite>
-
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
use property 'MCR.URIResolver.xslIncludes.datacite' to set stylesheet
used for oai_datacite transformation