### PR TITLE
MCR-1812 add thumbnail resource

### DIFF
--- a/mycore-media/pom.xml
+++ b/mycore-media/pom.xml
@@ -70,5 +70,13 @@
       <groupId>org.mycore</groupId>
       <artifactId>mycore-ifs</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.mycore</groupId>
+      <artifactId>mycore-iview2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mycore.iview2</groupId>
+      <artifactId>image-tiler</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/mycore-media/src/main/java/org/mycore/media/frontend/jersey/MCRThumbnailResource.java
+++ b/mycore-media/src/main/java/org/mycore/media/frontend/jersey/MCRThumbnailResource.java
@@ -1,0 +1,115 @@
+package org.mycore.media.frontend.jersey;
+
+import org.mycore.access.MCRAccessManager;
+import org.mycore.common.config.MCRConfiguration;
+import org.mycore.datamodel.metadata.MCRMetadataManager;
+import org.mycore.datamodel.metadata.MCRObjectID;
+import org.mycore.datamodel.niofs.MCRPath;
+import org.mycore.frontend.jersey.MCRJerseyUtil;
+import org.mycore.media.services.MCRThumbnailGenerator;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.nio.file.Files;
+
+import java.nio.file.attribute.FileTime;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Path("thumbnail")
+public class MCRThumbnailResource {
+    @Context
+    private Request request;
+
+    /**
+     * This method returns a thumbnail for a given document with a given size in pixel for the shortest side.
+     * @param documentId the documentID you want the thumbnail from
+     * @param size the size of the shortest side in pixel
+     * @return the thumbnail as png, jpg or error 404 if if there is no derivate or no generator for filetype
+     */
+    @GET
+    @Path("{documentId}/{size}.{ext}")
+    @Produces({"image/png","image/jpeg"})
+    public Response getThumbnailFromDocument(@PathParam("documentId") String documentId, @PathParam("size") int size,
+            @PathParam("ext") String ext) {
+        return getThumbnail(documentId, size, ext);
+    }
+
+    /**
+     * This method returns a thumbnail for a given document with a default size in pixel for the shortest side.
+     * @param documentId the documentID you want the thumbnail from
+     * @return the thumbnail as png, jpg or error 404 if if there is no derivate or no generator for filetype
+     */
+    @GET
+    @Path("{documentId}.{ext}")
+    @Produces({"image/png", "image/jpeg"})
+    public Response getThumbnailFromDocument(@PathParam("documentId") String documentId, @PathParam("ext") String ext) {
+        int defaultSize = MCRConfiguration.instance().getInt("MCR.Media.Thumbnail.DefaultSize");
+        return getThumbnail(documentId, defaultSize, ext);
+    }
+
+
+    private Response getThumbnail(String documentId, int size, String ext) {
+        List<MCRObjectID> derivateIds = MCRMetadataManager.getDerivateIds(MCRJerseyUtil.getID(documentId),
+            1,TimeUnit.MINUTES);
+        for (MCRObjectID derivateId : derivateIds) {
+            if (MCRAccessManager.checkPermissionForReadingDerivate(derivateId.toString())){
+                String nameOfMainFile = MCRMetadataManager.retrieveMCRDerivate(derivateId).getDerivate().getInternals()
+                    .getMainDoc();
+                if (nameOfMainFile != null && !nameOfMainFile.equals("")) {
+                    MCRPath mainFile = MCRPath.getPath(derivateId.toString(), '/' + nameOfMainFile);
+                    try {
+                        String mimeType = Files.probeContentType(mainFile);
+                        String generators = MCRConfiguration.instance()
+                            .getString("MCR.Media.Thumbnail.Generators");
+                        for (String generator : generators.split(",")) {
+                            Class<MCRThumbnailGenerator> classObject = (Class<MCRThumbnailGenerator>) Class
+                                .forName(generator);
+                            Constructor<MCRThumbnailGenerator> constructor = classObject.getConstructor();
+                            MCRThumbnailGenerator thumbnailGenerator = constructor.newInstance();
+                            if (thumbnailGenerator.matchesFileType(mimeType, mainFile)) {
+                                FileTime lastModified = Files.getLastModifiedTime(mainFile);
+                                Date lastModifiedDate = new Date(lastModified.toMillis());
+                                Response.ResponseBuilder resp = request.evaluatePreconditions(lastModifiedDate);
+                                if (resp == null) {
+                                    Optional<BufferedImage> thumbnail =
+                                        thumbnailGenerator.getThumbnail(mainFile, size);
+                                    if (thumbnail.isPresent()) {
+                                        CacheControl cc = new CacheControl();
+                                        cc.setMaxAge((int) TimeUnit.DAYS.toSeconds(1));
+                                        String type = "image/png";
+                                        if ("jpg".equals(ext) || "jpeg".equals(ext)) {
+                                            type = "image/jpeg";
+                                        }
+                                        return Response.ok(thumbnail.get())
+                                            .cacheControl(cc)
+                                            .lastModified(lastModifiedDate)
+                                            .type(type)
+                                            .build();
+                                    }
+                                    return Response.status(Response.Status.NOT_FOUND).build();
+                                }
+                                return resp.build();
+                            }
+                        }
+                    } catch (IOException | ReflectiveOperationException e) {
+                        throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+                    }
+                }
+            }
+        }
+        return Response.status(Response.Status.NOT_FOUND).build();
+    }
+}

