### PR TITLE
MCR-1822 use MCRInjectorConfig to instantiate

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/inject/MCRInjectorConfig.java
+++ b/mycore-base/src/main/java/org/mycore/common/inject/MCRInjectorConfig.java
@@ -62,14 +62,15 @@ public class MCRInjectorConfig {
     /**
      * Returns the global injector for mycore.
      * 
-     * @return
+     * @return returns the guice injector
      */
     public static synchronized Injector injector() {
         return INJECTOR;
     }
 
     /**
-     * Returns a list of all guice modules used by the {@link Injector}.
+     * Returns a list of all guice modules used by the {@link Injector}. Be aware that this list immutable and changes
+     * are not reflect on the injector.
      * 
      * @return list of guice modules
      */

--- a/mycore-base/src/test/java/org/mycore/common/config/MCRConfiguration2Test.java
+++ b/mycore-base/src/test/java/org/mycore/common/config/MCRConfiguration2Test.java
@@ -1,0 +1,60 @@
+package org.mycore.common.config;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.inject.Inject;
+
+import com.google.inject.AbstractModule;
+import org.junit.Test;
+import org.mycore.common.MCRTestCase;
+
+public class MCRConfiguration2Test extends MCRTestCase {
+
+    @Test
+    public void instantiateClass() {
+        TestClass testClass = MCRConfiguration2.instantiateClass(TestClass.class.getName());
+        assertEquals("welcome to my service", testClass.useService());
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MCRConfiguration2.set("MCR.Inject.Module.GuiceTest", TestModule.class.getName());
+    }
+
+    public static class TestModule extends AbstractModule {
+
+        @Override
+        protected void configure() {
+            bind(TestService.class).to(TestServiceImpl.class);
+        }
+
+    }
+
+    private static class TestClass {
+
+        @Inject
+        private TestService service;
+
+        public String useService() {
+            return service.get();
+        }
+
+    }
+
+    private interface TestService {
+
+        String get();
+
+    }
+
+    private static class TestServiceImpl implements MCRConfiguration2Test.TestService {
+
+        @Override
+        public String get() {
+            return "welcome to my service";
+        }
+
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/frontend/jersey/resources/MCRInjectServiceResourceTest.java
+++ b/mycore-base/src/test/java/org/mycore/frontend/jersey/resources/MCRInjectServiceResourceTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.mycore.common.config.MCRConfiguration;
 
 import com.google.inject.AbstractModule;
+import org.mycore.common.config.MCRConfiguration2;
 
 public class MCRInjectServiceResourceTest extends MCRJerseyTest {
 
@@ -53,7 +54,7 @@ public class MCRInjectServiceResourceTest extends MCRJerseyTest {
 
     @Override
     public Application configure() {
-        MCRConfiguration.instance().set("MCR.Inject.Module.GuiceTest", TestModule.class.getName());
+        MCRConfiguration2.set("MCR.Inject.Module.GuiceTest", TestModule.class.getName());
         return super.configure();
     }
 


### PR DESCRIPTION
We try to use the GUICE Injector to get class instances.
If there is no public default constructor or no injectable constructor,
we try the olf "instance()" or "getInstance()" factory methods for
compatibility.