### PR TITLE
MCR-1941 Fix Shutdown leak

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/events/MCRShutdownHandler.java
+++ b/mycore-base/src/main/java/org/mycore/common/events/MCRShutdownHandler.java
@@ -19,6 +19,7 @@
 package org.mycore.common.events;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.TimeUnit;
@@ -189,7 +190,10 @@ public class MCRShutdownHandler {
 
         @Override
         default int compareTo(Closeable other) {
-            return Integer.compare(other.getPriority(), getPriority());
+            //MCR-1941: never return 0 if !this.equals(other)
+            return Comparator.comparingInt(Closeable::getPriority)
+                .thenComparingLong(Closeable::hashCode)
+                .compare(other, this);
         }
     }
 


### PR DESCRIPTION
Source problem is that an internal sorted list just compares to entries and assumes
if the compare method returns '0' both objects are equal.
As we used the priority for comparison this results in Closeables that did not run
on shutdown and thus caused a leak.

[Link to jira](https://mycore.atlassian.net/browse/MCR-1941).