--- a/mycore-media/src/main/java/org/mycore/media/services/MCRImageThumbnailGenerator.java
+++ b/mycore-media/src/main/java/org/mycore/media/services/MCRImageThumbnailGenerator.java
@@ -1,0 +1,81 @@
+package org.mycore.media.services;
+
+import org.mycore.datamodel.niofs.MCRPath;
+
+import org.mycore.imagetiler.MCRImage;
+import org.mycore.imagetiler.MCRTiledPictureProps;
+import org.mycore.iview2.services.MCRIView2Tools;
+
+import javax.imageio.ImageReader;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+public class MCRImageThumbnailGenerator implements MCRThumbnailGenerator {
+
+    private static final Pattern MATCHING_MIMETYPE = Pattern.compile("^image\\/.*");
+
+    @Override
+    public boolean matchesFileType(String mimeType, MCRPath path) {
+        return MATCHING_MIMETYPE.matcher(mimeType).matches();
+    }
+
+    @Override
+    public Optional<BufferedImage> getThumbnail(MCRPath path, int size) throws IOException {
+        Path iviewFile = MCRImage.getTiledFile(MCRIView2Tools.getTileDir(), path.getOwner(), path.getFileName()
+            .toString());
+        MCRTiledPictureProps iviewFileProps = getIviewFileProps(iviewFile);
+        final double width = iviewFileProps.getWidth();
+        final double height = iviewFileProps.getHeight();
+        final int newWidth = width > height ? (int) Math.ceil(size * width / height) : size;
+        final int newHeight = width > height ? size : (int) Math.ceil(size * height / width);
+
+        // this value determines the zoom level!
+        final double scale = newWidth / width;
+
+        // We always want to use the the best needed zoom level!
+        int sourceZoomLevel = (int) Math.min(
+            Math.max(0, Math.ceil(iviewFileProps.getZoomlevel() - Math.log(scale) / Math.log(1.0 / 2.0))),
+            iviewFileProps.getZoomlevel());
+
+        // scale is the real scale which is needed! zoomLevelScale is the scale of the nearest zoom level!
+        double zoomLevelScale = Math.min(1.0, Math.pow(0.5, iviewFileProps.getZoomlevel() - sourceZoomLevel));
+
+        // this is the scale which is needed from the nearest zoom level to the required size of image
+        double drawScale = (newWidth / (width * zoomLevelScale));
+
+        try (FileSystem zipFileSystem = MCRIView2Tools.getFileSystem(iviewFile)) {
+            Path rootPath = zipFileSystem.getPath("/");
+            ImageReader imageReader = MCRIView2Tools.getTileImageReader();
+            BufferedImage testTile = MCRIView2Tools.readTile(rootPath, imageReader, sourceZoomLevel, 0, 0);
+            BufferedImage targetImage = getTargetImage(newWidth, newHeight, testTile);
+            Graphics2D graphics = targetImage.createGraphics();
+            graphics.scale(drawScale, drawScale);
+            for (int x = 0; x < Math.ceil(width * zoomLevelScale / 256); x++) {
+                for (int y = 0; y < Math.ceil(height * zoomLevelScale / 256); y++) {
+                    BufferedImage tile = MCRIView2Tools.readTile(rootPath, imageReader, sourceZoomLevel, x, y);
+                    graphics.drawImage(tile, x * 256, y * 256, null);
+                }
+            }
+            return Optional.of(targetImage);
+        }
+    }
+
+    private MCRTiledPictureProps getIviewFileProps(Path tiledFile) throws IOException {
+        MCRTiledPictureProps tiledPictureProps = null;
+        try (FileSystem fileSystem = MCRIView2Tools.getFileSystem(tiledFile)) {
+            tiledPictureProps = MCRTiledPictureProps.getInstanceFromDirectory(fileSystem.getPath("/"));
+        } catch (IOException e) {
+            throw new IOException("Could not provide image information!", e);
+        }
+        return tiledPictureProps;
+    }
+
+    private BufferedImage getTargetImage(int width, int height, BufferedImage firstTile) {
+        return new BufferedImage(width, height, firstTile.getType());
+    }
+}

