### PR TITLE
MCR-1643 go back to jersey 2.25.1 due to problems

### DIFF
--- a/mycore-base/pom.xml
+++ b/mycore-base/pom.xml
@@ -316,15 +316,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
-      <artifactId>jersey-common</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.inject</groupId>
-      <artifactId>jersey-hk2</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>

--- a/mycore-base/src/main/java/org/mycore/frontend/jersey/MCRJerseyDefaultConfiguration.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/jersey/MCRJerseyDefaultConfiguration.java
@@ -97,9 +97,7 @@ public class MCRJerseyDefaultConfiguration implements MCRJerseyConfiguration {
         resourceConfig.register(new AbstractContainerLifecycleListener() {
             @Override
             public void onStartup(Container container) {
-                ServiceLocator serviceLocator = container.getApplicationHandler().getInjectionManager()
-                    .getInstance(ServiceLocator.class);
-                Objects.requireNonNull(serviceLocator, "Cannot get hk2 ServiceLocator from InjectionManager");
+                ServiceLocator serviceLocator = container.getApplicationHandler().getServiceLocator();
                 Injector injector = MCRInjectorConfig.injector();
                 GuiceBridge.getGuiceBridge().initializeGuiceBridge(serviceLocator);
                 GuiceIntoHK2Bridge guiceBridge = serviceLocator.getService(GuiceIntoHK2Bridge.class);

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,8 @@
     <httpcore.version>4.4.9</httpcore.version>
     <jackson.version>2.9.5</jackson.version>
     <java.target.version>1.8</java.target.version>
-    <jersey.version>2.26</jersey.version>
+    <!-- jersey 2.26 leaks database connections and has CDI problems -->
+    <jersey.version>2.25.1</jersey.version>
     <jetty.version>9.3.14.v20161028</jetty.version>
     <log4j.version>2.11.0</log4j.version>
     <!-- lowest is 99, highest is 0 -->
@@ -1320,12 +1321,6 @@
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk16</artifactId>
         <version>1.46</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.glassfish.jersey.inject</groupId>
-        <artifactId>jersey-hk2</artifactId>
-        <version>${jersey.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
CDI is broken and causes database leaks with 2.26