--- a/mycore-media/src/main/java/org/mycore/media/services/MCRPdfThumbnailGenerator.java
+++ b/mycore-media/src/main/java/org/mycore/media/services/MCRPdfThumbnailGenerator.java
@@ -1,0 +1,47 @@
+package org.mycore.media.services;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.mycore.datamodel.niofs.MCRPath;
+
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+public class MCRPdfThumbnailGenerator implements MCRThumbnailGenerator {
+
+    private static final Pattern MATCHING_MIMETYPE = Pattern.compile("^application/pdf");
+
+    @Override
+    public boolean matchesFileType(String mimeType, MCRPath path) {
+        return MATCHING_MIMETYPE.matcher(mimeType).matches();
+    }
+
+    @Override
+    public Optional<BufferedImage> getThumbnail(MCRPath path, int size) throws IOException {
+        InputStream fileIS = Files.newInputStream(path.toPhysicalPath());
+        try (PDDocument pdf = PDDocument.load(fileIS)) {
+            float pdfWidth =  pdf.getPage(0).getCropBox().getWidth();
+            float pdfHeight =  pdf.getPage(0).getCropBox().getHeight();
+            final int newWidth = pdfWidth > pdfHeight ? (int) Math.ceil(size * pdfWidth / pdfHeight) : size;
+            final float scale = newWidth / pdfWidth;
+
+            PDFRenderer pdfRenderer = new PDFRenderer(pdf);
+            BufferedImage pdfRender = pdfRenderer.renderImage(0, scale);
+            int imageType = MCRThumbnailUtils.getImageType(pdfRender);
+            if (imageType == BufferedImage.TYPE_BYTE_BINARY || imageType == BufferedImage.TYPE_BYTE_GRAY) {
+                BufferedImage thumbnail = new BufferedImage(pdfRender.getWidth(), pdfRender.getHeight(),
+                    imageType);
+                Graphics g = thumbnail.getGraphics();
+                g.drawImage(pdfRender, 0, 0, null);
+                g.dispose();
+                return Optional.of(thumbnail);
+            }
+            return Optional.of(pdfRender);
+        }
+    }
+}

--- a/mycore-media/src/main/java/org/mycore/media/services/MCRThumbnailGenerator.java
+++ b/mycore-media/src/main/java/org/mycore/media/services/MCRThumbnailGenerator.java
@@ -1,0 +1,14 @@
+package org.mycore.media.services;
+
+import org.mycore.datamodel.niofs.MCRPath;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.util.Optional;
+
+public interface MCRThumbnailGenerator {
+
+    boolean matchesFileType(String mimeType, MCRPath path);
+
+    Optional<BufferedImage> getThumbnail(MCRPath path, int size) throws IOException;
+}

--- a/mycore-media/src/main/java/org/mycore/media/services/MCRThumbnailUtils.java
+++ b/mycore-media/src/main/java/org/mycore/media/services/MCRThumbnailUtils.java
@@ -1,0 +1,38 @@
+package org.mycore.media.services;
+
+import java.awt.image.BufferedImage;
+
+public class MCRThumbnailUtils {
+
+    public static int getImageType(BufferedImage image) {
+        int colorType = 12;
+        for (int x = 0; x < image.getWidth(); x++) {
+            for (int y = 0; y < image.getHeight(); y++) {
+                int colorTypeTemp = getColorType(image.getRGB(x,y));
+                if (colorTypeTemp == BufferedImage.TYPE_4BYTE_ABGR) {
+                    return colorTypeTemp;
+                }
+                colorType = colorTypeTemp < colorType ? colorTypeTemp : colorType;
+            }
+        }
+        return colorType;
+    }
+
+    public static int getColorType(int color) {
+        int alpha = (color >> 24) & 0xff;
+        int red = (color >> 16) & 0xff;
+        int green = (color >> 8) & 0xff;
+        int blue = (color) & 0xff;
+
+        if (alpha < 255) {
+            return BufferedImage.TYPE_4BYTE_ABGR;
+        }
+        if (red == green && green == blue) {
+            if (red == 255 || red == 0) {
+                return BufferedImage.TYPE_BYTE_BINARY;
+            }
+            return BufferedImage.TYPE_BYTE_GRAY;
+        }
+        return BufferedImage.TYPE_3BYTE_BGR;
+    }
+}

--- a/mycore-media/src/main/resources/components/media/config/mycore.properties
+++ b/mycore-media/src/main/resources/components/media/config/mycore.properties
@@ -25,6 +25,12 @@ MCR.Media.ConnectTimeout=1000
 #name of the used contentstore
 MCR.Media.ContentStore.Name=avdata
 
+#Thumbnail Generators
+MCR.Media.Thumbnail.Generators=%MCR.Media.Thumbnail.Generators%,org.mycore.media.services.MCRImageThumbnailGenerator,org.mycore.media.services.MCRPdfThumbnailGenerator
+
+#Thumbnail default size, in Pixel, for shortest side
+MCR.Media.Thumbnail.DefaultSize=512
+
 ######################################################################
 #                                                                    #
 #            Parameters general config of mycore/miless              #


### PR DESCRIPTION
Added a resource that generates a thumbnail for a document,
without knowing the derivate or the filetype.
Response with 404 if there is no derivate or no generator for filetype

Use:

```
rsc/thumbnail/{documentID} //default size 512 Pixel shortest side

rsc/thumbnail/{documentID}/{size} //size in Pixel for shortest side
```

e.g.:

```
http://localhost:8291/mir/rsc/thumbnail/mir_mods_00000001

http://localhost:8291/mir/rsc/thumbnail/mir_mods_00000001/1024
```