### PR TITLE
MCR-1961 Added DOI registration logic for crossref

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/MCRConstants.java
+++ b/mycore-base/src/main/java/org/mycore/common/MCRConstants.java
@@ -94,6 +94,8 @@ public final class MCRConstants {
 
     public static final Namespace PIDEF_NAMESPACE = Namespace.getNamespace("pidef", "http://nbn-resolving.org/pidef");
 
+    public static final Namespace CROSSREF_NAMESPACE = Namespace.getNamespace("cr","http://www.crossref.org/schema/4.4.1");
+
     public static final Namespace DIAG_NAMESPACE = Namespace.getNamespace("diag",
         "http://www.loc.gov/zing/srw/diagnostic");
 

--- a/mycore-mods/src/main/resources/components/mods/config/mycore.properties
+++ b/mycore-mods/src/main/resources/components/mods/config/mycore.properties
@@ -131,6 +131,11 @@ MCR.ContentTransformer.schemaOrg.Class=org.mycore.common.content.transformer.MCR
 MCR.ContentTransformer.schemaOrg.Stylesheet=xsl/mods2schemaorg.xsl
 MCR.ContentTransformer.schemaOrg.TransformerFactoryClass=net.sf.saxon.TransformerFactoryImpl
 
+# Configure Transformer for crossref.org
+MCR.ContentTransformer.crossref.Class=org.mycore.common.content.transformer.MCRXSLTransformer
+MCR.ContentTransformer.crossref.Stylesheet=xsl/crossref/mods.xsl
+MCR.ContentTransformer.crossref.TransformerFactoryClass=net.sf.saxon.TransformerFactoryImpl
+
 # Batch Editor to modify mods:mods
 MCR.BatchEditor.BaseLevel.publication=/mycoreobject/metadata/def.modsContainer/modsContainer/mods:mods
 

--- a/mycore-mods/src/main/resources/xsl/crossref/mods.xsl
+++ b/mycore-mods/src/main/resources/xsl/crossref/mods.xsl
@@ -1,0 +1,60 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:mods="http://www.loc.gov/mods/v3"
+                xmlns:cr="http://www.crossref.org/schema/4.4.1"
+                version="3.0"
+>
+
+  <xsl:include href="crossref-helper-4.4.1.xsl"/>
+  <xsl:include href="mods2journal.xsl" />
+  <xsl:include href="mods2book.xsl" />
+
+  <xsl:template match="/">
+    <xsl:apply-templates select="mycoreobject/metadata/def.modsContainer/modsContainer/mods:mods"/>
+  </xsl:template>
+
+  <xsl:template name="printFullTitle">
+    <xsl:param name="titleInfoNode"/>
+    <xsl:if test="$titleInfoNode">
+      <xsl:apply-templates select="$titleInfoNode/mods:nonSort" mode="printFullTitle"/>
+      <xsl:apply-templates select="$titleInfoNode/mods:title" mode="printFullTitle"/>
+      <xsl:apply-templates select="$titleInfoNode/mods:subTitle" mode="printFullTitle"/>
+      <xsl:apply-templates select="$titleInfoNode/mods:partNumber" mode="printFullTitle"/>
+      <xsl:apply-templates select="$titleInfoNode/mods:partName" mode="printFullTitle"/>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="mods:nonSort" mode="printFullTitle">
+    <xsl:value-of select="text()" />
+    <xsl:text> </xsl:text>
+  </xsl:template>
+
+  <xsl:template match="mods:title" mode="printFullTitle">
+    <xsl:value-of select="text()" />
+  </xsl:template>
+
+  <xsl:template match="mods:subTitle" mode="printFullTitle">
+    <xsl:text>: </xsl:text>
+    <xsl:value-of select="text()" />
+  </xsl:template>
+
+  <xsl:template match="mods:partNumber|mods:partName" mode="printFullTitle">
+    <xsl:value-of select="text()" />
+    <xsl:if test="position() != last()">
+      <xsl:text>, </xsl:text>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template name="publicationYear">
+    <xsl:param name="modsNode"/>
+    <xsl:variable name="publicationNode" select="$modsNode/mods:originInfo[@eventType='publication']"/>
+    <xsl:if test="$publicationNode/mods:dateIssued[@encoding='w3cdtf']/text()">
+      <cr:publication_date>
+        <cr:year>
+          <xsl:value-of
+              select="substring-before($publicationNode/mods:dateIssued[@encoding='w3cdtf']/text(), '-')"/>
+        </cr:year>
+      </cr:publication_date>
+    </xsl:if>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/mycore-mods/src/main/resources/xsl/crossref/mods2book.xsl
+++ b/mycore-mods/src/main/resources/xsl/crossref/mods2book.xsl
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This file is part of ***  M y C o R e  ***
+  ~ See http://www.mycore.de/ for details.
+  ~
+  ~ MyCoRe is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MyCoRe is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                xmlns:mods="http://www.loc.gov/mods/v3"
+                xmlns:cr="http://www.crossref.org/schema/4.4.1"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                version="3.0"
+>
+
+  <!--
+  Book
+    Required Elements
+    Series: titles, ISSN, volume, ISBN, publication_date (year), publisher (publisher_name)
+    Set: titles, ISBN, volume
+    Book: titles, publication_date (year), ISBN‡if no ISBN is available, use <noisbn> element, publisher
+    Chapter:doi_data
+
+  Recommended Elements
+    Series: doi_data,edition_number,contributors, coden, series_number, citation_list
+    Set: contributors, doi_data, edition_number, contributors, citation_list, doi_data
+    Book: contributors, ORCIDs, edition_number, doi_data, citation_list, metadata for funding, license, and CrossMark
+    Chapter: contributors, titles, pages, publication_date, citation_list
+    also recommended:  funding, license, and CrossMark metadata
+
+  Optional Elements
+    publisher_item
+    part_number
+    component_number
+    component_list
+  -->
+<!--
+  <xsl:template
+      match="mods:mods[contains(mods:classification/@valueURI, '#monograph') or contains(mods:classification/@valueURI, '#edited_book') or contains(mods:classification/@valueURI, '#reference') or contains(mods:classification/@valueURI, '#other')]">
+    <xsl:call-template name="crossrefContainer">
+      <xsl:with-param name="content">
+
+        <xsl:variable name="bookType">
+           edited_book|monograph|other|reference
+
+        </xsl:variable>
+        <cr:book book_type="{$bookType}">
+          <cr:book_metadata>
+            <xsl:call-template name="bookMetadata">
+              <xsl:with-param name="modsNode" select="."/>
+            </xsl:call-template>
+          </cr:book_metadata>
+          <xsl:variable name="seriesNode" select="mods:relatedItem[@type='series']"/>
+          <xsl:choose>
+            <xsl:when test="count($seriesNode)&gt;0">
+              <cr:book_series_metadata>
+                <xsl:call-template name="seriesMetadata">
+                  <xsl:with-param name="parentModsNode" select="$seriesNode"/>
+                </xsl:call-template>
+              </cr:book_series_metadata>
+            </xsl:when>
+          </xsl:choose>
+        </cr:book>
+      </xsl:with-param>
+    </xsl:call-template>
+  </xsl:template> -->
+
+  <xsl:template name="bookMetadata">
+    <xsl:param name="modsNode"/>
+    <cr:titles>
+      <xsl:for-each select="mods:titleInfo">
+        <cr:title>
+          <xsl:if test="mods:nonSort">
+            <xsl:value-of select="concat(mods:nonSort/text(), ' ')"/>
+          </xsl:if>
+          <xsl:value-of select="mods:title/text()"/>
+        </cr:title>
+        <xsl:if test="mods:subTitle">
+          <cr:subtitle>
+            <xsl:value-of select="mods:subTitle"/>
+          </cr:subtitle>
+        </xsl:if>
+      </xsl:for-each>
+    </cr:titles>
+
+    <xsl:variable name="publicationNode" select="mods:originInfo[@eventType='publication']"/>
+    <xsl:if test="count($publicationNode) &gt; 0">
+      <xsl:call-template name="publicationYear">
+        <xsl:with-param name="modsNode" select="." />
+      </xsl:call-template>
+      <cr:publisher>
+        <xsl:if test="$publicationNode/mods:publisher">
+          <cr:publisher_name>
+            <xsl:value-of select="$publicationNode/mods:publisher/text()"/>
+          </cr:publisher_name>
+        </xsl:if>
+      </cr:publisher>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template name="seriesMetadata">
+    <xsl:param name="parentModsNode"/>
+
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/mycore-mods/src/main/resources/xsl/crossref/mods2journal.xsl
+++ b/mycore-mods/src/main/resources/xsl/crossref/mods2journal.xsl
@@ -1,0 +1,206 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:mods="http://www.loc.gov/mods/v3"
+                xmlns:cr="http://www.crossref.org/schema/4.4.1"
+                xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1"
+                version="3.0"
+>
+
+  <xsl:template
+      match="mods:mods[count(mods:classification[ends-with(@authorityURI, 'crossrefTypes') and contains(@valueURI, '#journal')])&gt;0]">
+    <xsl:call-template name="crossrefContainer">
+      <xsl:with-param name="content">
+        <cr:journal>
+          <cr:journal_metadata>
+            <xsl:call-template name="journalContent">
+              <xsl:with-param name="mods" select="."/>
+            </xsl:call-template>
+
+            <xsl:call-template name="doiData">
+              <xsl:with-param name="id" select="/mycoreobject/@ID" />
+            </xsl:call-template>
+          </cr:journal_metadata>
+        </cr:journal>
+      </xsl:with-param>
+    </xsl:call-template>
+  </xsl:template>
+
+  <!-- TODO: change to classification and authorityURI -->
+  <xsl:template
+      match="mods:mods[count(mods:genre[ends-with(@authorityURI, 'mir_genres') and contains(@valueURI, '#issue')])&gt;0]">
+    <cr:journal>
+      <xsl:variable name="parent"
+                    select="mods:relatedItem[@type='host' and count(mods:classification[ends-with(@authorityURI, 'crossrefTypes') and contains(@valueURI, '#journal')])&gt;0]"/>
+
+      <xsl:if test="$parent">
+        <cr:journal_metadata>
+          <xsl:call-template name="journalContent">
+            <xsl:with-param name="mods" select="$parent"/>
+          </xsl:call-template>
+        </cr:journal_metadata>
+      </xsl:if>
+
+      <cr:journal_issue>
+        <xsl:for-each
+            select="mods:name[count(mods:role/mods:roleTerm[@authorithy='marcrelator' and @type='code' and @type='corporate' and mods:displayForm]) &gt; 0]">
+          <cr:contributors>
+            <cr:organization>
+              <xsl:value-of select="mods:displayForm"/>
+            </cr:organization>
+          </cr:contributors>
+        </xsl:for-each>
+        <xsl:call-template name="publicationYear">
+          <xsl:with-param name="modsNode" select="."/>
+        </xsl:call-template>
+      </cr:journal_issue>
+    </cr:journal>
+  </xsl:template>
+
+  <xsl:template
+      match="mods:mods[count(mods:classification[ends-with(@authorityURI, 'crossrefTypes') and contains(@valueURI, '#article')])&gt;0]">
+    <xsl:call-template name="crossrefContainer">
+      <xsl:with-param name="content">
+        <cr:journal>
+          <xsl:choose>
+            <xsl:when
+                test="mods:relatedItem[@type='host' and count(mods:classification[ends-with(@authorityURI, 'crossrefTypes') and contains(@valueURI, '#journal')])]">
+              <!-- Case 1: the parent is a journal and the issue data is present in related item-->
+              <xsl:variable name="parent"
+                            select="mods:relatedItem[@type='host' and count(mods:classification[ends-with(@authorityURI, 'crossrefTypes') and contains(@valueURI, '#journal')])]"/>
+              <cr:journal_metadata>
+                <xsl:call-template name="journalContent">
+                  <xsl:with-param name="mods" select="$parent"/>
+                </xsl:call-template>
+              </cr:journal_metadata>
+              <xsl:if test="mods:part">
+                <cr:journal_issue>
+                  <xsl:if test="$parent/mods:detail[@type='volume']">
+                    <cr:journal_volume>
+                      <cr:volume>
+                        <xsl:value-of select="$parent/mods:detail[@type='volume']"/>
+                      </cr:volume>
+                    </cr:journal_volume>
+                  </xsl:if>
+                  <xsl:if test="$parent/mods:detail[@type='issue']">
+                    <cr:issue>
+                      <xsl:value-of select="$parent/mods:detail[@type='issue']"/>
+                    </cr:issue>
+                  </xsl:if>
+                </cr:journal_issue>
+              </xsl:if>
+            </xsl:when>
+
+            <xsl:otherwise>
+              <xsl:message terminate="yes">No host present!</xsl:message>
+            </xsl:otherwise>
+          </xsl:choose>
+
+
+          <cr:journal_article>
+            <xsl:call-template name="articleTitle"/>
+            <xsl:call-template name="articleAbstract"/>
+            <xsl:call-template name="publicationYear">
+              <xsl:with-param name="modsNode" select="."/>
+            </xsl:call-template>
+
+            <!-- TODO: pages -->
+
+
+            <xsl:call-template name="doiData">
+              <xsl:with-param name="id" select="/mycoreobject/@ID"/>
+            </xsl:call-template>
+          </cr:journal_article>
+        </cr:journal>
+      </xsl:with-param>
+    </xsl:call-template>
+  </xsl:template>
+
+  <xsl:template name="articleTitle">
+    <cr:titles>
+      <xsl:for-each select="mods:titleInfo[not(@type)]">
+        <!-- convert normal titles -->
+        <cr:title>
+          <xsl:value-of select="mods:title/text()"/>
+        </cr:title>
+        <xsl:if test="mods:subTitle">
+          <cr:subtitle>
+            <xsl:value-of select="mods:subTitle"/>
+          </cr:subtitle>
+        </xsl:if>
+      </xsl:for-each>
+      <!-- convert translated titles-->
+      <xsl:for-each select="mods:titleInfo[@type='translated']">
+        <cr:original_language_title>
+          <xsl:if test="@xml:lang">
+            <xsl:attribute name="language">
+              <xsl:value-of select="@xml:lang"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:value-of select="mods:title"/>
+        </cr:original_language_title>
+        <xsl:if test="mods:subTitle">
+          <cr:subtitle>
+            <xsl:value-of select="mods:subTitle"/>
+          </cr:subtitle>
+        </xsl:if>
+      </xsl:for-each>
+    </cr:titles>
+  </xsl:template>
+
+  <xsl:template name="articlePublicationDate">
+    <xsl:if test="mods:originInfo[@type='publication']">
+      <cr:publication_date>
+        <cr:year>
+          <!-- TODO: split into y d m -->
+          <xsl:value-of select="mods:originInfo[@type='publication']/text()"/>
+        </cr:year>
+      </cr:publication_date>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template name="articleAbstract">
+    <xsl:for-each select="mods:abstract">
+      <jats:abstract>
+        <xsl:if test="@xml:lang">
+          <xsl:copy-of select="@xml:lang"/>
+        </xsl:if>
+        <jats:p>
+          <xsl:copy-of select="text()"/>
+        </jats:p>
+      </jats:abstract>
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template name="journalContent">
+    <xsl:param name="mods"/>
+
+    <!-- TODO: check compatibility of ISO 639 and RFC 5646 -->
+    <xsl:variable name="language" select="$mods/mods:language/mods:languageTerm[@authority='rfc5646']"/>
+    <xsl:if test="$language">
+      <xsl:attribute name="language">
+        <xsl:value-of select="$language"/>
+      </xsl:attribute>
+    </xsl:if>
+
+    <!-- TODO: evaluate: use mimetype attribute ?-->
+    <xsl:attribute name="metadata_distribution_opts">
+      <!-- TODO: property switch to 'query' -->
+      <xsl:value-of select="'any'"/>
+    </xsl:attribute>
+
+    <cr:full_title>
+      <xsl:call-template name="printFullTitle">
+        <xsl:with-param name="titleInfoNode" select="$mods/mods:titleInfo[1]"/>
+      </xsl:call-template>
+    </cr:full_title>
+
+    <xsl:if test="not($mods/mods:identifier[@type='issn'])">
+      <xsl:message terminate="yes">A issn is required in the journal</xsl:message>
+    </xsl:if>
+    <cr:issn>
+      <xsl:value-of select="$mods/mods:identifier[@type='issn']"/>
+    </cr:issn>
+
+    <xsl:call-template name="archive_locations"/>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/mycore-pi/pom.xml
+++ b/mycore-pi/pom.xml
@@ -49,6 +49,10 @@
       <artifactId>h2</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.persistence</groupId>
       <artifactId>javax.persistence-api</artifactId>
     </dependency>
@@ -71,6 +75,10 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpmime</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/mycore-pi/src/main/java/org/mycore/pi/MCRPIJobService.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/MCRPIJobService.java
@@ -250,6 +250,10 @@ public abstract class MCRPIJobService<T extends MCRPersistentIdentifier>
             session.setUserInformation(MCRSystemUserInformation.getGuestInstance());
             session.setUserInformation(user);
             LOGGER.info("Continue as User {}", jobUser);
+        } else {
+            savedUserInformation = session.getUserInformation();
+            session.setUserInformation(MCRSystemUserInformation.getGuestInstance());
+            session.setUserInformation(MCRSystemUserInformation.getJanitorInstance());
         }
 
         boolean transactionActive = !session.isTransactionActive();

--- a/mycore-pi/src/main/java/org/mycore/pi/MCRPIService.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/MCRPIService.java
@@ -17,13 +17,12 @@
  */
 package org.mycore.pi;
 
-import static org.mycore.access.MCRAccessManager.PERMISSION_WRITE;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -63,6 +62,8 @@ import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
+import static org.mycore.access.MCRAccessManager.PERMISSION_WRITE;
 
 public abstract class MCRPIService<T extends MCRPersistentIdentifier> {
 
@@ -477,5 +478,21 @@ public abstract class MCRPIService<T extends MCRPersistentIdentifier> {
         } catch (Exception e) {
             throw new MCRException("Could not update flags of object " + id, e);
         }
+    }
+
+    /**
+     * Validates a property of this service
+     * @param propertyName the property to check
+     * @return the property
+     * @throws MCRConfigurationException if property is not set or empty
+     */
+    protected String requireNotEmptyProperty(String propertyName) throws MCRConfigurationException{
+        final Map<String, String> properties = getProperties();
+        if (!properties.containsKey(propertyName) && properties.get(propertyName).length() > 0) {
+            throw new MCRConfigurationException(String
+                .format(Locale.ROOT,"The property %s%s.%s is empty or not set!", REGISTRATION_CONFIG_PREFIX, registrationServiceID,
+                    propertyName));
+        }
+        return properties.get(propertyName);
     }
 }

--- a/mycore-pi/src/main/java/org/mycore/pi/doi/MCRCrossrefService.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/doi/MCRCrossrefService.java
@@ -1,0 +1,168 @@
+package org.mycore.pi.doi;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.naming.OperationNotSupportedException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.mycore.common.MCRConstants;
+import org.mycore.common.config.MCRConfigurationException;
+import org.mycore.common.content.MCRBaseContent;
+import org.mycore.common.content.MCRContent;
+import org.mycore.datamodel.metadata.MCRBase;
+import org.mycore.datamodel.metadata.MCRMetadataManager;
+import org.mycore.datamodel.metadata.MCRObject;
+import org.mycore.datamodel.metadata.MCRObjectID;
+import org.mycore.frontend.MCRFrontendUtil;
+import org.mycore.pi.doi.client.crossref.MCRCrossrefClient;
+import org.mycore.pi.doi.crossref.MCRCrossrefUtil;
+import org.mycore.pi.exceptions.MCRPersistentIdentifierException;
+import org.xml.sax.SAXException;
+
+public class MCRCrossrefService extends MCRDOIBaseService {
+
+    private static final String CONFIG_TEST = "Test";
+
+    private static final String CONFIG_REGISTRANT = "Registrant";
+
+    private static final String CONFIG_DEPOSITOR_MAIL = "DepositorMail";
+
+    private static final String CONFIG_DEPOSITOR = "Depositor";
+
+    private static final String DEFAULT_SCHEMA = "xsd/crossref/4.4.1/crossref4.4.1.xsd";
+
+    private static final String TEST_HOST = "test.crossref.org";
+
+    private static final String PRODUCTION_HOST = "doi.crossref.org";
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private String registrant;
+
+    private String depositor;
+
+    private String depositorMail;
+
+    public MCRCrossrefService(String registrationServiceID) {
+        super(registrationServiceID);
+    }
+
+    @Override
+    protected String getDefaultSchemaPath() {
+        return DEFAULT_SCHEMA;
+    }
+
+    @Override
+    protected void checkConfiguration() throws MCRConfigurationException {
+        super.checkConfiguration();
+        init();
+    }
+
+    private void init() {
+        initCommonProperties();
+        registrant = requireNotEmptyProperty(CONFIG_REGISTRANT);
+        depositor = requireNotEmptyProperty(CONFIG_DEPOSITOR);
+        depositorMail = requireNotEmptyProperty(CONFIG_DEPOSITOR_MAIL);
+    }
+
+    @Override
+    protected void registerIdentifier(MCRBase obj, String additional, MCRDigitalObjectIdentifier pi)
+        throws MCRPersistentIdentifierException {
+        final Document resultDocument = transform(obj, pi.asString());
+        validateDocument(obj.getId().toString(), resultDocument);
+    }
+
+    @Override
+    protected Document transform(MCRBase obj, String pi)
+        throws MCRPersistentIdentifierException {
+        Document resultDocument;
+        try {
+            final MCRContent result = getTransformer().transform(new MCRBaseContent(obj));
+            resultDocument = result.asXML();
+        } catch (IOException | JDOMException | SAXException e) {
+            throw new MCRConfigurationException(
+                String.format(Locale.ROOT, "Could not transform the object %s with the trasformer %s", obj.getId(),
+                    getTransformerID()), e);
+        }
+
+        final Element root = resultDocument.getRootElement();
+
+        final Element headElement = root.getChild("head", MCRConstants.CROSSREF_NAMESPACE);
+        final String batchID = UUID.randomUUID().toString() + "_" + obj.getId().toString();
+        final String timestampMilliseconds = String.valueOf(new Date().getTime());
+        MCRCrossrefUtil.insertBatchInformation(headElement, batchID, timestampMilliseconds, depositor, depositorMail,
+            registrant);
+
+        MCRCrossrefUtil.replaceDOIData(root, (objectID) -> Objects.equals(obj.getId().toString(), objectID) ? pi : null,
+            MCRFrontendUtil.getBaseURL());
+
+        return resultDocument;
+    }
+
+    private String getHost() {
+        return Optional.ofNullable(getProperties().get(CONFIG_TEST))
+            .map(Boolean::valueOf)
+            .map(testMode -> testMode ? TEST_HOST : PRODUCTION_HOST)
+            .orElse(PRODUCTION_HOST);
+    }
+
+    @Override
+    protected void delete(MCRDigitalObjectIdentifier identifier, MCRBase obj, String additional)
+        throws MCRPersistentIdentifierException {
+        throw new MCRPersistentIdentifierException("Delete is not Supported!",
+            new OperationNotSupportedException("Delete is not Supported!"));
+    }
+
+    @Override
+    protected void deleteJob(Map<String, String> parameters) throws MCRPersistentIdentifierException {
+
+    }
+
+    @Override
+    protected void updateJob(Map<String, String> parameters) throws MCRPersistentIdentifierException {
+        String doi = parameters.get(CONTEXT_DOI);
+        String idString = parameters.get(CONTEXT_OBJ);
+
+        if (!checkJobValid(idString, PiJobAction.UPDATE)) {
+            return;
+        }
+
+        MCRObjectID objectID = MCRObjectID.getInstance(idString);
+        this.validateJobUserRights(objectID);
+        MCRObject object = MCRMetadataManager.retrieveMCRObject(objectID);
+
+        Document newCrossrefBatch = transform(object, doi);
+        final MCRCrossrefClient client = new MCRCrossrefClient(getHost(), getUsername(), getPassword());
+
+        client.doMDUpload(newCrossrefBatch);
+    }
+
+    @Override
+    protected void registerJob(Map<String, String> parameters) throws MCRPersistentIdentifierException {
+        String doi = parameters.get(CONTEXT_DOI);
+        String idString = parameters.get(CONTEXT_OBJ);
+
+        if (!checkJobValid(idString, PiJobAction.REGISTER)) {
+            return;
+        }
+
+        MCRObjectID objectID = MCRObjectID.getInstance(idString);
+        this.validateJobUserRights(objectID);
+        MCRObject mcrBase = MCRMetadataManager.retrieveMCRObject(objectID);
+
+        final Document resultDocument = transform(mcrBase, doi);
+        final MCRCrossrefClient client = new MCRCrossrefClient(getHost(), getUsername(), getPassword());
+        client.doMDUpload(resultDocument);
+    }
+
+}

--- a/mycore-pi/src/main/java/org/mycore/pi/doi/MCRDOIBaseService.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/doi/MCRDOIBaseService.java
@@ -1,0 +1,200 @@
+package org.mycore.pi.doi;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import javax.persistence.NoResultException;
+import javax.xml.XMLConstants;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+
+import org.jdom2.Document;
+import org.jdom2.transform.JDOMSource;
+import org.mycore.backend.hibernate.MCRHIBConnection;
+import org.mycore.common.MCRClassTools;
+import org.mycore.common.config.MCRConfigurationException;
+import org.mycore.common.content.transformer.MCRContentTransformer;
+import org.mycore.common.content.transformer.MCRContentTransformerFactory;
+import org.mycore.datamodel.metadata.MCRBase;
+import org.mycore.datamodel.metadata.MCRMetadataManager;
+import org.mycore.datamodel.metadata.MCRObjectID;
+import org.mycore.pi.MCRPIJobService;
+import org.mycore.pi.MCRPIManager;
+import org.mycore.pi.backend.MCRPI;
+import org.mycore.pi.exceptions.MCRPersistentIdentifierException;
+import org.xml.sax.SAXException;
+
+/**
+ * A doi Base Service which contains common DOI registration code.
+ */
+public abstract class MCRDOIBaseService extends MCRPIJobService<MCRDigitalObjectIdentifier> {
+
+    protected static final String CONTEXT_OBJ = "obj";
+
+    protected static final String CONTEXT_DOI = "doi";
+
+    private static final String CONFIG_TRANSFORMER = "Transformer";
+
+    private static final String CONFIG_USER_NAME = "Username";
+
+    private static final String CONFIG_PASSWORD = "Password";
+
+    private static final String CONFIG_SCHEMA = "Schema";
+
+    private static final String TYPE = "doi";
+
+    private String username;
+
+    private String password;
+
+    private Schema schema;
+
+    private String transformerID;
+
+    public MCRDOIBaseService(String registrationServiceID) {
+        super(registrationServiceID, TYPE);
+    }
+
+    protected void initCommonProperties() {
+        setUsername(requireNotEmptyProperty(CONFIG_USER_NAME));
+        setPassword(requireNotEmptyProperty(CONFIG_PASSWORD));
+        setTransformerID(requireNotEmptyProperty(CONFIG_TRANSFORMER));
+
+        final MCRContentTransformer transformer = getTransformer();
+
+        final Map<String, String> properties = getProperties();
+        final String schemaURL = properties.getOrDefault(CONFIG_SCHEMA, getDefaultSchemaPath());
+        try {
+            SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            schemaFactory.setFeature("http://apache.org/xml/features/validation/schema-full-checking", false);
+
+            URL localSchemaURL = MCRClassTools.getClassLoader().getResource(schemaURL);
+            if (localSchemaURL == null) {
+                throw new MCRConfigurationException(schemaURL + " was not found!");
+            }
+            setSchema(schemaFactory.newSchema(localSchemaURL));
+        } catch (SAXException e) {
+            throw new MCRConfigurationException("Error while loading " + getServiceID() + " schema!", e);
+        }
+    }
+
+    protected abstract String getDefaultSchemaPath();
+
+    @Override
+    protected Optional<String> getJobInformation(Map<String, String> contextParameters) {
+        String pattern = "{0} DOI: {1} for object: {2}";
+        return Optional.of(String.format(Locale.ROOT, pattern, getAction(contextParameters).toString(),
+            contextParameters.get(CONTEXT_DOI), contextParameters.get(CONTEXT_OBJ)));
+    }
+
+    protected boolean checkJobValid(String mycoreID, PiJobAction action) {
+        final MCRObjectID objectID = MCRObjectID.getInstance(mycoreID);
+        final boolean exists = MCRMetadataManager.exists(objectID);
+
+        try {
+            MCRPIManager.getInstance().get(getServiceID(), mycoreID, "");
+        } catch (NoResultException r) {
+            return false;
+        }
+
+        return exists;
+    }
+
+    @Override
+    public void update(MCRDigitalObjectIdentifier doi, MCRBase obj, String additional)
+        throws MCRPersistentIdentifierException {
+        if (isRegistered(obj.getId(), additional)) {
+            HashMap<String, String> contextParameters = new HashMap<>();
+            contextParameters.put(CONTEXT_DOI, doi.asString());
+            contextParameters.put(CONTEXT_OBJ, obj.getId().toString());
+            this.addUpdateJob(contextParameters);
+        } else if (!hasRegistrationStarted(obj.getId(), additional)) {
+            Predicate<MCRBase> registrationCondition = getRegistrationCondition(obj.getId().getTypeId());
+            if (registrationCondition.test(obj)) {
+                this.updateStartRegistrationDate(obj.getId(), "", new Date());
+                startRegisterJob(obj, doi);
+            }
+        }
+    }
+
+    @Override
+    public MCRPI insertIdentifierToDatabase(MCRBase obj, String additional, MCRDigitalObjectIdentifier identifier) {
+        Date registrationStarted = null;
+        if (getRegistrationCondition(obj.getId().getTypeId()).test(obj)) {
+            registrationStarted = new Date();
+            startRegisterJob(obj, identifier);
+        }
+
+        MCRPI databaseEntry = new MCRPI(identifier.asString(), getType(), obj.getId().toString(), additional,
+            this.getServiceID(), provideRegisterDate(obj, additional), registrationStarted);
+        MCRHIBConnection.instance().getSession().save(databaseEntry);
+        return databaseEntry;
+    }
+
+    protected void startRegisterJob(MCRBase obj, MCRDigitalObjectIdentifier newDOI) {
+        HashMap<String, String> contextParameters = new HashMap<>();
+        contextParameters.put(CONTEXT_DOI, newDOI.asString());
+        contextParameters.put(CONTEXT_OBJ, obj.getId().toString());
+        this.addRegisterJob(contextParameters);
+    }
+
+    protected MCRContentTransformer getTransformer() {
+        return MCRContentTransformerFactory.getTransformer(transformerID);
+    }
+
+    protected void validateDocument(String id, Document resultDocument)
+        throws MCRPersistentIdentifierException {
+        try {
+            getSchema().newValidator().validate(new JDOMSource(resultDocument));
+        } catch (SAXException | IOException e) {
+            throw new MCRPersistentIdentifierException(
+                "Error while validating generated xml for " + id, e);
+        }
+    }
+
+    @Override
+    protected Date provideRegisterDate(MCRBase obj, String additional) {
+        return null;
+    }
+
+    protected abstract Document transform(MCRBase obj, String pi)
+        throws MCRPersistentIdentifierException;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public Schema getSchema() {
+        return schema;
+    }
+
+    public void setSchema(Schema schema) {
+        this.schema = schema;
+    }
+
+    public String getTransformerID() {
+        return transformerID;
+    }
+
+    public void setTransformerID(String transformerID) {
+        this.transformerID = transformerID;
+    }
+}

--- a/mycore-pi/src/main/java/org/mycore/pi/doi/MCRDOIResolver.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/doi/MCRDOIResolver.java
@@ -21,10 +21,10 @@ package org.mycore.pi.doi;
 import java.util.stream.Stream;
 
 import org.mycore.pi.MCRPIResolver;
-import org.mycore.pi.doi.rest.MCRDOIRest;
-import org.mycore.pi.doi.rest.MCRDOIRestResponse;
-import org.mycore.pi.doi.rest.MCRDOIRestResponseEntry;
-import org.mycore.pi.doi.rest.MCRDOIRestResponseEntryDataStringValue;
+import org.mycore.pi.doi.client.datacite.MCRDataciteRest;
+import org.mycore.pi.doi.client.datacite.MCRDataciteRestResponse;
+import org.mycore.pi.doi.client.datacite.MCRDataciteRestResponseEntry;
+import org.mycore.pi.doi.client.datacite.MCRDataciteRestResponseEntryDataStringValue;
 import org.mycore.pi.exceptions.MCRIdentifierUnresolvableException;
 
 public class MCRDOIResolver extends MCRPIResolver<MCRDigitalObjectIdentifier> {
@@ -34,15 +34,15 @@ public class MCRDOIResolver extends MCRPIResolver<MCRDigitalObjectIdentifier> {
 
     @Override
     public Stream<String> resolve(MCRDigitalObjectIdentifier identifier) throws MCRIdentifierUnresolvableException {
-        MCRDOIRestResponse restResponse = MCRDOIRest.get(identifier);
+        MCRDataciteRestResponse restResponse = MCRDataciteRest.get(identifier);
 
         if (restResponse.getResponseCode() == 1) {
             return restResponse.getValues()
                 .stream()
                 .filter(responseEntry -> responseEntry.getType().equals("URL"))
-                .map(MCRDOIRestResponseEntry::getData)
+                .map(MCRDataciteRestResponseEntry::getData)
                 .filter(responseEntryData -> responseEntryData.getFormat().equals("string"))
-                .map(responseEntryData -> ((MCRDOIRestResponseEntryDataStringValue) responseEntryData
+                .map(responseEntryData -> ((MCRDataciteRestResponseEntryDataStringValue) responseEntryData
                     .getValue()).getValue());
         }
 

--- a/mycore-pi/src/main/java/org/mycore/pi/doi/client/crossref/MCRCrossrefClient.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/doi/client/crossref/MCRCrossrefClient.java
@@ -1,0 +1,145 @@
+package org.mycore.pi.doi.client.crossref;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import javax.validation.constraints.NotNull;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jdom2.Document;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+import org.mycore.pi.exceptions.MCRDatacenterException;
+import org.mycore.pi.exceptions.MCRPersistentIdentifierException;
+
+public class MCRCrossrefClient {
+
+    public static final Logger LOGGER = LogManager.getLogger();
+
+    private static final String HTTP_SCHEME_PREFIX = "http://";
+
+    private static final String HTTPS_SCHEME_PREFIX = "https://";
+
+    private static final String NOT_NULL_MESSAGE = "%s needs to be not null!";
+
+    private static final String DEPOSIT_PATH = "servlet/deposit";
+
+    private static final String OPERATION_PARAM = "operation";
+
+    private static final String USER_PARAM = "login_id";
+
+    private static final String PASSWORD_PARAM = "login_passwd";
+
+    private static final String OPERATION_DOMDUPLOAD = "doMDUpload";
+
+    private static final XMLOutputter METADATA_OUTPUTTER = new XMLOutputter(Format.getPrettyFormat());
+
+    private String host, username, password;
+
+    public MCRCrossrefClient(@NotNull String host, @NotNull String username, @NotNull String password) {
+        if (host == null) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, NOT_NULL_MESSAGE, "Host"));
+        }
+        if (username == null) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, NOT_NULL_MESSAGE, "Username"));
+        }
+        if (password == null) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, NOT_NULL_MESSAGE, "Password"));
+        }
+
+        this.host = host;
+        this.username = username;
+        this.password = password;
+
+        if (host.endsWith("/")) {
+            this.host = this.host.substring(0, host.length() - 1);
+        }
+
+        if (this.host.startsWith(HTTP_SCHEME_PREFIX)) {
+            this.host = this.host.substring(HTTP_SCHEME_PREFIX.length());
+        } else if (this.host.startsWith(HTTPS_SCHEME_PREFIX)) {
+            this.host = this.host.substring(HTTPS_SCHEME_PREFIX.length());
+        }
+    }
+
+    private static CloseableHttpClient getHttpClient() {
+        return HttpClientBuilder.create().build();
+    }
+
+    public void doMDUpload(Document metadata) throws MCRPersistentIdentifierException {
+        final HttpPost postRequest;
+
+        try {
+            final URIBuilder uriBuilder;
+            uriBuilder = new URIBuilder("https://" + this.host + "/" + DEPOSIT_PATH);
+            addAuthParameters(uriBuilder);
+            uriBuilder.addParameter(OPERATION_PARAM, OPERATION_DOMDUPLOAD);
+            postRequest = new HttpPost(uriBuilder.build());
+        } catch (URISyntaxException e) {
+            throw new MCRPersistentIdentifierException(
+                String.format(Locale.ROOT, "Can not build a valid URL with  host: %s", this.host));
+        }
+
+        final String metadataXmlAsString = METADATA_OUTPUTTER.outputString(metadata);
+
+        HttpEntity reqEntity = MultipartEntityBuilder.create()
+            .addBinaryBody("fname",metadataXmlAsString.getBytes(StandardCharsets.UTF_8), ContentType.APPLICATION_XML, "crossref_query.xml")
+            .build();
+        postRequest.setEntity(reqEntity);
+
+        try (final CloseableHttpClient client = getHttpClient()) {
+            try (final CloseableHttpResponse response = client.execute(postRequest)) {
+                final int statusCode = response.getStatusLine().getStatusCode();
+                final HttpEntity entity = response.getEntity();
+                String message = "";
+
+                switch (statusCode) {
+                    case 200:
+                        if (entity != null) {
+                            try (InputStream inputStream = entity.getContent()) {
+                                List<String> doc = IOUtils.readLines(inputStream, StandardCharsets.UTF_8);
+                                message = doc.stream().collect(Collectors.joining(System.lineSeparator()));
+                                LOGGER.debug(message);
+                            }
+                        }
+                        return; // everything OK!
+                    case 503:
+                        LOGGER.error("Seems like the quota of 10000 Entries is exceeded!");
+                    default:
+                        if (entity != null) {
+                            try (InputStream inputStream = entity.getContent()) {
+                                List<String> doc = IOUtils.readLines(inputStream, StandardCharsets.UTF_8);
+                                message = doc.stream().collect(Collectors.joining(System.lineSeparator()));
+                            }
+                        }
+                        throw new MCRDatacenterException(
+                            String.format(Locale.ROOT, "Error while doMDUpload: (%d)%s%s%s", statusCode,
+                                response.getStatusLine().getReasonPhrase(), System.lineSeparator(), message));
+                }
+            }
+        } catch (IOException e) {
+            throw new MCRDatacenterException(String.format(Locale.ROOT, "Error while sending request to %s", host), e);
+        }
+    }
+
+    private void addAuthParameters(URIBuilder uriBuilder) {
+        uriBuilder.addParameter(USER_PARAM, this.username);
+        uriBuilder.addParameter(PASSWORD_PARAM, this.password);
+    }
+
+}

--- a/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDOIRestResponseEntryDataValueDeserializer.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDOIRestResponseEntryDataValueDeserializer.java
@@ -16,7 +16,7 @@
  * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.mycore.pi.doi.rest;
+package org.mycore.pi.doi.client.datacite;
 
 import java.lang.reflect.Type;
 
@@ -26,9 +26,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 
-public class MCRDOIRestResponseEntryDataValueDeserializer implements JsonDeserializer<MCRDOIRestResponseEntryData> {
+public class MCRDOIRestResponseEntryDataValueDeserializer implements JsonDeserializer<MCRDataciteRestResponseEntryData> {
     @Override
-    public MCRDOIRestResponseEntryData deserialize(JsonElement jsonElement, Type type,
+    public MCRDataciteRestResponseEntryData deserialize(JsonElement jsonElement, Type type,
         JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
         JsonObject dataObject = jsonElement.getAsJsonObject();
 
@@ -37,18 +37,18 @@ public class MCRDOIRestResponseEntryDataValueDeserializer implements JsonDeseria
 
         switch (format) {
             case "string":
-                return new MCRDOIRestResponseEntryData(format,
-                    new MCRDOIRestResponseEntryDataStringValue(value.getAsJsonPrimitive().getAsString()));
+                return new MCRDataciteRestResponseEntryData(format,
+                    new MCRDataciteRestResponseEntryDataStringValue(value.getAsJsonPrimitive().getAsString()));
             case "base64":
-                return new MCRDOIRestResponseEntryData(format,
-                    new MCRDOIRestResponseEntryDataBase64Value(value.getAsJsonPrimitive().getAsString()));
+                return new MCRDataciteRestResponseEntryData(format,
+                    new MCRDataciteRestResponseEntryDataBase64Value(value.getAsJsonPrimitive().getAsString()));
             case "hex":
             case "admin":
             case "vlist":
             case "site":
             default:
                 // currently not supported
-                return new MCRDOIRestResponseEntryData(format, new MCRDOIRestResponseEntryDataValue());
+                return new MCRDataciteRestResponseEntryData(format, new MCRDataciteRestResponseEntryDataValue());
         }
     }
 }

--- a/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteClient.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteClient.java
@@ -16,7 +16,7 @@
  * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.mycore.pi.doi;
+package org.mycore.pi.doi.client.datacite;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -55,17 +55,14 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jdom2.Document;
-import org.jdom2.Element;
 import org.jdom2.JDOMException;
-import org.jdom2.Namespace;
-import org.jdom2.filter.Filters;
 import org.jdom2.input.SAXBuilder;
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
-import org.jdom2.xpath.XPathExpression;
-import org.jdom2.xpath.XPathFactory;
 import org.mycore.common.MCRException;
 import org.mycore.common.config.MCRConfigurationException;
+import org.mycore.pi.doi.MCRDOIParser;
+import org.mycore.pi.doi.MCRDigitalObjectIdentifier;
 import org.mycore.pi.exceptions.MCRDatacenterAuthenticationException;
 import org.mycore.pi.exceptions.MCRDatacenterException;
 import org.mycore.pi.exceptions.MCRIdentifierUnresolvableException;

--- a/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteRest.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteRest.java
@@ -16,7 +16,7 @@
  * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.mycore.pi.doi.rest;
+package org.mycore.pi.doi.client.datacite;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -36,7 +36,7 @@ import org.mycore.pi.exceptions.MCRIdentifierUnresolvableException;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-public class MCRDOIRest {
+public class MCRDataciteRest {
 
     private static final String URL_TEMPLATE = "http://doi.org/api/handles/{doi}";
 
@@ -44,7 +44,7 @@ public class MCRDOIRest {
         return HttpClientBuilder.create().build();
     }
 
-    public static MCRDOIRestResponse get(MCRDigitalObjectIdentifier doi) throws MCRIdentifierUnresolvableException {
+    public static MCRDataciteRestResponse get(MCRDigitalObjectIdentifier doi) throws MCRIdentifierUnresolvableException {
 
         HttpGet get = new HttpGet(URL_TEMPLATE.replaceAll("\\{doi\\}", doi.asString()));
         try (CloseableHttpClient httpClient = getHttpClient()) {
@@ -54,9 +54,9 @@ public class MCRDOIRest {
             try (BufferedReader buffer = new BufferedReader(
                 new InputStreamReader(entity.getContent(), Charset.forName("UTF-8")))) {
                 String json = buffer.lines().collect(Collectors.joining("\n"));
-                Gson gson = new GsonBuilder().registerTypeAdapter(MCRDOIRestResponseEntryData.class,
+                Gson gson = new GsonBuilder().registerTypeAdapter(MCRDataciteRestResponseEntryData.class,
                     new MCRDOIRestResponseEntryDataValueDeserializer()).create();
-                return gson.fromJson(json, MCRDOIRestResponse.class);
+                return gson.fromJson(json, MCRDataciteRestResponse.class);
             }
 
         } catch (IOException e) {
@@ -67,7 +67,7 @@ public class MCRDOIRest {
     }
 
     public static void main(String[] args) throws MCRIdentifierUnresolvableException {
-        MCRDOIRestResponse mcrdoiRestResponse = get(new MCRDOIParser().parse("10.1000/1").get());
+        MCRDataciteRestResponse mcrdoiRestResponse = get(new MCRDOIParser().parse("10.1000/1").get());
     }
 
 }

--- a/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteRestResponse.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteRestResponse.java
@@ -16,16 +16,16 @@
  * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.mycore.pi.doi.rest;
+package org.mycore.pi.doi.client.datacite;
 
 import java.util.List;
 
-public class MCRDOIRestResponse {
+public class MCRDataciteRestResponse {
     int responseCode;
 
     String handle;
 
-    List<MCRDOIRestResponseEntry> values;
+    List<MCRDataciteRestResponseEntry> values;
 
     /**
      * 1 : Success. (HTTP 200 OK)
@@ -43,7 +43,7 @@ public class MCRDOIRestResponse {
         return handle;
     }
 
-    public List<MCRDOIRestResponseEntry> getValues() {
+    public List<MCRDataciteRestResponseEntry> getValues() {
         return values;
     }
 }

--- a/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteRestResponseEntry.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteRestResponseEntry.java
@@ -16,14 +16,14 @@
  * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.mycore.pi.doi.rest;
+package org.mycore.pi.doi.client.datacite;
 
-public class MCRDOIRestResponseEntry {
+public class MCRDataciteRestResponseEntry {
     int index;
 
     String type;
 
-    MCRDOIRestResponseEntryData data;
+    MCRDataciteRestResponseEntryData data;
 
     int ttl;
 
@@ -37,7 +37,7 @@ public class MCRDOIRestResponseEntry {
         return type;
     }
 
-    public MCRDOIRestResponseEntryData getData() {
+    public MCRDataciteRestResponseEntryData getData() {
         return data;
     }
 

--- a/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteRestResponseEntryData.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteRestResponseEntryData.java
@@ -16,19 +16,23 @@
  * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.mycore.pi.doi.rest;
+package org.mycore.pi.doi.client.datacite;
 
-import java.util.Base64;
+public class MCRDataciteRestResponseEntryData {
+    String format;
 
-public class MCRDOIRestResponseEntryDataBase64Value extends MCRDOIRestResponseEntryDataValue {
+    MCRDataciteRestResponseEntryDataValue value;
 
-    private final byte[] decodedValue;
-
-    public MCRDOIRestResponseEntryDataBase64Value(String base64value) {
-        decodedValue = Base64.getDecoder().decode(base64value);
+    public MCRDataciteRestResponseEntryData(String format, MCRDataciteRestResponseEntryDataValue value) {
+        this.format = format;
+        this.value = value;
     }
 
-    public byte[] getDecodedValue() {
-        return decodedValue;
+    public MCRDataciteRestResponseEntryDataValue getValue() {
+        return value;
+    }
+
+    public String getFormat() {
+        return format;
     }
 }

--- a/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteRestResponseEntryDataBase64Value.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteRestResponseEntryDataBase64Value.java
@@ -16,17 +16,19 @@
  * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.mycore.pi.doi.rest;
+package org.mycore.pi.doi.client.datacite;
 
-public class MCRDOIRestResponseEntryDataStringValue extends MCRDOIRestResponseEntryDataValue {
-    private String value;
+import java.util.Base64;
 
-    public MCRDOIRestResponseEntryDataStringValue(String value) {
-        this.value = value;
+public class MCRDataciteRestResponseEntryDataBase64Value extends MCRDataciteRestResponseEntryDataValue {
+
+    private final byte[] decodedValue;
+
+    public MCRDataciteRestResponseEntryDataBase64Value(String base64value) {
+        decodedValue = Base64.getDecoder().decode(base64value);
     }
 
-    public String getValue() {
-        return value;
+    public byte[] getDecodedValue() {
+        return decodedValue;
     }
-
 }

--- a/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteRestResponseEntryDataStringValue.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteRestResponseEntryDataStringValue.java
@@ -16,8 +16,17 @@
  * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.mycore.pi.doi.rest;
+package org.mycore.pi.doi.client.datacite;
 
-public class MCRDOIRestResponseEntryDataValue {
+public class MCRDataciteRestResponseEntryDataStringValue extends MCRDataciteRestResponseEntryDataValue {
+    private String value;
+
+    public MCRDataciteRestResponseEntryDataStringValue(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
 
 }

--- a/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteRestResponseEntryDataValue.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteRestResponseEntryDataValue.java
@@ -16,23 +16,8 @@
  * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.mycore.pi.doi.rest;
+package org.mycore.pi.doi.client.datacite;
 
-public class MCRDOIRestResponseEntryData {
-    String format;
+public class MCRDataciteRestResponseEntryDataValue {
 
-    MCRDOIRestResponseEntryDataValue value;
-
-    public MCRDOIRestResponseEntryData(String format, MCRDOIRestResponseEntryDataValue value) {
-        this.format = format;
-        this.value = value;
-    }
-
-    public MCRDOIRestResponseEntryDataValue getValue() {
-        return value;
-    }
-
-    public String getFormat() {
-        return format;
-    }
 }

--- a/mycore-pi/src/main/java/org/mycore/pi/doi/crossref/MCRCrossrefUtil.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/doi/crossref/MCRCrossrefUtil.java
@@ -1,0 +1,89 @@
+package org.mycore.pi.doi.crossref;
+
+import java.util.List;
+import java.util.Objects;
+
+import javax.validation.constraints.NotNull;
+
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+import org.jdom2.filter.Filters;
+import org.jdom2.xpath.XPathExpression;
+import org.jdom2.xpath.XPathFactory;
+import org.mycore.common.MCRConstants;
+import org.mycore.common.function.MCRThrowFunction;
+import org.mycore.pi.exceptions.MCRPersistentIdentifierException;
+
+/**
+ * Proivides Util functions for Crossref registration.
+ */
+public class MCRCrossrefUtil {
+
+    private static final Namespace CR = MCRConstants.CROSSREF_NAMESPACE;
+
+
+    /**
+     * Inserts informations to the crossref head element.
+     * @param headElement existing head element
+     * @param batchID Publisher generated ID that uniquely identifies the DOI submission batch. It will be used as a
+     *                reference in error messages sent by the MDDB, and can be used for submission tracking. The
+     *                publisher must insure that this number is unique for every submission to CrossRef.
+     * @param timestamp Indicates version of a batch file instance or DOI. timestamp is used
+     * 				to uniquely identify batch files and DOI values when a DOI has been updated one or
+     * 				more times. timestamp is an integer representation of date and time that serves as a
+     * 				version number for the record that is being deposited. Because CrossRef uses it as a
+     * 				version number, the format need not follow any public standard and therefore the
+     * 				publisher can determine the internal format. The schema format is a double of at
+     * 				least 64 bits, insuring that a fully qualified date/time stamp of 19 digits can be
+     * 				submitted. When depositing data, CrossRef will check to see if a DOI has already
+     * 				been deposited for the specific doi value. If the newer data carries a time stamp
+     * 				value that is equal to or greater than the old data based on a strict numeric
+     * 				comparison, the new data will replace the old data. If the new data value is less
+     * 				than the old data value, the new data will not replace the old data. timestamp is
+     * 				optional in doi_data and required in head. The value from the head instance
+     * 				timestamp will be used for all instances of doi_data that do not include a timestamp
+     * 				element.
+     * @param depositorName Name of the organization registering the DOIs. The name placed in this element should match
+     *                      the name under which a depositing organization has registered with CrossRef.
+     * @param depositorMail e-mail address to which batch success and/or error messages are sent.
+     *                      It is recommended that this address be unique to a position within the organization
+     *                      submitting data (e.g. "doi@...") rather than unique to a person. In this way, the
+     *                      alias for delivery of this mail can be changed as responsibility for submission of
+     *                      DOI data within the organization changes from one person to another.
+     * @param registrant The organization that owns the information being registered.
+     */
+    public static void insertBatchInformation(@NotNull Element headElement, @NotNull String batchID,
+        @NotNull String timestamp, @NotNull String depositorName, @NotNull String depositorMail,
+        @NotNull String registrant) {
+        headElement.getChild("doi_batch_id", CR).setText(Objects.requireNonNull(batchID));
+        headElement.getChild("timestamp", CR).setText(Objects.requireNonNull(timestamp));
+        final Element depositorElement = headElement.getChild("depositor", CR);
+        depositorElement.getChild("depositor_name", CR).setText(Objects.requireNonNull(depositorName));
+        depositorElement.getChild("email_address", CR).setText(Objects.requireNonNull(depositorMail));
+        headElement.getChild("registrant", CR).setText(Objects.requireNonNull(registrant));
+    }
+
+    public static void replaceDOIData(Element root,
+        MCRThrowFunction<String, String, MCRPersistentIdentifierException> idDOIFunction, String baseURL)
+        throws MCRPersistentIdentifierException {
+        XPathFactory xpfac = XPathFactory.instance();
+        XPathExpression<Element> xp = xpfac
+            .compile(".//cr:doi_data_replace", Filters.element(), null, MCRConstants.getStandardNamespaces());
+        List<Element> evaluate = xp.evaluate(root);
+        for (Element element : evaluate) {
+            final String mycoreObjectID = element.getText();
+            final String doi = idDOIFunction.apply(mycoreObjectID);
+            element.removeContent();
+            if (doi != null) {
+                element.addContent(new Element("doi", CR).setText(doi));
+                element.addContent(new Element("resource", CR).setText(baseURL + "/receive/" + mycoreObjectID));
+                element.setName("doi_data");
+            } else {
+                element.getParentElement().removeContent(element);
+            }
+        }
+
+    }
+
+
+}

--- a/mycore-pi/src/main/java/org/mycore/pi/frontend/resources/MCRPersistentIdentifierRegistrationResource.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/frontend/resources/MCRPersistentIdentifierRegistrationResource.java
@@ -132,13 +132,16 @@ public class MCRPersistentIdentifierRegistrationResource {
         try {
             identifier = registrationService.register(object, additional, true);
         } catch (MCRPersistentIdentifierException | MCRActiveLinkException | ExecutionException | InterruptedException e) {
-            LOGGER.error(e);
+            LOGGER.error("Error while registering PI:",e);
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                 .entity(buildErrorJSON("Error while register new identifier!", e)).build();
         } catch (MCRAccessException e) {
-            LOGGER.error(e);
+            LOGGER.error("Error while registering PI:",e);
             return Response.status(Response.Status.FORBIDDEN)
                 .entity(buildErrorJSON("Error while register new identifier!", e)).build();
+        } catch (Throwable t){
+            LOGGER.error("Error while registering PI:",t);
+            throw t;
         }
 
 

--- a/mycore-pi/src/main/resources/catalog.xml
+++ b/mycore-pi/src/main/resources/catalog.xml
@@ -37,4 +37,18 @@
   <system systemId="http://schema.datacite.org/meta/kernel-3/include/datacite-descriptionType-v3.xsd"
           uri="xsd/datacite/v3/datacite-descriptionType-v3.xsd" />
 
+  <system systemId="http://data.crossref.org/schemas/crossref4.4.1.xsd" uri="xsd/crossref/4.4.1/crossref4.4.1.xsd" />
+  <system systemId="http://data.crossref.org/schemas/common4.4.1.xsd" uri="xsd/crossref/4.4.1/common4.4.1.xsd" />
+  <system systemId="http://data.crossref.org/schemas/common4.3.5.xsd" uri="xsd/crossref/4.3.5/common4.3.5.xsd" />
+  <system systemId="http://data.crossref.org/schemas/JATS-journalpublishing1.xsd" uri="xsd/crossref/4.4.1/JATS-journalpublishing1.xsd" />
+  <system systemId="http://data.crossref.org/schemas/relations.xsd" uri="xsd/crossref/4.4.1/relations.xsd" />
+  <system systemId="http://data.crossref.org/schemas/fundref.xsd" uri="xsd/crossref/4.4.1/fundref.xsd" />
+  <system systemId="http://data.crossref.org/schemas/AccessIndicators.xsd" uri="xsd/crossref/4.4.1/AccessIndicators.xsd" />
+  <system systemId="http://data.crossref.org/schemas/clinicaltrials.xsd" uri="xsd/crossref/4.4.1/clinicaltrials.xsd" />
+  <system systemId="http://www.w3.org/Math/XMLSchema/mathml3/mathml3.xsd" uri="xsd/crossref/4.4.1/mathml3.xsd" />
+  <system systemId="http://www.w3.org/Math/XMLSchema/mathml3/mathml3-common.xsd" uri="xsd/crossref/4.4.1/mathml3-common.xsd" />
+  <system systemId="http://www.w3.org/Math/XMLSchema/mathml3/mathml3-content.xsd" uri="xsd/crossref/4.4.1/mathml3-content.xsd" />
+  <system systemId="http://www.w3.org/Math/XMLSchema/mathml3/mathml3-presentation.xsd" uri="xsd/crossref/4.4.1/mathml3-presentation.xsd" />
+  <system systemId="http://www.w3.org/Math/XMLSchema/mathml3/mathml3-strict-content.xsd" uri="xsd/crossref/4.4.1/mathml3-strict-content.xsd" />
+
 </catalog>

--- a/mycore-pi/src/main/resources/components/pi/config/mycore.properties
+++ b/mycore-pi/src/main/resources/components/pi/config/mycore.properties
@@ -52,3 +52,4 @@ MCR.PI.Generator.MapObjectIDDOI=org.mycore.pi.doi.MCRMapObjectIDDOIGenerator
 #MCR.PI.MetadataService.DefaultURNXpath=org.mycore.pi.urn.MCRPIXPathMetadataService
 #MCR.PI.MetadataService.DefaultURNXpath.Xpath=/mycoreobject/metadata/def.identifier[@class='MCRMetaLangText']/identifier[@type='urn'][starts-with(text(), 'urn:example-prefix')]
 
+

--- a/mycore-pi/src/main/resources/xsd/crossref/4.4.1/AccessIndicators.xsd
+++ b/mycore-pi/src/main/resources/xsd/crossref/4.4.1/AccessIndicators.xsd
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://www.crossref.org/AccessIndicators.xsd"
+    xmlns="http://www.crossref.org/AccessIndicators.xsd">
+    
+    <xsd:annotation>
+        <xsd:documentation> Version: 1.1 This is CrossRef's schema for defining the applicable
+            licenses for a given item. This schema was available and in use prior to the completion
+            of the NISO working group Access and License Indicators
+            (http://www.niso.org/publications/rp/rp-22-2015). That effort produced a schema
+            (http://www.niso.org/schemas/ali/1.0/ali.xsd) that extended the CrossRef definition but
+            at the same time omitted necessary CrossRef features. This schema will continue as the
+            basis for CrossRef metadata deposits, but will incorporate the NISO work where possible.
+            Change history: 2/23/15 CSK added Niso free_to_read element 
+                            4/21/15 CSK added start and end attributes to the free-to-read element as in the Niso ALI schema
+                                        but will make both attributes optional.
+        </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:element name="program">
+        <xsd:annotation>
+            <xsd:documentation>Accommodates deposit of license metadata. The license_ref value will
+                be a URL. Values for the "applies_to" attribute are vor (version of record),am
+                (accepted manuscript), and tdm (text and data mining).</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element ref="free_to_read" minOccurs="0"/>
+                <xsd:element ref="license_ref" minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+            <xsd:attribute name="name" type="xsd:string" fixed="AccessIndicators"/>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="license_ref">
+        <xsd:complexType>
+            <xsd:simpleContent>
+                <xsd:extension base="license_ref_t">
+                    <xsd:attribute name="start_date" type="xsd:date" use="optional"/>
+                    <xsd:attribute name="applies_to" use="optional">
+                        <xsd:simpleType>
+                            <xsd:restriction base="xsd:NMTOKEN">
+                                <xsd:enumeration value="vor"/>
+                                <xsd:enumeration value="am"/>
+                                <xsd:enumeration value="tdm"/>
+                            </xsd:restriction>
+                        </xsd:simpleType>
+                    </xsd:attribute>
+                </xsd:extension>
+            </xsd:simpleContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:simpleType name="license_ref_t">
+        <xsd:restriction base="xsd:anyURI">
+            <xsd:minLength value="10"/>
+            <xsd:pattern value="([hH][tT][tT][pP]|[hH][tT][tT][pP][sS]|[fF][tT][pP])://.*"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:element name="free_to_read">
+        <xsd:complexType>
+            <xsd:attribute name="end_date" use="optional" type="xsd:date"/>
+            <xsd:attribute name="start_date" use="optional" type="xsd:date"/>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/mycore-pi/src/main/resources/xsd/crossref/4.4.1/JATS-journalpublishing1.xsd
+++ b/mycore-pi/src/main/resources/xsd/crossref/4.4.1/JATS-journalpublishing1.xsd
@@ -1,0 +1,6176 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns="http://www.ncbi.nlm.nih.gov/JATS1"
+  targetNamespace="http://www.ncbi.nlm.nih.gov/JATS1"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" elementFormDefault="qualified">
+  <xs:import namespace="http://www.w3.org/1998/Math/MathML" schemaLocation="http://www.w3.org/Math/XMLSchema/mathml3/mathml3.xsd"/>
+  <xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.w3.org/1999/xlink.xsd"/>
+  <!-- XSD import of namespace  suppressed, whee -->
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+  <xs:element name="contrib-group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="contrib"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="address"/>
+          <xs:element ref="aff"/>
+          <xs:element ref="aff-alternatives"/>
+          <xs:element ref="author-comment"/>
+          <xs:element ref="bio"/>
+          <xs:element ref="email"/>
+          <xs:element ref="ext-link"/>
+          <xs:element ref="on-behalf-of"/>
+          <xs:element ref="role"/>
+          <xs:element ref="uri"/>
+          <xs:element ref="xref"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="contrib">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="contrib-id"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="anonymous"/>
+          <xs:element ref="collab"/>
+          <xs:element ref="collab-alternatives"/>
+          <xs:element ref="name"/>
+          <xs:element ref="name-alternatives"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="degrees"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="address"/>
+          <xs:element ref="aff"/>
+          <xs:element ref="aff-alternatives"/>
+          <xs:element ref="author-comment"/>
+          <xs:element ref="bio"/>
+          <xs:element ref="email"/>
+          <xs:element ref="ext-link"/>
+          <xs:element ref="on-behalf-of"/>
+          <xs:element ref="role"/>
+          <xs:element ref="uri"/>
+          <xs:element ref="xref"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="contrib-type"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="corresp">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="no"/>
+            <xs:enumeration value="yes"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="equal-contrib">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="no"/>
+            <xs:enumeration value="yes"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="deceased">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="no"/>
+            <xs:enumeration value="yes"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rid" type="xs:IDREFS"/>
+      <xs:attribute name="specific-use"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="copyright-holder">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="copyright-statement">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="copyright-year">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="license">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="license-p"/>
+      </xs:sequence>
+      <xs:attribute name="license-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="license-p">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="address"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="array"/>
+        <xs:element ref="boxed-text"/>
+        <xs:element ref="chem-struct-wrap"/>
+        <xs:element ref="fig"/>
+        <xs:element ref="fig-group"/>
+        <xs:element ref="graphic"/>
+        <xs:element ref="media"/>
+        <xs:element ref="preformat"/>
+        <xs:element ref="supplementary-material"/>
+        <xs:element ref="table-wrap"/>
+        <xs:element ref="table-wrap-group"/>
+        <xs:element ref="disp-formula"/>
+        <xs:element ref="disp-formula-group"/>
+        <xs:element ref="citation-alternatives"/>
+        <xs:element ref="element-citation"/>
+        <xs:element ref="mixed-citation"/>
+        <xs:element ref="nlm-citation"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="award-id"/>
+        <xs:element ref="funding-source"/>
+        <xs:element ref="open-access"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="def-list"/>
+        <xs:element ref="list"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="disp-quote"/>
+        <xs:element ref="speech"/>
+        <xs:element ref="statement"/>
+        <xs:element ref="verse-group"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="price"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="permissions">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="copyright-statement"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="copyright-year"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="copyright-holder"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="license"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="article-title">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="break"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="aff">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="addr-line"/>
+        <xs:element ref="country"/>
+        <xs:element ref="fax"/>
+        <xs:element ref="institution"/>
+        <xs:element ref="phone"/>
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="break"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="label"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="rid" type="xs:IDREFS"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="aff-alternatives">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="aff"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="conf-date">
+    <xs:complexType mixed="true">
+      <xs:attribute name="iso-8601-date"/>
+      <xs:attribute name="calendar"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="conf-loc">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="conf-name">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="conf-sponsor">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="object-id">
+    <xs:complexType mixed="true">
+      <xs:attribute name="pub-id-type"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="isbn">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="issn">
+    <xs:complexType mixed="true">
+      <xs:attribute name="pub-type"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="issn-l">
+    <xs:complexType mixed="true">
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="issue">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="seq"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="issue-id">
+    <xs:complexType mixed="true">
+      <xs:attribute name="pub-id-type"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="issue-part">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="issue-sponsor">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="issue-title">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="journal-id">
+    <xs:complexType mixed="true">
+      <xs:attribute name="journal-id-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="role">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="trans-title-group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="trans-title"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="trans-subtitle"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="trans-subtitle">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="break"/>
+      </xs:choice>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="trans-title">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="break"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="volume">
+    <xs:complexType mixed="true">
+      <xs:attribute name="seq"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="volume-id">
+    <xs:complexType mixed="true">
+      <xs:attribute name="pub-id-type"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="volume-series">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="anonymous">
+    <xs:complexType>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="etal">
+    <xs:complexType mixed="true">
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="on-behalf-of">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+      </xs:choice>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="publisher">
+    <xs:complexType>
+      <xs:sequence maxOccurs="unbounded">
+        <xs:element ref="publisher-name"/>
+        <xs:element minOccurs="0" ref="publisher-loc"/>
+      </xs:sequence>
+      <xs:attribute name="content-type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="publisher-name">
+    <xs:complexType mixed="true">
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="publisher-loc">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+      </xs:choice>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="fpage">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="seq"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="lpage">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="page-range">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="size">
+    <xs:complexType mixed="true">
+      <xs:attribute name="units" use="required"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="elocation-id">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="seq"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="citation-alternatives">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="element-citation"/>
+        <xs:element ref="mixed-citation"/>
+        <xs:element ref="nlm-citation"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="mixed-citation">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="label"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="annotation"/>
+        <xs:element ref="article-title"/>
+        <xs:element ref="chapter-title"/>
+        <xs:element ref="collab"/>
+        <xs:element ref="collab-alternatives"/>
+        <xs:element ref="comment"/>
+        <xs:element ref="conf-date"/>
+        <xs:element ref="conf-loc"/>
+        <xs:element ref="conf-name"/>
+        <xs:element ref="conf-sponsor"/>
+        <xs:element ref="date"/>
+        <xs:element ref="date-in-citation"/>
+        <xs:element ref="day"/>
+        <xs:element ref="edition"/>
+        <xs:element ref="email"/>
+        <xs:element ref="elocation-id"/>
+        <xs:element ref="etal"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="fpage"/>
+        <xs:element ref="gov"/>
+        <xs:element ref="institution"/>
+        <xs:element ref="isbn"/>
+        <xs:element ref="issn"/>
+        <xs:element ref="issn-l"/>
+        <xs:element ref="issue"/>
+        <xs:element ref="issue-id"/>
+        <xs:element ref="issue-part"/>
+        <xs:element ref="issue-title"/>
+        <xs:element ref="lpage"/>
+        <xs:element ref="month"/>
+        <xs:element ref="name"/>
+        <xs:element ref="name-alternatives"/>
+        <xs:element ref="object-id"/>
+        <xs:element ref="page-range"/>
+        <xs:element ref="part-title"/>
+        <xs:element ref="patent"/>
+        <xs:element ref="person-group"/>
+        <xs:element ref="pub-id"/>
+        <xs:element ref="publisher-loc"/>
+        <xs:element ref="publisher-name"/>
+        <xs:element ref="role"/>
+        <xs:element ref="season"/>
+        <xs:element ref="series"/>
+        <xs:element ref="size"/>
+        <xs:element ref="source"/>
+        <xs:element ref="std"/>
+        <xs:element ref="string-name"/>
+        <xs:element ref="supplement"/>
+        <xs:element ref="trans-source"/>
+        <xs:element ref="trans-title"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="volume"/>
+        <xs:element ref="volume-id"/>
+        <xs:element ref="volume-series"/>
+        <xs:element ref="year"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="publication-type"/>
+      <xs:attribute name="publisher-type"/>
+      <xs:attribute name="publication-format"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="element-citation">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="label"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="annotation"/>
+        <xs:element ref="article-title"/>
+        <xs:element ref="chapter-title"/>
+        <xs:element ref="collab"/>
+        <xs:element ref="collab-alternatives"/>
+        <xs:element ref="comment"/>
+        <xs:element ref="conf-date"/>
+        <xs:element ref="conf-loc"/>
+        <xs:element ref="conf-name"/>
+        <xs:element ref="conf-sponsor"/>
+        <xs:element ref="date"/>
+        <xs:element ref="date-in-citation"/>
+        <xs:element ref="day"/>
+        <xs:element ref="edition"/>
+        <xs:element ref="email"/>
+        <xs:element ref="elocation-id"/>
+        <xs:element ref="etal"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="fpage"/>
+        <xs:element ref="gov"/>
+        <xs:element ref="institution"/>
+        <xs:element ref="isbn"/>
+        <xs:element ref="issn"/>
+        <xs:element ref="issn-l"/>
+        <xs:element ref="issue"/>
+        <xs:element ref="issue-id"/>
+        <xs:element ref="issue-part"/>
+        <xs:element ref="issue-title"/>
+        <xs:element ref="lpage"/>
+        <xs:element ref="month"/>
+        <xs:element ref="name"/>
+        <xs:element ref="name-alternatives"/>
+        <xs:element ref="object-id"/>
+        <xs:element ref="page-range"/>
+        <xs:element ref="part-title"/>
+        <xs:element ref="patent"/>
+        <xs:element ref="person-group"/>
+        <xs:element ref="pub-id"/>
+        <xs:element ref="publisher-loc"/>
+        <xs:element ref="publisher-name"/>
+        <xs:element ref="role"/>
+        <xs:element ref="season"/>
+        <xs:element ref="series"/>
+        <xs:element ref="size"/>
+        <xs:element ref="source"/>
+        <xs:element ref="std"/>
+        <xs:element ref="string-name"/>
+        <xs:element ref="supplement"/>
+        <xs:element ref="trans-source"/>
+        <xs:element ref="trans-title"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="volume"/>
+        <xs:element ref="volume-id"/>
+        <xs:element ref="volume-series"/>
+        <xs:element ref="year"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="publication-type"/>
+      <xs:attribute name="publisher-type"/>
+      <xs:attribute name="publication-format"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="address">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="addr-line"/>
+        <xs:element ref="country"/>
+        <xs:element ref="fax"/>
+        <xs:element ref="institution"/>
+        <xs:element ref="phone"/>
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="addr-line">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="country"/>
+        <xs:element ref="fax"/>
+        <xs:element ref="institution"/>
+        <xs:element ref="phone"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="country">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="country"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="email">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="fax">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="institution">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="phone">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="uri">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="supplement">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="contrib-group"/>
+        <xs:element ref="title"/>
+      </xs:choice>
+      <xs:attribute name="supplement-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="date">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs="0">
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="day"/>
+            <xs:element minOccurs="0" ref="month"/>
+          </xs:sequence>
+          <xs:element ref="season"/>
+        </xs:choice>
+        <xs:element ref="year"/>
+      </xs:sequence>
+      <xs:attribute name="date-type"/>
+      <xs:attribute name="publication-format"/>
+      <xs:attribute name="iso-8601-date"/>
+      <xs:attribute name="calendar"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="day">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="month">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="season">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="year">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="iso-8601-date"/>
+      <xs:attribute name="calendar"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="string-date">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="day"/>
+        <xs:element ref="month"/>
+        <xs:element ref="season"/>
+        <xs:element ref="year"/>
+      </xs:choice>
+      <xs:attribute name="iso-8601-date"/>
+      <xs:attribute name="calendar"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="collab-alternatives">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="collab"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="collab">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="addr-line"/>
+        <xs:element ref="country"/>
+        <xs:element ref="fax"/>
+        <xs:element ref="institution"/>
+        <xs:element ref="phone"/>
+        <xs:element ref="contrib-group"/>
+        <xs:element ref="address"/>
+        <xs:element ref="aff"/>
+        <xs:element ref="aff-alternatives"/>
+        <xs:element ref="author-comment"/>
+        <xs:element ref="bio"/>
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="on-behalf-of"/>
+        <xs:element ref="role"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="fn"/>
+      </xs:choice>
+      <xs:attribute name="collab-type"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="contrib-id">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute name="contrib-id-type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="name-alternatives">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="name"/>
+        <xs:element ref="string-name"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="name">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice>
+          <xs:sequence>
+            <xs:element ref="surname"/>
+            <xs:element minOccurs="0" ref="given-names"/>
+          </xs:sequence>
+          <xs:element ref="given-names"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="prefix"/>
+        <xs:element minOccurs="0" ref="suffix"/>
+      </xs:sequence>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="name-style" default="western">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="western"/>
+            <xs:enumeration value="eastern"/>
+            <xs:enumeration value="islensk"/>
+            <xs:enumeration value="given-only"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="string-name">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="degrees"/>
+        <xs:element ref="given-names"/>
+        <xs:element ref="prefix"/>
+        <xs:element ref="surname"/>
+        <xs:element ref="suffix"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="name-style" default="western">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="western"/>
+            <xs:enumeration value="eastern"/>
+            <xs:enumeration value="islensk"/>
+            <xs:enumeration value="given-only"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="degrees">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="given-names">
+    <xs:complexType mixed="true">
+      <xs:attribute name="initials"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="surname">
+    <xs:complexType mixed="true">
+      <xs:attribute name="initials"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="prefix">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="suffix">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ext-link">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="ext-link-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="attrib">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="def">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="p"/>
+      </xs:sequence>
+      <xs:attribute name="rid" type="xs:IDREFS"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="label">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="alt"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="price">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+      </xs:choice>
+      <xs:attribute name="currency"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="title">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="break"/>
+        <xs:element ref="citation-alternatives"/>
+        <xs:element ref="element-citation"/>
+        <xs:element ref="mixed-citation"/>
+        <xs:element ref="nlm-citation"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="related-article">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="journal-id"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="annotation"/>
+        <xs:element ref="article-title"/>
+        <xs:element ref="chapter-title"/>
+        <xs:element ref="collab"/>
+        <xs:element ref="collab-alternatives"/>
+        <xs:element ref="comment"/>
+        <xs:element ref="conf-date"/>
+        <xs:element ref="conf-loc"/>
+        <xs:element ref="conf-name"/>
+        <xs:element ref="conf-sponsor"/>
+        <xs:element ref="date"/>
+        <xs:element ref="date-in-citation"/>
+        <xs:element ref="day"/>
+        <xs:element ref="edition"/>
+        <xs:element ref="email"/>
+        <xs:element ref="elocation-id"/>
+        <xs:element ref="etal"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="fpage"/>
+        <xs:element ref="gov"/>
+        <xs:element ref="institution"/>
+        <xs:element ref="isbn"/>
+        <xs:element ref="issn"/>
+        <xs:element ref="issn-l"/>
+        <xs:element ref="issue"/>
+        <xs:element ref="issue-id"/>
+        <xs:element ref="issue-part"/>
+        <xs:element ref="issue-title"/>
+        <xs:element ref="lpage"/>
+        <xs:element ref="month"/>
+        <xs:element ref="name"/>
+        <xs:element ref="name-alternatives"/>
+        <xs:element ref="object-id"/>
+        <xs:element ref="page-range"/>
+        <xs:element ref="part-title"/>
+        <xs:element ref="patent"/>
+        <xs:element ref="person-group"/>
+        <xs:element ref="pub-id"/>
+        <xs:element ref="publisher-loc"/>
+        <xs:element ref="publisher-name"/>
+        <xs:element ref="role"/>
+        <xs:element ref="season"/>
+        <xs:element ref="series"/>
+        <xs:element ref="size"/>
+        <xs:element ref="source"/>
+        <xs:element ref="std"/>
+        <xs:element ref="string-name"/>
+        <xs:element ref="supplement"/>
+        <xs:element ref="trans-source"/>
+        <xs:element ref="trans-title"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="volume"/>
+        <xs:element ref="volume-id"/>
+        <xs:element ref="volume-series"/>
+        <xs:element ref="year"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="related-article-type" use="required"/>
+      <xs:attribute name="ext-link-type"/>
+      <xs:attribute name="vol"/>
+      <xs:attribute name="page"/>
+      <xs:attribute name="issue"/>
+      <xs:attribute name="elocation-id"/>
+      <xs:attribute name="journal-id"/>
+      <xs:attribute name="journal-id-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sig-block">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="break"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="graphic"/>
+        <xs:element ref="media"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sig"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="rid" type="xs:IDREFS"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sig">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="break"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="graphic"/>
+        <xs:element ref="media"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="rid" type="xs:IDREFS"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ack">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="p"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="sec"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="ref-list"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="bio">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="sec-meta"/>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="address"/>
+          <xs:element ref="alternatives"/>
+          <xs:element ref="array"/>
+          <xs:element ref="boxed-text"/>
+          <xs:element ref="chem-struct-wrap"/>
+          <xs:element ref="fig"/>
+          <xs:element ref="fig-group"/>
+          <xs:element ref="graphic"/>
+          <xs:element ref="media"/>
+          <xs:element ref="preformat"/>
+          <xs:element ref="supplementary-material"/>
+          <xs:element ref="table-wrap"/>
+          <xs:element ref="table-wrap-group"/>
+          <xs:element ref="disp-formula"/>
+          <xs:element ref="disp-formula-group"/>
+          <xs:element ref="def-list"/>
+          <xs:element ref="list"/>
+          <xs:element ref="tex-math"/>
+          <xs:element ref="mml:math"/>
+          <xs:element ref="p"/>
+          <xs:element ref="related-article"/>
+          <xs:element ref="related-object"/>
+          <xs:element ref="disp-quote"/>
+          <xs:element ref="speech"/>
+          <xs:element ref="statement"/>
+          <xs:element ref="verse-group"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="sec"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="fn-group"/>
+          <xs:element ref="glossary"/>
+          <xs:element ref="ref-list"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="rid" type="xs:IDREFS"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="notes">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="sec-meta"/>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="address"/>
+          <xs:element ref="alternatives"/>
+          <xs:element ref="array"/>
+          <xs:element ref="boxed-text"/>
+          <xs:element ref="chem-struct-wrap"/>
+          <xs:element ref="fig"/>
+          <xs:element ref="fig-group"/>
+          <xs:element ref="graphic"/>
+          <xs:element ref="media"/>
+          <xs:element ref="preformat"/>
+          <xs:element ref="supplementary-material"/>
+          <xs:element ref="table-wrap"/>
+          <xs:element ref="table-wrap-group"/>
+          <xs:element ref="disp-formula"/>
+          <xs:element ref="disp-formula-group"/>
+          <xs:element ref="def-list"/>
+          <xs:element ref="list"/>
+          <xs:element ref="tex-math"/>
+          <xs:element ref="mml:math"/>
+          <xs:element ref="p"/>
+          <xs:element ref="related-article"/>
+          <xs:element ref="related-object"/>
+          <xs:element ref="disp-quote"/>
+          <xs:element ref="speech"/>
+          <xs:element ref="statement"/>
+          <xs:element ref="verse-group"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="sec"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="fn-group"/>
+          <xs:element ref="glossary"/>
+          <xs:element ref="ref-list"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="notes-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="alt-text">
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="long-desc">
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="custom-meta-group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="custom-meta"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="custom-meta">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="meta-name"/>
+        <xs:element ref="meta-value"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="meta-name" type="xs:string"/>
+  <xs:element name="meta-value">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="alternatives">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="array"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="graphic"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="media"/>
+        <xs:element ref="preformat"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="supplementary-material"/>
+        <xs:element ref="table"/>
+        <xs:element ref="textual-form"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="textual-form">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="x">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute ref="xml:space" default="preserve"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="article-meta">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="article-id"/>
+        <xs:element minOccurs="0" ref="article-categories"/>
+        <xs:element ref="title-group"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="contrib-group"/>
+          <xs:element ref="aff"/>
+          <xs:element ref="aff-alternatives"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="author-notes"/>
+        <xs:element maxOccurs="unbounded" ref="pub-date"/>
+        <xs:element minOccurs="0" ref="volume"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="volume-id"/>
+        <xs:element minOccurs="0" ref="volume-series"/>
+        <xs:element minOccurs="0" ref="issue"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="issue-id"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="issue-title"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="issue-sponsor"/>
+        <xs:element minOccurs="0" ref="issue-part"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="isbn"/>
+        <xs:element minOccurs="0" ref="supplement"/>
+        <xs:choice minOccurs="0">
+          <xs:sequence>
+            <xs:element ref="fpage"/>
+            <xs:element minOccurs="0" ref="lpage"/>
+            <xs:element minOccurs="0" ref="page-range"/>
+          </xs:sequence>
+          <xs:element ref="elocation-id"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="email"/>
+          <xs:element ref="ext-link"/>
+          <xs:element ref="uri"/>
+          <xs:element ref="product"/>
+          <xs:element ref="supplementary-material"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="history"/>
+        <xs:element minOccurs="0" ref="permissions"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="self-uri"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="related-article"/>
+          <xs:element ref="related-object"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="abstract"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="trans-abstract"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="kwd-group"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="funding-group"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="conference"/>
+        <xs:element minOccurs="0" ref="counts"/>
+        <xs:element minOccurs="0" ref="custom-meta-group"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="article-id">
+    <xs:complexType mixed="true">
+      <xs:attribute name="pub-id-type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="art-access-id"/>
+            <xs:enumeration value="arxiv"/>
+            <xs:enumeration value="coden"/>
+            <xs:enumeration value="doaj"/>
+            <xs:enumeration value="doi"/>
+            <xs:enumeration value="isbn"/>
+            <xs:enumeration value="manuscript"/>
+            <xs:enumeration value="medline"/>
+            <xs:enumeration value="other"/>
+            <xs:enumeration value="pii"/>
+            <xs:enumeration value="pmcid"/>
+            <xs:enumeration value="pmid"/>
+            <xs:enumeration value="publisher-id"/>
+            <xs:enumeration value="sici"/>
+            <xs:enumeration value="std-designation"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="article-categories">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="subj-group"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="series-title"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="series-text"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="subj-group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="subject"/>
+          <xs:element ref="compound-subject"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="subj-group"/>
+      </xs:sequence>
+      <xs:attribute name="subj-group-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="subject">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="compound-subject">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="compound-subject-part"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="compound-subject-part">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="series-title">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="series-text">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="author-notes">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="corresp"/>
+          <xs:element ref="fn"/>
+          <xs:element ref="p"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="rid" type="xs:IDREFS"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="product">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="break"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="price"/>
+        <xs:element ref="annotation"/>
+        <xs:element ref="article-title"/>
+        <xs:element ref="chapter-title"/>
+        <xs:element ref="collab"/>
+        <xs:element ref="collab-alternatives"/>
+        <xs:element ref="comment"/>
+        <xs:element ref="conf-date"/>
+        <xs:element ref="conf-loc"/>
+        <xs:element ref="conf-name"/>
+        <xs:element ref="conf-sponsor"/>
+        <xs:element ref="date"/>
+        <xs:element ref="date-in-citation"/>
+        <xs:element ref="day"/>
+        <xs:element ref="edition"/>
+        <xs:element ref="email"/>
+        <xs:element ref="elocation-id"/>
+        <xs:element ref="etal"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="fpage"/>
+        <xs:element ref="gov"/>
+        <xs:element ref="institution"/>
+        <xs:element ref="isbn"/>
+        <xs:element ref="issn"/>
+        <xs:element ref="issn-l"/>
+        <xs:element ref="issue"/>
+        <xs:element ref="issue-id"/>
+        <xs:element ref="issue-part"/>
+        <xs:element ref="issue-title"/>
+        <xs:element ref="lpage"/>
+        <xs:element ref="month"/>
+        <xs:element ref="name"/>
+        <xs:element ref="name-alternatives"/>
+        <xs:element ref="object-id"/>
+        <xs:element ref="page-range"/>
+        <xs:element ref="part-title"/>
+        <xs:element ref="patent"/>
+        <xs:element ref="person-group"/>
+        <xs:element ref="pub-id"/>
+        <xs:element ref="publisher-loc"/>
+        <xs:element ref="publisher-name"/>
+        <xs:element ref="role"/>
+        <xs:element ref="season"/>
+        <xs:element ref="series"/>
+        <xs:element ref="size"/>
+        <xs:element ref="source"/>
+        <xs:element ref="std"/>
+        <xs:element ref="string-name"/>
+        <xs:element ref="supplement"/>
+        <xs:element ref="trans-source"/>
+        <xs:element ref="trans-title"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="volume"/>
+        <xs:element ref="volume-id"/>
+        <xs:element ref="volume-series"/>
+        <xs:element ref="year"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="product-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="history">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="date"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="self-uri">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="abstract">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="p"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="sec"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="abstract-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="trans-abstract">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="p"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="sec"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="abstract-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="kwd-group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="kwd"/>
+          <xs:element ref="compound-kwd"/>
+          <xs:element ref="nested-kwd"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="kwd-group-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="kwd">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="compound-kwd">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="compound-kwd-part"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="compound-kwd-part">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="nested-kwd">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="kwd"/>
+          <xs:element ref="compound-kwd"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="nested-kwd"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="unstructured-kwd-group">
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="kwd-group-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="corresp">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="addr-line"/>
+        <xs:element ref="country"/>
+        <xs:element ref="fax"/>
+        <xs:element ref="institution"/>
+        <xs:element ref="phone"/>
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="label"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="pub-date">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs="0">
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="day"/>
+            <xs:element minOccurs="0" ref="month"/>
+          </xs:sequence>
+          <xs:element ref="season"/>
+        </xs:choice>
+        <xs:element ref="year"/>
+      </xs:sequence>
+      <xs:attribute name="pub-type"/>
+      <xs:attribute name="publication-format"/>
+      <xs:attribute name="date-type"/>
+      <xs:attribute name="iso-8601-date"/>
+      <xs:attribute name="calendar"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="conference">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="conf-date"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="conf-name"/>
+          <xs:element ref="conf-acronym"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="conf-num"/>
+        <xs:element minOccurs="0" ref="conf-loc"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="conf-sponsor"/>
+        <xs:element minOccurs="0" ref="conf-theme"/>
+      </xs:sequence>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="conf-acronym">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="conf-num">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="conf-theme">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="string-conf">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="conf-date"/>
+        <xs:element ref="conf-name"/>
+        <xs:element ref="conf-num"/>
+        <xs:element ref="conf-loc"/>
+        <xs:element ref="conf-sponsor"/>
+        <xs:element ref="conf-theme"/>
+        <xs:element ref="conf-acronym"/>
+        <xs:element ref="string-conf"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="counts">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="count"/>
+        <xs:element minOccurs="0" ref="fig-count"/>
+        <xs:element minOccurs="0" ref="table-count"/>
+        <xs:element minOccurs="0" ref="equation-count"/>
+        <xs:element minOccurs="0" ref="ref-count"/>
+        <xs:element minOccurs="0" ref="page-count"/>
+        <xs:element minOccurs="0" ref="word-count"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="count">
+    <xs:complexType>
+      <xs:attribute name="count-type" use="required"/>
+      <xs:attribute name="count" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="equation-count">
+    <xs:complexType>
+      <xs:attribute name="count" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="fig-count">
+    <xs:complexType>
+      <xs:attribute name="count" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="table-count">
+    <xs:complexType>
+      <xs:attribute name="count" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ref-count">
+    <xs:complexType>
+      <xs:attribute name="count" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="page-count">
+    <xs:complexType>
+      <xs:attribute name="count" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="word-count">
+    <xs:complexType>
+      <xs:attribute name="count" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="title-group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="article-title"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="subtitle"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="trans-title-group"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="alt-title"/>
+        <xs:element minOccurs="0" ref="fn-group"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="subtitle">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="break"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="alt-title">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="break"/>
+      </xs:choice>
+      <xs:attribute name="alt-title-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="author-comment">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:element maxOccurs="unbounded" ref="p"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="app-group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="address"/>
+          <xs:element ref="alternatives"/>
+          <xs:element ref="array"/>
+          <xs:element ref="boxed-text"/>
+          <xs:element ref="chem-struct-wrap"/>
+          <xs:element ref="fig"/>
+          <xs:element ref="fig-group"/>
+          <xs:element ref="graphic"/>
+          <xs:element ref="media"/>
+          <xs:element ref="preformat"/>
+          <xs:element ref="supplementary-material"/>
+          <xs:element ref="table-wrap"/>
+          <xs:element ref="table-wrap-group"/>
+          <xs:element ref="disp-formula"/>
+          <xs:element ref="disp-formula-group"/>
+          <xs:element ref="def-list"/>
+          <xs:element ref="list"/>
+          <xs:element ref="tex-math"/>
+          <xs:element ref="mml:math"/>
+          <xs:element ref="p"/>
+          <xs:element ref="related-article"/>
+          <xs:element ref="related-object"/>
+          <xs:element ref="disp-quote"/>
+          <xs:element ref="speech"/>
+          <xs:element ref="statement"/>
+          <xs:element ref="verse-group"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="app"/>
+          <xs:element ref="ref-list"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="app">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:sequence>
+          <xs:element minOccurs="0" ref="sec-meta"/>
+          <xs:choice>
+            <xs:sequence>
+              <xs:element ref="label"/>
+              <xs:element minOccurs="0" ref="title"/>
+            </xs:sequence>
+            <xs:element ref="title"/>
+          </xs:choice>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="address"/>
+            <xs:element ref="alternatives"/>
+            <xs:element ref="array"/>
+            <xs:element ref="boxed-text"/>
+            <xs:element ref="chem-struct-wrap"/>
+            <xs:element ref="fig"/>
+            <xs:element ref="fig-group"/>
+            <xs:element ref="graphic"/>
+            <xs:element ref="media"/>
+            <xs:element ref="preformat"/>
+            <xs:element ref="supplementary-material"/>
+            <xs:element ref="table-wrap"/>
+            <xs:element ref="table-wrap-group"/>
+            <xs:element ref="disp-formula"/>
+            <xs:element ref="disp-formula-group"/>
+            <xs:element ref="def-list"/>
+            <xs:element ref="list"/>
+            <xs:element ref="tex-math"/>
+            <xs:element ref="mml:math"/>
+            <xs:element ref="p"/>
+            <xs:element ref="related-article"/>
+            <xs:element ref="related-object"/>
+            <xs:element ref="disp-quote"/>
+            <xs:element ref="speech"/>
+            <xs:element ref="statement"/>
+            <xs:element ref="verse-group"/>
+          </xs:choice>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="sec"/>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="fn-group"/>
+            <xs:element ref="glossary"/>
+            <xs:element ref="ref-list"/>
+          </xs:choice>
+        </xs:sequence>
+        <xs:element minOccurs="0" ref="permissions"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="fn-group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:element maxOccurs="unbounded" ref="fn"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="glossary">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="address"/>
+          <xs:element ref="alternatives"/>
+          <xs:element ref="array"/>
+          <xs:element ref="boxed-text"/>
+          <xs:element ref="chem-struct-wrap"/>
+          <xs:element ref="fig"/>
+          <xs:element ref="fig-group"/>
+          <xs:element ref="graphic"/>
+          <xs:element ref="media"/>
+          <xs:element ref="preformat"/>
+          <xs:element ref="supplementary-material"/>
+          <xs:element ref="table-wrap"/>
+          <xs:element ref="table-wrap-group"/>
+          <xs:element ref="disp-formula"/>
+          <xs:element ref="disp-formula-group"/>
+          <xs:element ref="def-list"/>
+          <xs:element ref="list"/>
+          <xs:element ref="tex-math"/>
+          <xs:element ref="mml:math"/>
+          <xs:element ref="p"/>
+          <xs:element ref="related-article"/>
+          <xs:element ref="related-object"/>
+          <xs:element ref="disp-quote"/>
+          <xs:element ref="speech"/>
+          <xs:element ref="statement"/>
+          <xs:element ref="verse-group"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="glossary"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="array">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="alt-text"/>
+          <xs:element ref="long-desc"/>
+          <xs:element ref="email"/>
+          <xs:element ref="ext-link"/>
+          <xs:element ref="uri"/>
+        </xs:choice>
+        <xs:choice>
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="alternatives"/>
+            <xs:element ref="graphic"/>
+            <xs:element ref="media"/>
+          </xs:choice>
+          <xs:element ref="tbody"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="attrib"/>
+          <xs:element ref="permissions"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute name="orientation" default="portrait">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="portrait"/>
+            <xs:enumeration value="landscape"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="boxed-text">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="object-id"/>
+        <xs:element minOccurs="0" ref="sec-meta"/>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="caption"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="address"/>
+          <xs:element ref="alternatives"/>
+          <xs:element ref="array"/>
+          <xs:element ref="boxed-text"/>
+          <xs:element ref="chem-struct-wrap"/>
+          <xs:element ref="fig"/>
+          <xs:element ref="fig-group"/>
+          <xs:element ref="graphic"/>
+          <xs:element ref="media"/>
+          <xs:element ref="preformat"/>
+          <xs:element ref="supplementary-material"/>
+          <xs:element ref="table-wrap"/>
+          <xs:element ref="table-wrap-group"/>
+          <xs:element ref="disp-formula"/>
+          <xs:element ref="disp-formula-group"/>
+          <xs:element ref="def-list"/>
+          <xs:element ref="list"/>
+          <xs:element ref="tex-math"/>
+          <xs:element ref="mml:math"/>
+          <xs:element ref="p"/>
+          <xs:element ref="related-article"/>
+          <xs:element ref="related-object"/>
+          <xs:element ref="disp-quote"/>
+          <xs:element ref="speech"/>
+          <xs:element ref="statement"/>
+          <xs:element ref="verse-group"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="sec"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="fn-group"/>
+          <xs:element ref="glossary"/>
+          <xs:element ref="ref-list"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="attrib"/>
+          <xs:element ref="permissions"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="position" default="float">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="anchor"/>
+            <xs:enumeration value="background"/>
+            <xs:enumeration value="float"/>
+            <xs:enumeration value="margin"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="orientation" default="portrait">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="portrait"/>
+            <xs:enumeration value="landscape"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="content-type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="chem-struct-wrap">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="object-id"/>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="caption"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="alt-text"/>
+          <xs:element ref="long-desc"/>
+          <xs:element ref="email"/>
+          <xs:element ref="ext-link"/>
+          <xs:element ref="uri"/>
+        </xs:choice>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="alternatives"/>
+          <xs:element ref="chem-struct"/>
+          <xs:element ref="graphic"/>
+          <xs:element ref="media"/>
+          <xs:element ref="preformat"/>
+          <xs:element ref="textual-form"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="attrib"/>
+          <xs:element ref="permissions"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="position" default="float">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="anchor"/>
+            <xs:enumeration value="background"/>
+            <xs:enumeration value="float"/>
+            <xs:enumeration value="margin"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="orientation" default="portrait">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="portrait"/>
+            <xs:enumeration value="landscape"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="content-type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="chem-struct">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="alt-text"/>
+        <xs:element ref="long-desc"/>
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="break"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="label"/>
+        <xs:element ref="def-list"/>
+        <xs:element ref="list"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="array"/>
+        <xs:element ref="graphic"/>
+        <xs:element ref="media"/>
+        <xs:element ref="preformat"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="fig-group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="caption"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="alt-text"/>
+          <xs:element ref="long-desc"/>
+          <xs:element ref="email"/>
+          <xs:element ref="ext-link"/>
+          <xs:element ref="uri"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="fig"/>
+          <xs:element ref="alternatives"/>
+          <xs:element ref="graphic"/>
+          <xs:element ref="media"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="position" default="float">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="anchor"/>
+            <xs:enumeration value="background"/>
+            <xs:enumeration value="float"/>
+            <xs:enumeration value="margin"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="orientation" default="portrait">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="portrait"/>
+            <xs:enumeration value="landscape"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="content-type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="fig">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="object-id"/>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="caption"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="alt-text"/>
+          <xs:element ref="long-desc"/>
+          <xs:element ref="email"/>
+          <xs:element ref="ext-link"/>
+          <xs:element ref="uri"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="disp-formula"/>
+          <xs:element ref="disp-formula-group"/>
+          <xs:element ref="chem-struct-wrap"/>
+          <xs:element ref="disp-quote"/>
+          <xs:element ref="speech"/>
+          <xs:element ref="statement"/>
+          <xs:element ref="verse-group"/>
+          <xs:element ref="table-wrap"/>
+          <xs:element ref="p"/>
+          <xs:element ref="def-list"/>
+          <xs:element ref="list"/>
+          <xs:element ref="alternatives"/>
+          <xs:element ref="array"/>
+          <xs:element ref="graphic"/>
+          <xs:element ref="media"/>
+          <xs:element ref="preformat"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="attrib"/>
+          <xs:element ref="permissions"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="position" default="float">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="anchor"/>
+            <xs:enumeration value="background"/>
+            <xs:enumeration value="float"/>
+            <xs:enumeration value="margin"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="orientation" default="portrait">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="portrait"/>
+            <xs:enumeration value="landscape"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="fig-type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="caption">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="p"/>
+      </xs:sequence>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="style"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="graphic">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="alt-text"/>
+        <xs:element ref="long-desc"/>
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="object-id"/>
+        <xs:element ref="label"/>
+        <xs:element ref="caption"/>
+        <xs:element ref="attrib"/>
+        <xs:element ref="permissions"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="position" default="float">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="anchor"/>
+            <xs:enumeration value="background"/>
+            <xs:enumeration value="float"/>
+            <xs:enumeration value="margin"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="orientation" default="portrait">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="portrait"/>
+            <xs:enumeration value="landscape"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="mime-subtype"/>
+      <xs:attribute name="mimetype"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href" use="required"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="media">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="alt-text"/>
+        <xs:element ref="long-desc"/>
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="object-id"/>
+        <xs:element ref="label"/>
+        <xs:element ref="caption"/>
+        <xs:element ref="attrib"/>
+        <xs:element ref="permissions"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="position" default="float">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="anchor"/>
+            <xs:enumeration value="background"/>
+            <xs:enumeration value="float"/>
+            <xs:enumeration value="margin"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="orientation" default="portrait">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="portrait"/>
+            <xs:enumeration value="landscape"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="mimetype"/>
+      <xs:attribute name="mime-subtype"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href" use="required"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="inline-graphic">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="alt-text"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="baseline-shift"/>
+      <xs:attribute name="mimetype"/>
+      <xs:attribute name="mime-subtype"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href" use="required"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="preformat">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="alt-text"/>
+        <xs:element ref="long-desc"/>
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="attrib"/>
+        <xs:element ref="permissions"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="position" default="float">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="anchor"/>
+            <xs:enumeration value="background"/>
+            <xs:enumeration value="float"/>
+            <xs:enumeration value="margin"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="orientation" default="portrait">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="portrait"/>
+            <xs:enumeration value="landscape"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="preformat-type"/>
+      <xs:attribute ref="xml:space" default="preserve"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="supplementary-material">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="object-id"/>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="caption"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="alt-text"/>
+          <xs:element ref="long-desc"/>
+          <xs:element ref="email"/>
+          <xs:element ref="ext-link"/>
+          <xs:element ref="uri"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="disp-formula"/>
+          <xs:element ref="disp-formula-group"/>
+          <xs:element ref="chem-struct-wrap"/>
+          <xs:element ref="disp-quote"/>
+          <xs:element ref="speech"/>
+          <xs:element ref="statement"/>
+          <xs:element ref="verse-group"/>
+          <xs:element ref="table-wrap"/>
+          <xs:element ref="p"/>
+          <xs:element ref="def-list"/>
+          <xs:element ref="list"/>
+          <xs:element ref="alternatives"/>
+          <xs:element ref="array"/>
+          <xs:element ref="graphic"/>
+          <xs:element ref="media"/>
+          <xs:element ref="preformat"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="attrib"/>
+          <xs:element ref="permissions"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="position" default="float">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="anchor"/>
+            <xs:enumeration value="background"/>
+            <xs:enumeration value="float"/>
+            <xs:enumeration value="margin"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="orientation" default="portrait">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="portrait"/>
+            <xs:enumeration value="landscape"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="mimetype"/>
+      <xs:attribute name="mime-subtype"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="table-wrap-group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="caption"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="alt-text"/>
+          <xs:element ref="long-desc"/>
+          <xs:element ref="email"/>
+          <xs:element ref="ext-link"/>
+          <xs:element ref="uri"/>
+        </xs:choice>
+        <xs:element maxOccurs="unbounded" ref="table-wrap"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="position" default="float">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="anchor"/>
+            <xs:enumeration value="background"/>
+            <xs:enumeration value="float"/>
+            <xs:enumeration value="margin"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="orientation" default="portrait">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="portrait"/>
+            <xs:enumeration value="landscape"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="content-type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="table-wrap">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="object-id"/>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="caption"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="alt-text"/>
+          <xs:element ref="long-desc"/>
+          <xs:element ref="email"/>
+          <xs:element ref="ext-link"/>
+          <xs:element ref="uri"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="disp-quote"/>
+          <xs:element ref="speech"/>
+          <xs:element ref="statement"/>
+          <xs:element ref="verse-group"/>
+          <xs:element ref="def-list"/>
+          <xs:element ref="list"/>
+          <xs:element ref="alternatives"/>
+          <xs:element ref="chem-struct-wrap"/>
+          <xs:element ref="graphic"/>
+          <xs:element ref="media"/>
+          <xs:element ref="preformat"/>
+          <xs:element ref="table"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="table-wrap-foot"/>
+          <xs:element ref="attrib"/>
+          <xs:element ref="permissions"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="position" default="float">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="anchor"/>
+            <xs:enumeration value="background"/>
+            <xs:enumeration value="float"/>
+            <xs:enumeration value="margin"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="orientation" default="portrait">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="portrait"/>
+            <xs:enumeration value="landscape"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="content-type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="table-wrap-foot">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="p"/>
+          <xs:element ref="fn-group"/>
+          <xs:element ref="fn"/>
+          <xs:element ref="attrib"/>
+          <xs:element ref="permissions"/>
+        </xs:choice>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="hr">
+    <xs:complexType/>
+  </xs:element>
+  <xs:element name="break">
+    <xs:complexType/>
+  </xs:element>
+  <xs:element name="bold">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="italic">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="monospace">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="roman">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sans-serif">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sc">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="overline">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="strike">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sub">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="arrange">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="stack"/>
+            <xs:enumeration value="stagger"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sup">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="arrange">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="stack"/>
+            <xs:enumeration value="stagger"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="underline">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="underline-style"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="overline-start">
+    <xs:complexType>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="overline-end">
+    <xs:complexType>
+      <xs:attribute name="rid" use="required" type="xs:IDREF"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="underline-start">
+    <xs:complexType>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="underline-end">
+    <xs:complexType>
+      <xs:attribute name="rid" use="required" type="xs:IDREF"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="funding-group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="award-group"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="funding-statement"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="open-access"/>
+      </xs:sequence>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="funding-statement">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="rid" type="xs:IDREFS"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="open-access">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="p"/>
+      </xs:sequence>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="award-group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="funding-source"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="award-id"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="principal-award-recipient"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="principal-investigator"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="rid" type="xs:IDREFS"/>
+      <xs:attribute name="award-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="funding-source">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="rid" type="xs:IDREFS"/>
+      <xs:attribute name="source-type"/>
+      <xs:attribute name="country"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="award-id">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="rid" type="xs:IDREFS"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="principal-award-recipient">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="contrib-id"/>
+        <xs:element ref="name"/>
+        <xs:element ref="name-alternatives"/>
+        <xs:element ref="institution"/>
+        <xs:element ref="string-name"/>
+      </xs:choice>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="principal-investigator">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="contrib-id"/>
+        <xs:element ref="name"/>
+        <xs:element ref="name-alternatives"/>
+        <xs:element ref="string-name"/>
+      </xs:choice>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="journal-meta">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="journal-id"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="journal-title-group"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="contrib-group"/>
+          <xs:element ref="aff"/>
+          <xs:element ref="aff-alternatives"/>
+        </xs:choice>
+        <xs:element maxOccurs="unbounded" ref="issn"/>
+        <xs:element minOccurs="0" ref="issn-l"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="isbn"/>
+        <xs:element minOccurs="0" ref="publisher"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="notes"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="self-uri"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="journal-title-group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="journal-title"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="journal-subtitle"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="trans-title-group"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="abbrev-journal-title"/>
+      </xs:sequence>
+      <xs:attribute name="content-type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="journal-title">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="journal-subtitle">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="abbrev-journal-title">
+    <xs:complexType mixed="true">
+      <xs:attribute name="abbrev-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="fn">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element maxOccurs="unbounded" ref="p"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="fn-type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="abbr"/>
+            <xs:enumeration value="com"/>
+            <xs:enumeration value="con"/>
+            <xs:enumeration value="conflict"/>
+            <xs:enumeration value="corresp"/>
+            <xs:enumeration value="current-aff"/>
+            <xs:enumeration value="deceased"/>
+            <xs:enumeration value="edited-by"/>
+            <xs:enumeration value="equal"/>
+            <xs:enumeration value="financial-disclosure"/>
+            <xs:enumeration value="on-leave"/>
+            <xs:enumeration value="participating-researchers"/>
+            <xs:enumeration value="presented-at"/>
+            <xs:enumeration value="presented-by"/>
+            <xs:enumeration value="present-address"/>
+            <xs:enumeration value="previously-at"/>
+            <xs:enumeration value="study-group-members"/>
+            <xs:enumeration value="supplementary-material"/>
+            <xs:enumeration value="supported-by"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute name="symbol"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="target">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="target-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="xref">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="alt"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="ref-type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="aff"/>
+            <xs:enumeration value="app"/>
+            <xs:enumeration value="author-notes"/>
+            <xs:enumeration value="bibr"/>
+            <xs:enumeration value="boxed-text"/>
+            <xs:enumeration value="chem"/>
+            <xs:enumeration value="contrib"/>
+            <xs:enumeration value="corresp"/>
+            <xs:enumeration value="disp-formula"/>
+            <xs:enumeration value="fig"/>
+            <xs:enumeration value="fn"/>
+            <xs:enumeration value="kwd"/>
+            <xs:enumeration value="list"/>
+            <xs:enumeration value="plate"/>
+            <xs:enumeration value="scheme"/>
+            <xs:enumeration value="sec"/>
+            <xs:enumeration value="statement"/>
+            <xs:enumeration value="supplementary-material"/>
+            <xs:enumeration value="table"/>
+            <xs:enumeration value="table-fn"/>
+            <xs:enumeration value="other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rid" type="xs:IDREFS"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="inline-supplementary-material">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="alt-text"/>
+        <xs:element ref="long-desc"/>
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="mimetype"/>
+      <xs:attribute name="mime-subtype"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="def-list">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:element minOccurs="0" ref="term-head"/>
+        <xs:element minOccurs="0" ref="def-head"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="def-item"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="def-list"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="list-type"/>
+      <xs:attribute name="prefix-word"/>
+      <xs:attribute name="list-content"/>
+      <xs:attribute name="continued-from" type="xs:IDREF"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="term-head">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="def-head">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="def-item">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="term"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="def"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="term">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="disp-formula"/>
+        <xs:element ref="disp-formula-group"/>
+        <xs:element ref="array"/>
+        <xs:element ref="graphic"/>
+        <xs:element ref="media"/>
+        <xs:element ref="preformat"/>
+      </xs:choice>
+      <xs:attribute name="rid" type="xs:IDREFS"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="list">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:element maxOccurs="unbounded" ref="list-item"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="list-type"/>
+      <xs:attribute name="prefix-word"/>
+      <xs:attribute name="list-content"/>
+      <xs:attribute name="continued-from" type="xs:IDREF"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="list-item">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="p"/>
+          <xs:element ref="def-list"/>
+          <xs:element ref="list"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="inline-formula">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="disp-formula">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="alt-text"/>
+        <xs:element ref="long-desc"/>
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="break"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="label"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="array"/>
+        <xs:element ref="graphic"/>
+        <xs:element ref="media"/>
+        <xs:element ref="preformat"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="disp-formula-group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="caption"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="alt-text"/>
+          <xs:element ref="long-desc"/>
+          <xs:element ref="email"/>
+          <xs:element ref="ext-link"/>
+          <xs:element ref="uri"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="disp-formula"/>
+          <xs:element ref="disp-formula-group"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tex-math">
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="notation">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="LaTeX"/>
+            <xs:enumeration value="tex"/>
+            <xs:enumeration value="TEX"/>
+            <xs:enumeration value="TeX"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="version"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="nlm-citation">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="person-group"/>
+          <xs:element ref="collab"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="article-title"/>
+          <xs:element ref="trans-title"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="source"/>
+        <xs:element minOccurs="0" ref="patent"/>
+        <xs:element minOccurs="0" ref="trans-source"/>
+        <xs:element minOccurs="0" ref="year"/>
+        <xs:choice>
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="month"/>
+            <xs:element minOccurs="0" ref="day"/>
+            <xs:element minOccurs="0" ref="time-stamp"/>
+          </xs:sequence>
+          <xs:element minOccurs="0" ref="season"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="access-date"/>
+        <xs:element minOccurs="0" ref="volume"/>
+        <xs:element minOccurs="0" ref="edition"/>
+        <xs:element minOccurs="0" ref="conf-name"/>
+        <xs:element minOccurs="0" ref="conf-date"/>
+        <xs:element minOccurs="0" ref="conf-loc"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="issue"/>
+          <xs:element ref="supplement"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="publisher-loc"/>
+        <xs:element minOccurs="0" ref="publisher-name"/>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+          <xs:element minOccurs="0" ref="fpage"/>
+          <xs:element minOccurs="0" ref="lpage"/>
+        </xs:sequence>
+        <xs:element minOccurs="0" ref="page-count"/>
+        <xs:element minOccurs="0" ref="series"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="comment"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="pub-id"/>
+        <xs:element minOccurs="0" ref="annotation"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="publication-type"/>
+      <xs:attribute name="publisher-type"/>
+      <xs:attribute name="publication-format"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="p">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="address"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="array"/>
+        <xs:element ref="boxed-text"/>
+        <xs:element ref="chem-struct-wrap"/>
+        <xs:element ref="fig"/>
+        <xs:element ref="fig-group"/>
+        <xs:element ref="graphic"/>
+        <xs:element ref="media"/>
+        <xs:element ref="preformat"/>
+        <xs:element ref="supplementary-material"/>
+        <xs:element ref="table-wrap"/>
+        <xs:element ref="table-wrap-group"/>
+        <xs:element ref="disp-formula"/>
+        <xs:element ref="disp-formula-group"/>
+        <xs:element ref="citation-alternatives"/>
+        <xs:element ref="element-citation"/>
+        <xs:element ref="mixed-citation"/>
+        <xs:element ref="nlm-citation"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="award-id"/>
+        <xs:element ref="funding-source"/>
+        <xs:element ref="open-access"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="def-list"/>
+        <xs:element ref="list"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="disp-quote"/>
+        <xs:element ref="speech"/>
+        <xs:element ref="statement"/>
+        <xs:element ref="verse-group"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="disp-quote">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="address"/>
+          <xs:element ref="alternatives"/>
+          <xs:element ref="array"/>
+          <xs:element ref="boxed-text"/>
+          <xs:element ref="chem-struct-wrap"/>
+          <xs:element ref="fig"/>
+          <xs:element ref="fig-group"/>
+          <xs:element ref="graphic"/>
+          <xs:element ref="media"/>
+          <xs:element ref="preformat"/>
+          <xs:element ref="supplementary-material"/>
+          <xs:element ref="table-wrap"/>
+          <xs:element ref="table-wrap-group"/>
+          <xs:element ref="disp-formula"/>
+          <xs:element ref="disp-formula-group"/>
+          <xs:element ref="def-list"/>
+          <xs:element ref="list"/>
+          <xs:element ref="tex-math"/>
+          <xs:element ref="mml:math"/>
+          <xs:element ref="p"/>
+          <xs:element ref="related-article"/>
+          <xs:element ref="related-object"/>
+          <xs:element ref="disp-quote"/>
+          <xs:element ref="speech"/>
+          <xs:element ref="statement"/>
+          <xs:element ref="verse-group"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="attrib"/>
+          <xs:element ref="permissions"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="speech">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="speaker"/>
+        <xs:element maxOccurs="unbounded" ref="p"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="speaker">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="degrees"/>
+        <xs:element ref="given-names"/>
+        <xs:element ref="prefix"/>
+        <xs:element ref="surname"/>
+        <xs:element ref="suffix"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="statement">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:element maxOccurs="unbounded" ref="p"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="attrib"/>
+          <xs:element ref="permissions"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="verse-group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:element minOccurs="0" ref="subtitle"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="verse-line"/>
+          <xs:element ref="verse-group"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="attrib"/>
+          <xs:element ref="permissions"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="verse-line">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="abbrev">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="def"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute name="alt"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="milestone-start">
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="rid" type="xs:IDREF"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="rationale"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="milestone-end">
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="rid" type="xs:IDREF"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="rationale"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="named-content">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="address"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="array"/>
+        <xs:element ref="boxed-text"/>
+        <xs:element ref="chem-struct-wrap"/>
+        <xs:element ref="fig"/>
+        <xs:element ref="fig-group"/>
+        <xs:element ref="graphic"/>
+        <xs:element ref="media"/>
+        <xs:element ref="preformat"/>
+        <xs:element ref="supplementary-material"/>
+        <xs:element ref="table-wrap"/>
+        <xs:element ref="table-wrap-group"/>
+        <xs:element ref="disp-formula"/>
+        <xs:element ref="disp-formula-group"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="def-list"/>
+        <xs:element ref="list"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="disp-quote"/>
+        <xs:element ref="speech"/>
+        <xs:element ref="statement"/>
+        <xs:element ref="verse-group"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="rid" type="xs:IDREFS"/>
+      <xs:attribute name="alt"/>
+      <xs:attribute name="content-type" use="required"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="styled-content">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="address"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="array"/>
+        <xs:element ref="boxed-text"/>
+        <xs:element ref="chem-struct-wrap"/>
+        <xs:element ref="fig"/>
+        <xs:element ref="fig-group"/>
+        <xs:element ref="graphic"/>
+        <xs:element ref="media"/>
+        <xs:element ref="preformat"/>
+        <xs:element ref="supplementary-material"/>
+        <xs:element ref="table-wrap"/>
+        <xs:element ref="table-wrap-group"/>
+        <xs:element ref="disp-formula"/>
+        <xs:element ref="disp-formula-group"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="def-list"/>
+        <xs:element ref="list"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="disp-quote"/>
+        <xs:element ref="speech"/>
+        <xs:element ref="statement"/>
+        <xs:element ref="verse-group"/>
+      </xs:choice>
+      <xs:attribute name="style"/>
+      <xs:attribute name="style-type"/>
+      <xs:attribute name="alt"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ref-list">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" ref="title"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="address"/>
+          <xs:element ref="alternatives"/>
+          <xs:element ref="array"/>
+          <xs:element ref="boxed-text"/>
+          <xs:element ref="chem-struct-wrap"/>
+          <xs:element ref="fig"/>
+          <xs:element ref="fig-group"/>
+          <xs:element ref="graphic"/>
+          <xs:element ref="media"/>
+          <xs:element ref="preformat"/>
+          <xs:element ref="supplementary-material"/>
+          <xs:element ref="table-wrap"/>
+          <xs:element ref="table-wrap-group"/>
+          <xs:element ref="disp-formula"/>
+          <xs:element ref="disp-formula-group"/>
+          <xs:element ref="def-list"/>
+          <xs:element ref="list"/>
+          <xs:element ref="tex-math"/>
+          <xs:element ref="mml:math"/>
+          <xs:element ref="p"/>
+          <xs:element ref="related-article"/>
+          <xs:element ref="related-object"/>
+          <xs:element ref="disp-quote"/>
+          <xs:element ref="speech"/>
+          <xs:element ref="statement"/>
+          <xs:element ref="verse-group"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="ref"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="ref-list"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ref">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="citation-alternatives"/>
+          <xs:element ref="element-citation"/>
+          <xs:element ref="mixed-citation"/>
+          <xs:element ref="nlm-citation"/>
+          <xs:element ref="note"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="note">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="p"/>
+          <xs:element ref="product"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="access-date">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="annotation">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="p"/>
+      </xs:sequence>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="chapter-title">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="comment">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="date-in-citation">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="day"/>
+        <xs:element ref="month"/>
+        <xs:element ref="season"/>
+        <xs:element ref="year"/>
+      </xs:choice>
+      <xs:attribute name="iso-8601-date"/>
+      <xs:attribute name="calendar"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="edition">
+    <xs:complexType mixed="true">
+      <xs:attribute name="designator"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="gov">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="part-title">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="patent">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="country"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="person-group">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="anonymous"/>
+        <xs:element ref="collab"/>
+        <xs:element ref="collab-alternatives"/>
+        <xs:element ref="name"/>
+        <xs:element ref="name-alternatives"/>
+        <xs:element ref="aff"/>
+        <xs:element ref="aff-alternatives"/>
+        <xs:element ref="etal"/>
+        <xs:element ref="role"/>
+        <xs:element ref="string-name"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="person-group-type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="allauthors"/>
+            <xs:enumeration value="assignee"/>
+            <xs:enumeration value="author"/>
+            <xs:enumeration value="compiler"/>
+            <xs:enumeration value="director"/>
+            <xs:enumeration value="editor"/>
+            <xs:enumeration value="guest-editor"/>
+            <xs:enumeration value="inventor"/>
+            <xs:enumeration value="translator"/>
+            <xs:enumeration value="transed"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="pub-id">
+    <xs:complexType mixed="true">
+      <xs:attribute name="pub-id-type">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="art-access-id"/>
+            <xs:enumeration value="arxiv"/>
+            <xs:enumeration value="coden"/>
+            <xs:enumeration value="doaj"/>
+            <xs:enumeration value="doi"/>
+            <xs:enumeration value="isbn"/>
+            <xs:enumeration value="manuscript"/>
+            <xs:enumeration value="medline"/>
+            <xs:enumeration value="other"/>
+            <xs:enumeration value="pii"/>
+            <xs:enumeration value="pmcid"/>
+            <xs:enumeration value="pmid"/>
+            <xs:enumeration value="publisher-id"/>
+            <xs:enumeration value="sici"/>
+            <xs:enumeration value="std-designation"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="series">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="std">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="day"/>
+        <xs:element ref="month"/>
+        <xs:element ref="pub-id"/>
+        <xs:element ref="source"/>
+        <xs:element ref="std-organization"/>
+        <xs:element ref="year"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="std-organization">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="source">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="time-stamp">
+    <xs:complexType mixed="true">
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="trans-source">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="related-object">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="annotation"/>
+        <xs:element ref="article-title"/>
+        <xs:element ref="chapter-title"/>
+        <xs:element ref="collab"/>
+        <xs:element ref="collab-alternatives"/>
+        <xs:element ref="comment"/>
+        <xs:element ref="conf-date"/>
+        <xs:element ref="conf-loc"/>
+        <xs:element ref="conf-name"/>
+        <xs:element ref="conf-sponsor"/>
+        <xs:element ref="date"/>
+        <xs:element ref="date-in-citation"/>
+        <xs:element ref="day"/>
+        <xs:element ref="edition"/>
+        <xs:element ref="email"/>
+        <xs:element ref="elocation-id"/>
+        <xs:element ref="etal"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="fpage"/>
+        <xs:element ref="gov"/>
+        <xs:element ref="institution"/>
+        <xs:element ref="isbn"/>
+        <xs:element ref="issn"/>
+        <xs:element ref="issn-l"/>
+        <xs:element ref="issue"/>
+        <xs:element ref="issue-id"/>
+        <xs:element ref="issue-part"/>
+        <xs:element ref="issue-title"/>
+        <xs:element ref="lpage"/>
+        <xs:element ref="month"/>
+        <xs:element ref="name"/>
+        <xs:element ref="name-alternatives"/>
+        <xs:element ref="object-id"/>
+        <xs:element ref="page-range"/>
+        <xs:element ref="part-title"/>
+        <xs:element ref="patent"/>
+        <xs:element ref="person-group"/>
+        <xs:element ref="pub-id"/>
+        <xs:element ref="publisher-loc"/>
+        <xs:element ref="publisher-name"/>
+        <xs:element ref="role"/>
+        <xs:element ref="season"/>
+        <xs:element ref="series"/>
+        <xs:element ref="size"/>
+        <xs:element ref="source"/>
+        <xs:element ref="std"/>
+        <xs:element ref="string-name"/>
+        <xs:element ref="supplement"/>
+        <xs:element ref="trans-source"/>
+        <xs:element ref="trans-title"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="volume"/>
+        <xs:element ref="volume-id"/>
+        <xs:element ref="volume-series"/>
+        <xs:element ref="year"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="link-type"/>
+      <xs:attribute name="ext-link-type"/>
+      <xs:attribute name="source-id"/>
+      <xs:attribute name="source-id-type"/>
+      <xs:attribute name="source-type"/>
+      <xs:attribute name="document-id"/>
+      <xs:attribute name="document-id-type"/>
+      <xs:attribute name="document-type"/>
+      <xs:attribute name="object-id"/>
+      <xs:attribute name="object-id-type"/>
+      <xs:attribute name="object-type"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/><xs:attribute ref="xlink:type"/>
+      <xs:attribute ref="xlink:href"/>
+      <xs:attribute ref="xlink:role"/>
+      <xs:attribute ref="xlink:title"/>
+      <xs:attribute ref="xlink:show"/>
+      <xs:attribute ref="xlink:actuate"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="floats-group">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="alternatives"/>
+        <xs:element ref="boxed-text"/>
+        <xs:element ref="chem-struct-wrap"/>
+        <xs:element ref="fig"/>
+        <xs:element ref="fig-group"/>
+        <xs:element ref="graphic"/>
+        <xs:element ref="media"/>
+        <xs:element ref="preformat"/>
+        <xs:element ref="supplementary-material"/>
+        <xs:element ref="table-wrap"/>
+        <xs:element ref="table-wrap-group"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sec">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="sec-meta"/>
+        <xs:choice>
+          <xs:sequence>
+            <xs:element ref="label"/>
+            <xs:element minOccurs="0" ref="title"/>
+          </xs:sequence>
+          <xs:element ref="title"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="address"/>
+          <xs:element ref="alternatives"/>
+          <xs:element ref="array"/>
+          <xs:element ref="boxed-text"/>
+          <xs:element ref="chem-struct-wrap"/>
+          <xs:element ref="fig"/>
+          <xs:element ref="fig-group"/>
+          <xs:element ref="graphic"/>
+          <xs:element ref="media"/>
+          <xs:element ref="preformat"/>
+          <xs:element ref="supplementary-material"/>
+          <xs:element ref="table-wrap"/>
+          <xs:element ref="table-wrap-group"/>
+          <xs:element ref="disp-formula"/>
+          <xs:element ref="disp-formula-group"/>
+          <xs:element ref="def-list"/>
+          <xs:element ref="list"/>
+          <xs:element ref="tex-math"/>
+          <xs:element ref="mml:math"/>
+          <xs:element ref="p"/>
+          <xs:element ref="related-article"/>
+          <xs:element ref="related-object"/>
+          <xs:element ref="disp-quote"/>
+          <xs:element ref="speech"/>
+          <xs:element ref="statement"/>
+          <xs:element ref="verse-group"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="sec"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="fn-group"/>
+          <xs:element ref="glossary"/>
+          <xs:element ref="ref-list"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:attribute name="sec-type"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sec-meta">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="contrib-group"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="kwd-group"/>
+        <xs:element minOccurs="0" ref="permissions"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="table">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="col"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="colgroup"/>
+        </xs:choice>
+        <xs:choice>
+          <xs:sequence>
+            <xs:element minOccurs="0" ref="thead"/>
+            <xs:element minOccurs="0" ref="tfoot"/>
+            <xs:element maxOccurs="unbounded" ref="tbody"/>
+          </xs:sequence>
+          <xs:element maxOccurs="unbounded" ref="tr"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="summary"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="border"/>
+      <xs:attribute name="frame">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="void"/>
+            <xs:enumeration value="above"/>
+            <xs:enumeration value="below"/>
+            <xs:enumeration value="hsides"/>
+            <xs:enumeration value="lhs"/>
+            <xs:enumeration value="rhs"/>
+            <xs:enumeration value="vsides"/>
+            <xs:enumeration value="box"/>
+            <xs:enumeration value="border"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rules">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="groups"/>
+            <xs:enumeration value="rows"/>
+            <xs:enumeration value="cols"/>
+            <xs:enumeration value="all"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="cellspacing"/>
+      <xs:attribute name="cellpadding"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="thead">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="tr"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tfoot">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="tr"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tbody">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="tr"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="colgroup">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="col"/>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="span" default="1"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="col">
+    <xs:complexType>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="span" default="1"/>
+      <xs:attribute name="width"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="tr">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="th"/>
+        <xs:element ref="td"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="th">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="hr"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="disp-formula"/>
+        <xs:element ref="disp-formula-group"/>
+        <xs:element ref="break"/>
+        <xs:element ref="citation-alternatives"/>
+        <xs:element ref="element-citation"/>
+        <xs:element ref="mixed-citation"/>
+        <xs:element ref="nlm-citation"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="def-list"/>
+        <xs:element ref="list"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="array"/>
+        <xs:element ref="graphic"/>
+        <xs:element ref="media"/>
+        <xs:element ref="preformat"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="abbr"/>
+      <xs:attribute name="axis"/>
+      <xs:attribute name="headers" type="xs:IDREFS"/>
+      <xs:attribute name="scope">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="row"/>
+            <xs:enumeration value="col"/>
+            <xs:enumeration value="rowgroup"/>
+            <xs:enumeration value="colgroup"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowspan" default="1"/>
+      <xs:attribute name="colspan" default="1"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="td">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="email"/>
+        <xs:element ref="ext-link"/>
+        <xs:element ref="uri"/>
+        <xs:element ref="hr"/>
+        <xs:element ref="inline-supplementary-material"/>
+        <xs:element ref="related-article"/>
+        <xs:element ref="related-object"/>
+        <xs:element ref="disp-formula"/>
+        <xs:element ref="disp-formula-group"/>
+        <xs:element ref="break"/>
+        <xs:element ref="citation-alternatives"/>
+        <xs:element ref="element-citation"/>
+        <xs:element ref="mixed-citation"/>
+        <xs:element ref="nlm-citation"/>
+        <xs:element ref="bold"/>
+        <xs:element ref="italic"/>
+        <xs:element ref="monospace"/>
+        <xs:element ref="overline"/>
+        <xs:element ref="roman"/>
+        <xs:element ref="sans-serif"/>
+        <xs:element ref="sc"/>
+        <xs:element ref="strike"/>
+        <xs:element ref="underline"/>
+        <xs:element ref="chem-struct"/>
+        <xs:element ref="inline-formula"/>
+        <xs:element ref="def-list"/>
+        <xs:element ref="list"/>
+        <xs:element ref="tex-math"/>
+        <xs:element ref="mml:math"/>
+        <xs:element ref="abbrev"/>
+        <xs:element ref="milestone-end"/>
+        <xs:element ref="milestone-start"/>
+        <xs:element ref="named-content"/>
+        <xs:element ref="styled-content"/>
+        <xs:element ref="alternatives"/>
+        <xs:element ref="array"/>
+        <xs:element ref="graphic"/>
+        <xs:element ref="media"/>
+        <xs:element ref="preformat"/>
+        <xs:element ref="inline-graphic"/>
+        <xs:element ref="private-char"/>
+        <xs:element ref="fn"/>
+        <xs:element ref="target"/>
+        <xs:element ref="xref"/>
+        <xs:element ref="sub"/>
+        <xs:element ref="sup"/>
+      </xs:choice>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="content-type"/>
+      <xs:attribute name="style"/>
+      <xs:attribute name="abbr"/>
+      <xs:attribute name="axis"/>
+      <xs:attribute name="headers" type="xs:IDREFS"/>
+      <xs:attribute name="scope">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="row"/>
+            <xs:enumeration value="col"/>
+            <xs:enumeration value="rowgroup"/>
+            <xs:enumeration value="colgroup"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowspan" default="1"/>
+      <xs:attribute name="colspan" default="1"/>
+      <xs:attribute name="align">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="left"/>
+            <xs:enumeration value="center"/>
+            <xs:enumeration value="right"/>
+            <xs:enumeration value="justify"/>
+            <xs:enumeration value="char"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="char"/>
+      <xs:attribute name="charoff"/>
+      <xs:attribute name="valign">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="top"/>
+            <xs:enumeration value="middle"/>
+            <xs:enumeration value="bottom"/>
+            <xs:enumeration value="baseline"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="private-char">
+    <xs:complexType>
+      <xs:choice>
+        <xs:choice>
+          <xs:element ref="glyph-data"/>
+          <xs:element ref="glyph-ref"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="inline-graphic"/>
+      </xs:choice>
+      <xs:attribute name="description"/>
+      <xs:attribute name="name"/>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="glyph-data">
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="fontchar"/>
+      <xs:attribute name="fontname"/>
+      <xs:attribute name="format" type="xs:NMTOKEN"/>
+      <xs:attribute name="resolution"/>
+      <xs:attribute ref="xml:space" default="preserve"/>
+      <xs:attribute name="x-size"/>
+      <xs:attribute name="y-size"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="glyph-ref">
+    <xs:complexType>
+      <xs:attribute name="glyph-data" type="xs:IDREF"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="article">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="front"/>
+        <xs:element minOccurs="0" ref="body"/>
+        <xs:element minOccurs="0" ref="back"/>
+        <xs:element minOccurs="0" ref="floats-group"/>
+        <xs:choice>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="sub-article"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="response"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="article-type"/>
+      <xs:attribute name="dtd-version" default="1.0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="1.0"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang" default="en"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="front">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="journal-meta"/>
+        <xs:element ref="article-meta"/>
+        <xs:element minOccurs="0" ref="notes"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="body">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="address"/>
+          <xs:element ref="alternatives"/>
+          <xs:element ref="array"/>
+          <xs:element ref="boxed-text"/>
+          <xs:element ref="chem-struct-wrap"/>
+          <xs:element ref="fig"/>
+          <xs:element ref="fig-group"/>
+          <xs:element ref="graphic"/>
+          <xs:element ref="media"/>
+          <xs:element ref="preformat"/>
+          <xs:element ref="supplementary-material"/>
+          <xs:element ref="table-wrap"/>
+          <xs:element ref="table-wrap-group"/>
+          <xs:element ref="disp-formula"/>
+          <xs:element ref="disp-formula-group"/>
+          <xs:element ref="def-list"/>
+          <xs:element ref="list"/>
+          <xs:element ref="tex-math"/>
+          <xs:element ref="mml:math"/>
+          <xs:element ref="p"/>
+          <xs:element ref="related-article"/>
+          <xs:element ref="related-object"/>
+          <xs:element ref="disp-quote"/>
+          <xs:element ref="speech"/>
+          <xs:element ref="statement"/>
+          <xs:element ref="verse-group"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="sec"/>
+        <xs:element minOccurs="0" ref="sig-block"/>
+      </xs:sequence>
+      <xs:attribute name="specific-use"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="back">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="label"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="title"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="ack"/>
+          <xs:element ref="app-group"/>
+          <xs:element ref="bio"/>
+          <xs:element ref="fn-group"/>
+          <xs:element ref="glossary"/>
+          <xs:element ref="ref-list"/>
+          <xs:element ref="notes"/>
+          <xs:element ref="sec"/>
+        </xs:choice>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="sub-article">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice>
+          <xs:element ref="front"/>
+          <xs:element ref="front-stub"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="body"/>
+        <xs:element minOccurs="0" ref="back"/>
+        <xs:element minOccurs="0" ref="floats-group"/>
+        <xs:choice>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="sub-article"/>
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="response"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="article-type"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="front-stub">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="article-id"/>
+        <xs:element minOccurs="0" ref="article-categories"/>
+        <xs:element minOccurs="0" ref="title-group"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="contrib-group"/>
+          <xs:element ref="aff"/>
+          <xs:element ref="aff-alternatives"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="author-notes"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="pub-date"/>
+        <xs:element minOccurs="0" ref="volume"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="volume-id"/>
+        <xs:element minOccurs="0" ref="volume-series"/>
+        <xs:element minOccurs="0" ref="issue"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="issue-id"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="issue-title"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="issue-sponsor"/>
+        <xs:element minOccurs="0" ref="issue-part"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="isbn"/>
+        <xs:element minOccurs="0" ref="supplement"/>
+        <xs:choice minOccurs="0">
+          <xs:sequence>
+            <xs:element ref="fpage"/>
+            <xs:element minOccurs="0" ref="lpage"/>
+            <xs:element minOccurs="0" ref="page-range"/>
+          </xs:sequence>
+          <xs:element ref="elocation-id"/>
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="email"/>
+          <xs:element ref="ext-link"/>
+          <xs:element ref="uri"/>
+          <xs:element ref="product"/>
+          <xs:element ref="supplementary-material"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="history"/>
+        <xs:element minOccurs="0" ref="permissions"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="self-uri"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="related-article"/>
+          <xs:element ref="related-object"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="abstract"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="trans-abstract"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="kwd-group"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="funding-group"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="conference"/>
+        <xs:element minOccurs="0" ref="counts"/>
+        <xs:element minOccurs="0" ref="custom-meta-group"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="response">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice>
+          <xs:element ref="front"/>
+          <xs:element ref="front-stub"/>
+        </xs:choice>
+        <xs:element minOccurs="0" ref="body"/>
+        <xs:element minOccurs="0" ref="back"/>
+        <xs:element minOccurs="0" ref="floats-group"/>
+      </xs:sequence>
+      <xs:attribute name="response-type"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="specific-use"/>
+      <xs:attribute ref="xml:lang"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/mycore-pi/src/main/resources/xsd/crossref/4.4.1/clinicaltrials.xsd
+++ b/mycore-pi/src/main/resources/xsd/crossref/4.4.1/clinicaltrials.xsd
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://www.crossref.org/clinicaltrials.xsd"
+    xmlns="http://www.crossref.org/clinicaltrials.xsd">
+
+    <xsd:annotation>
+        <xsd:documentation>  
+         Linked Clinical Trials is a CrossRef initiative helping to connect the published literature to registered clinical trials associated with the research,
+         
+            - version 1.0 (initial release) September 24, 2015
+        </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:element name="program">
+        <xsd:annotation>
+            <xsd:documentation>Accommodates deposit of linked clincal trials metadata. The clinical-trial-number value will
+                be a string that must match a specific pattern appropriate for a given clinical trial registry. The
+                registry is identified in the required attribute 'registry' and must be the DOI of a recognized registry
+                (see http://dx.doi.org/10.18810/registries)
+            </xsd:documentation>
+        </xsd:annotation>
+        
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element ref="clinical-trial-number" minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:element name="clinical-trial-number">
+        <xsd:complexType mixed="true">
+            <xsd:attribute name="registry" use="required">
+                <xsd:annotation>
+                    <xsd:documentation> The clinical trial identifier related to the article.
+                    </xsd:documentation>
+                </xsd:annotation>
+                <xsd:simpleType>
+                    <xsd:restriction base="xsd:string">
+                        <xsd:maxLength value="200"/>
+                        <xsd:minLength value="12"/>
+                        <xsd:pattern value="10.18810/[a-z-]+"/>
+                    </xsd:restriction>
+                </xsd:simpleType>
+            </xsd:attribute>
+            <xsd:attribute name="type" use="optional">
+                <xsd:annotation>
+                    <xsd:documentation> Used to identify the article publication date in relation to the issuance of the trial results
+                    </xsd:documentation>
+                </xsd:annotation>
+                <xsd:simpleType>
+                    <xsd:restriction base="xsd:string">
+                        <xsd:enumeration value="preResults"/>
+                        <xsd:enumeration value="results"/>
+                        <xsd:enumeration value="postResults"/>
+                    </xsd:restriction>
+                </xsd:simpleType>
+            </xsd:attribute>
+        </xsd:complexType>
+    </xsd:element>
+
+</xsd:schema>

--- a/mycore-pi/src/main/resources/xsd/crossref/4.4.1/common4.3.5.xsd
+++ b/mycore-pi/src/main/resources/xsd/crossref/4.4.1/common4.3.5.xsd
@@ -1,0 +1,2770 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:fr="http://www.crossref.org/fundref.xsd"
+	xmlns:ai="http://www.crossref.org/AccessIndicators.xsd"
+	xmlns:mml="http://www.w3.org/1998/Math/MathML">
+
+	<!-- =============================================================
+
+                          Introduction
+
+     CrossRef Schema Version 4.3.5
+	 Developed for CrossRef (www.crossref.org) by
+
+     Inera Incorporated
+     http://www.inera.com
+     email: info@inera.com
+
+
+     ============================================================= -->
+	<!-- =============================================================
+
+                          File Organization
+
+     This schema is organized into the following sections:
+     1. Shared attributes
+     2. Schema-specific data types
+     3. Header elements
+     4. Book elements
+     5. Journal elements
+     6. Elements common to journals, books or conferences
+     7. Elements used for citation deposit and XML queries
+     8. Elements used to deposit components
+     9. CrossMark-specific elements
+     10. Standard-specific elements
+
+     ============================================================= -->
+	<!-- =============================================================
+
+                          Change History
+
+    Changes record version, author initials, date, and comments
+  
+  4.3.0 - 4.4.1 (PDF) 3/1/18 update language.atts
+  4.3.1-4.4.0 (PDF) 6/5/2017 change ORCID to accept both http and https
+  4.3.0 - 4.4.0 (PDF) 5/15/2017 make crossmark_domains optional, limit crossmark_domain_exclusive to 1
+  4.3.5 (PDF) add WebCite as value for archive
+  4.3.0-6 (PDF) disallow empty value for citation "key" attribute
+  4.3.5, 4.3.6 (PDF) 5/14/2015 added text/rtf as mime type
+  4.3.5,6 (PDF) 3/31/2015 added ai:program to components
+  4.3.1,2,4,5,6 (PDF) 3/2/2015 removed redundant ORCID validation
+  4.3.5	(PDF) 10/9/2014 updated standard_designator and child elements, moved mml:math to xrefFaces to fix problem with depositing mathML and other markup, restricted CrossMark update types to an enumerated list, removed cm_update_label
+  4.3.1,2,4 (PDF) 6/24/2014 minor change to ORCID regex to only allow X
+  4.3.4 (PDF) 5/27/2014 added unspecified and syndication as values for property attribute, removed tdm as value for content_version
+  4.3.2,4 (PDF) 4/14/2014 changed superseded_by to supersedes
+  4.3.4 (PDF) 3/26/2014 moved standard_designator, standards_body, and child elements to common file, added standard_designator and standards_body to citation; added type attribute to standard_designator
+  4.3.1,,2,4 (PDF) 3/13/2014 added application/epub+zip to mime_type.atts
+  4.3.4 (PDF) 12/19/2013 changed 'KLB' to 'KB'
+  4.3.4 (PDF) 12/10/2013 added archive_location and archive; changed name to depositor_name to support JATS-like name changes, added alt-name, name elements 
+  4.3.4 (PDF) 12/10/2013 added archive_location and archive; changed name to depositor_name to support JATS-like name changes, added alt-name, name elements 
+  4.3.4 (PDF) 12/10/2013 added archive_location and archive; changed name to depositor_name to support JATS-like name changes, added alt-name, name elements 
+  4.3.2 (PDF) 9/17/2013 added content_version attribute to <resource> element
+  4.3.2 (PDF) 5/1/2013 changed openAI.xsd to AccessIndicators.xsd
+  4.3.2 (PDF) 4/10/2013 added reference_distribution_opt and metadata_distribution_opt attribute
+  4.3.2 (PDF) 4/10/2013 added openAI.xsd namespace and import (for Open Access Indicators program)
+  4.3.2 (PDF) 4/9/2013  added "text-mining" value to the property attribute of the <collection> element, optional mime-type attribute to the <resource> element 
+  4.3.2 (PDF) added reg-agency attribute to component
+  4.3.1 (PDF) added application/eps and application/vnd.openxmlformats-officedocument.wordprocessingml.document
+  				as mime types
+  4.3.1 (PDF) 10/4/2012 added ORCID to contributors 
+  4.3.1 (PDF) 9/12/2012 extended surname length to 45 chars
+  4.3.0 (PDF) 7/11/2012 added video/mp4 as mime type
+  4.3.0 (PDF) 12/21/2011 added video/x-flv and audio/x-wav  as mime types
+  4.3.0 (PDF) 12/9/2011 moved all CrossMark elements from main deposit schema to accommodate CrossMark-only deposits
+
+  4.3.0 (PDF) 7/27/2011 added IsTranslationOf and language attribute to components
+  
+  4.3.0 (PDF) 6/29/2011 added CrossMark elements
+  
+  4.3.0 (CSK) 1/31/2011  changed volume and issue to 32 characters
+
+     4.3.0 (CSK)  6/10/2010  Added video/wmv
+
+   4.3.0 (CSK) 3/4/08 Changed to rev 4.3.0 to match the main schema version.
+
+	1.0.5 (BDR) 7/17/07 Changed surname and given_name elements to disallow digits and "?"
+						so as to avoid incorrectly encoded special characters and also affiliation
+						link numbers in author names
+
+   1.0.4.2 (CSK) 8/28/06  Changed element resource data type to anyURI
+                                        moved <collection> from under <collection> back to <item>
+
+    1.0.4.1(CSK) 8/23/06  Added basic 13 digit ISBN capability
+
+    1.0.4 (BDR) 3/24/06  Updated to work with database element
+                         Changed description in component element
+                         to only allow one occurance
+          (BDR) 4/6/06   Added affiliation element to person_name
+
+    1.0.3.4 (CSK) 2/6/2006  Restructured publication_date element to
+                          use a date type.
+
+    1.0.3.3 (CSK) 7/28/05 Included Bruce's fixes to email and  isbn pattern
+
+    1.0.3.2 (CSK)  5/19/05 Added video/avi to mime_type.atts
+
+    1.0.3.2 (HS) added article_title
+
+    1.0.3.1 (CSK) minor revision, backward compatible
+
+    1/25/05   Added chemical mime types
+
+    1.0.3 (CSK)
+
+    7/20/04  Added elements for the deposit of components (section #8)
+    12/7/04  Added size attribute to component
+    12/7/04  Added minOccurs=0 attribute to the <citation_list> child element <citation>
+
+
+    1.0.2 (CSK)   7/16/04
+
+    Moved elments resource,item,collection,property_t and property from the
+    main schema file to this include file to faciliate creating a schema
+    for the deposit of only multiple resolution data.
+
+    1.0.1 (HS)  4/2/03
+
+    Modified "year" model in citation_t to be cYear to support
+    non numeric years in references (e.g. 1998a , 1999-2000)
+
+    3.0.0 (BDR) 10/17/03 (CSK) 12/23/03
+
+    Created with elements from CrossRef Deposit Schema 2.0.6 based
+    largely on elements from section 1, 2 3, and 8 of that parent file.
+    This file now serves as an included module to the parent file
+    and other schemas from CrossRef.
+
+     ============================================================= -->
+	<!-- =============================================================
+
+                          1. Shared attributes
+
+     ============================================================= -->
+
+	<xsd:import namespace="http://www.w3.org/1998/Math/MathML"
+		schemaLocation="http://www.w3.org/Math/XMLSchema/mathml3/mathml3.xsd"/>
+	<xsd:import namespace="http://www.crossref.org/fundref.xsd" schemaLocation="fundref.xsd"/>
+	<xsd:import namespace="http://www.crossref.org/AccessIndicators.xsd"
+		schemaLocation="AccessIndicators.xsd"/>
+	<xsd:attributeGroup name="publication_type.atts">
+		<xsd:attribute name="publication_type" default="full_text">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:NMTOKEN">
+					<xsd:enumeration value="abstract_only"/>
+					<xsd:enumeration value="full_text"/>
+					<xsd:enumeration value="bibliographic_record"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="media_type.atts">
+		<xsd:attribute name="media_type" default="print">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:NMTOKEN">
+					<xsd:enumeration value="print"/>
+					<xsd:enumeration value="electronic"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="contributor.atts">
+		<xsd:attribute name="sequence" use="required">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:NMTOKEN">
+					<xsd:enumeration value="first"/>
+					<xsd:enumeration value="additional"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="contributor_role" use="required">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:NMTOKEN">
+					<xsd:enumeration value="author"/>
+					<xsd:enumeration value="editor"/>
+					<xsd:enumeration value="chair"/>
+					<xsd:enumeration value="translator"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="name-style" use="optional">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:token">
+					<xsd:enumeration value="western"/>
+					<xsd:enumeration value="eastern"/>
+					<xsd:enumeration value="islensk"/>
+					<xsd:enumeration value="given-only"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="language.atts"/>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="language.atts">
+		<xsd:annotation>
+			<xsd:documentation>Language attributes are based on ISO 639</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="language" use="optional">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:NMTOKEN">
+					<xsd:enumeration value="aa"/>
+					<xsd:enumeration value="ab"/>
+					<xsd:enumeration value="ae"/>
+					<xsd:enumeration value="af"/>
+					<xsd:enumeration value="ak"/>
+					<xsd:enumeration value="am"/>
+					<xsd:enumeration value="an"/>
+					<xsd:enumeration value="ar"/>
+					<xsd:enumeration value="as"/>
+					<xsd:enumeration value="av"/>
+					<xsd:enumeration value="ay"/>
+					<xsd:enumeration value="az"/>
+					<xsd:enumeration value="ba"/>
+					<xsd:enumeration value="be"/>
+					<xsd:enumeration value="bg"/>
+					<xsd:enumeration value="bh"/>
+					<xsd:enumeration value="bi"/>
+					<xsd:enumeration value="bm"/>
+					<xsd:enumeration value="bn"/>
+					<xsd:enumeration value="bo"/>
+					<xsd:enumeration value="br"/>
+					<xsd:enumeration value="bs"/>
+					<xsd:enumeration value="ca"/>
+					<xsd:enumeration value="ce"/>
+					<xsd:enumeration value="ch"/>
+					<xsd:enumeration value="co"/>
+					<xsd:enumeration value="cr"/>
+					<xsd:enumeration value="cs"/>
+					<xsd:enumeration value="cu"/>
+					<xsd:enumeration value="cv"/>
+					<xsd:enumeration value="cy"/>
+					<xsd:enumeration value="da"/>
+					<xsd:enumeration value="de"/>
+					<xsd:enumeration value="dv"/>
+					<xsd:enumeration value="dz"/>
+					<xsd:enumeration value="ee"/>
+					<xsd:enumeration value="el"/>
+					<xsd:enumeration value="en"/>
+					<xsd:enumeration value="eo"/>
+					<xsd:enumeration value="es"/>
+					<xsd:enumeration value="et"/>
+					<xsd:enumeration value="eu"/>
+					<xsd:enumeration value="fa"/>
+					<xsd:enumeration value="ff"/>
+					<xsd:enumeration value="fi"/>
+					<xsd:enumeration value="fj"/>
+					<xsd:enumeration value="fo"/>
+					<xsd:enumeration value="fr"/>
+					<xsd:enumeration value="fy"/>
+					<xsd:enumeration value="ga"/>
+					<xsd:enumeration value="gd"/>
+					<xsd:enumeration value="gl"/>
+					<xsd:enumeration value="gn"/>
+					<xsd:enumeration value="gu"/>
+					<xsd:enumeration value="gv"/>
+					<xsd:enumeration value="ha"/>
+					<xsd:enumeration value="he"/>
+					<xsd:enumeration value="hi"/>
+					<xsd:enumeration value="ho"/>
+					<xsd:enumeration value="hr"/>
+					<xsd:enumeration value="ht"/>
+					<xsd:enumeration value="hu"/>
+					<xsd:enumeration value="hy"/>
+					<xsd:enumeration value="hz"/>
+					<xsd:enumeration value="ia"/>
+					<xsd:enumeration value="id"/>
+					<xsd:enumeration value="ie"/>
+					<xsd:enumeration value="ig"/>
+					<xsd:enumeration value="ii"/>
+					<xsd:enumeration value="ik"/>
+					<xsd:enumeration value="io"/>
+					<xsd:enumeration value="is"/>
+					<xsd:enumeration value="it"/>
+					<xsd:enumeration value="iu"/>
+					<xsd:enumeration value="ja"/>
+					<xsd:enumeration value="jw"/>
+					<xsd:enumeration value="ka"/>
+					<xsd:enumeration value="kg"/>
+					<xsd:enumeration value="ki"/>
+					<xsd:enumeration value="kj"/>
+					<xsd:enumeration value="kk"/>
+					<xsd:enumeration value="kl"/>
+					<xsd:enumeration value="km"/>
+					<xsd:enumeration value="kn"/>
+					<xsd:enumeration value="ko"/>
+					<xsd:enumeration value="kr"/>
+					<xsd:enumeration value="ks"/>
+					<xsd:enumeration value="ku"/>
+					<xsd:enumeration value="kv"/>
+					<xsd:enumeration value="kw"/>
+					<xsd:enumeration value="ky"/>
+					<xsd:enumeration value="la"/>
+					<xsd:enumeration value="lb"/>
+					<xsd:enumeration value="lg"/>
+					<xsd:enumeration value="li"/>
+					<xsd:enumeration value="ln"/>
+					<xsd:enumeration value="lo"/>
+					<xsd:enumeration value="lt"/>
+					<xsd:enumeration value="lu"/>
+					<xsd:enumeration value="lv"/>
+					<xsd:enumeration value="mg"/>
+					<xsd:enumeration value="mu"/>
+					<xsd:enumeration value="mi"/>
+					<xsd:enumeration value="mk"/>
+					<xsd:enumeration value="ml"/>
+					<xsd:enumeration value="mn"/>
+					<xsd:enumeration value="mr"/>
+					<xsd:enumeration value="ms"/>
+					<xsd:enumeration value="mt"/>
+					<xsd:enumeration value="my"/>
+					<xsd:enumeration value="na"/>
+					<xsd:enumeration value="nb"/>
+					<xsd:enumeration value="nd"/>
+					<xsd:enumeration value="ne"/>
+					<xsd:enumeration value="ng"/>
+					<xsd:enumeration value="nl"/>
+					<xsd:enumeration value="nn"/>
+					<xsd:enumeration value="no"/>
+					<xsd:enumeration value="nr"/>
+					<xsd:enumeration value="nv"/>
+					<xsd:enumeration value="ny"/>
+					<xsd:enumeration value="oc"/>
+					<xsd:enumeration value="oj"/>
+					<xsd:enumeration value="om"/>
+					<xsd:enumeration value="or"/>
+					<xsd:enumeration value="os"/>
+					<xsd:enumeration value="pa"/>
+					<xsd:enumeration value="pi"/>
+					<xsd:enumeration value="pl"/>
+					<xsd:enumeration value="ps"/>
+					<xsd:enumeration value="pt"/>
+					<xsd:enumeration value="qu"/>
+					<xsd:enumeration value="rm"/>
+					<xsd:enumeration value="rn"/>
+					<xsd:enumeration value="ro"/>
+					<xsd:enumeration value="ru"/>
+					<xsd:enumeration value="rw"/>
+					<xsd:enumeration value="sa"/>
+					<xsd:enumeration value="sc"/>
+					<xsd:enumeration value="sd"/>
+					<xsd:enumeration value="se"/>
+					<xsd:enumeration value="sg"/>
+					<xsd:enumeration value="si"/>
+					<xsd:enumeration value="sk"/>
+					<xsd:enumeration value="sl"/>
+					<xsd:enumeration value="sm"/>
+					<xsd:enumeration value="sn"/>
+					<xsd:enumeration value="so"/>
+					<xsd:enumeration value="sq"/>
+					<xsd:enumeration value="sr"/>
+					<xsd:enumeration value="ss"/>
+					<xsd:enumeration value="st"/>
+					<xsd:enumeration value="su"/>
+					<xsd:enumeration value="sv"/>
+					<xsd:enumeration value="sw"/>
+					<xsd:enumeration value="ta"/>
+					<xsd:enumeration value="te"/>
+					<xsd:enumeration value="tg"/>
+					<xsd:enumeration value="th"/>
+					<xsd:enumeration value="ti"/>
+					<xsd:enumeration value="tk"/>
+					<xsd:enumeration value="tl"/>
+					<xsd:enumeration value="tn"/>
+					<xsd:enumeration value="to"/>
+					<xsd:enumeration value="tr"/>
+					<xsd:enumeration value="ts"/>
+					<xsd:enumeration value="tt"/>
+					<xsd:enumeration value="tw"/>
+					<xsd:enumeration value="ty"/>
+					<xsd:enumeration value="ug"/>
+					<xsd:enumeration value="uk"/>
+					<xsd:enumeration value="ur"/>
+					<xsd:enumeration value="uz"/>
+					<xsd:enumeration value="ve"/>
+					<xsd:enumeration value="vi"/>
+					<xsd:enumeration value="vo"/>
+					<xsd:enumeration value="wa"/>
+					<xsd:enumeration value="wo"/>
+					<xsd:enumeration value="xh"/>
+					<xsd:enumeration value="yi"/>
+					<xsd:enumeration value="yo"/>
+					<xsd:enumeration value="za"/>
+					<xsd:enumeration value="zh"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="mime_type.atts">
+		<xsd:annotation>
+			<xsd:documentation>Mime types for component format. For mime types refer to
+				http://www.iana.org/assignments/media-types/</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="mime_type" use="optional">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="text/plain"/>
+					<xsd:enumeration value="text/richtext"/>
+					<xsd:enumeration value="text/enriched"/>
+					<xsd:enumeration value="text/tab-separated-values"/>
+					<xsd:enumeration value="text/html"/>
+					<xsd:enumeration value="text/sgml"/>
+					<xsd:enumeration value="text/css"/>
+                                        <xsd:enumeration value="text/rtf"/>
+					<xsd:enumeration value="text/xml"/>
+					<xsd:enumeration value="text/xml-external-parsed-entity"/>
+					<xsd:enumeration value="multipart/mixed"/>
+					<xsd:enumeration value="multipart/alternative"/>
+					<xsd:enumeration value="multipart/digest"/>
+					<xsd:enumeration value="multipart/parallel"/>
+					<xsd:enumeration value="multipart/appledouble"/>
+					<xsd:enumeration value="multipart/header-set"/>
+					<xsd:enumeration value="multipart/form-data"/>
+					<xsd:enumeration value="multipart/report"/>
+					<xsd:enumeration value="multipart/voice-message"/>
+					<xsd:enumeration value="multipart/signed"/>
+					<xsd:enumeration value="multipart/encrypted"/>
+					<xsd:enumeration value="multipart/byteranges"/>
+					<xsd:enumeration value="application/eps"/>
+					<xsd:enumeration value="application/epub+zip"/>
+					<xsd:enumeration value="application/octet-stream"/>
+					<xsd:enumeration value="application/postscript"/>
+					<xsd:enumeration value="application/rtf"/>
+					<xsd:enumeration value="application/applefile"/>
+					<xsd:enumeration value="application/mac-binhex40"/>
+					<xsd:enumeration value="application/wordperfect5.1"/>
+					<xsd:enumeration value="application/pdf"/>
+					<xsd:enumeration value="application/x-gzip"/>
+					<xsd:enumeration value="application/zip"/>
+					<xsd:enumeration value="application/gzip"/>
+					<xsd:enumeration value="application/macwriteii"/>
+					<xsd:enumeration value="application/msword"/>
+					<xsd:enumeration value="application/sgml"/>
+					<xsd:enumeration value="application/cals-1840"/>
+					<xsd:enumeration value="application/pgp-encrypted"/>
+					<xsd:enumeration value="application/pgp-signature"/>
+					<xsd:enumeration value="application/pgp-keys"/>
+					<xsd:enumeration value="application/sgml-open-catalog"/>
+					<xsd:enumeration value="application/rc"/>
+					<xsd:enumeration value="application/xml"/>
+					<xsd:enumeration value="application/xml-external-parsed-entity"/>
+					<xsd:enumeration value="application/xml-dtd"/>
+					<xsd:enumeration value="application/batch-SMTP"/>
+					<xsd:enumeration value="application/ipp"/>
+					<xsd:enumeration value="application/ocsp-request"/>
+					<xsd:enumeration value="application/ocsp-response"/>
+					<xsd:enumeration value="application/vnd.oasis.opendocument.text"/>
+					<xsd:enumeration value="application/vnd.oasis.opendocument.presentation"/>
+					<xsd:enumeration value="application/vnd.oasis.opendocument.spreadsheet"/>
+					<xsd:enumeration value="application/vnd.ms-excel"/>
+					<xsd:enumeration value="application/vnd.ms-powerpoint"/>
+					<xsd:enumeration
+						value="application/vnd.openxmlformats-officedocument.presentationml.presentation"/>
+					<xsd:enumeration
+						value="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/>
+					<xsd:enumeration
+						value="application/vnd.openxmlformats-officedocument.wordprocessingml.document"/>
+					<xsd:enumeration value="application/epub+zip"/>
+					<xsd:enumeration value="image/fits"/>
+					<xsd:enumeration value="image/jpeg"/>
+					<xsd:enumeration value="image/gif"/>
+					<xsd:enumeration value="image/ief"/>
+					<xsd:enumeration value="image/g3fax"/>
+					<xsd:enumeration value="image/tiff"/>
+					<xsd:enumeration value="image/Graphics-Metafile"/>
+					<xsd:enumeration value="image/png"/>
+					<xsd:enumeration value="audio/basic"/>
+					<xsd:enumeration value="audio/32kadpcm"/>
+					<xsd:enumeration value="audio/mpeg"/>
+					<xsd:enumeration value="audio/parityfec"/>
+					<xsd:enumeration value="audio/MP4A-LATM"/>
+					<xsd:enumeration value="audio/mpa-robust"/>
+					<xsd:enumeration value="video/x-ms-wmv"/>
+					<xsd:enumeration value="video/avi"/>
+					<xsd:enumeration value="video/mpeg"/>
+					<xsd:enumeration value="video/quicktime"/>
+					<xsd:enumeration value="video/pointer"/>
+					<xsd:enumeration value="video/parityfec"/>
+					<xsd:enumeration value="video/MP4V-ES"/>
+					<xsd:enumeration value="video/mp4"/>
+					<xsd:enumeration value="chemical/x-alchemy"/>
+					<xsd:enumeration value="chemical/x-cache-csf"/>
+					<xsd:enumeration value="chemical/x-cactvs-binary"/>
+					<xsd:enumeration value="chemical/x-cactvs-binary"/>
+					<xsd:enumeration value="chemical/x-cactvs-binary"/>
+					<xsd:enumeration value="chemical/x-cdx"/>
+					<xsd:enumeration value="chemical/x-cerius"/>
+					<xsd:enumeration value="chemical/x-chemdraw"/>
+					<xsd:enumeration value="chemical/x-cif"/>
+					<xsd:enumeration value="chemical/x-mmcif"/>
+					<xsd:enumeration value="chemical/x-chem3d"/>
+					<xsd:enumeration value="chemical/x-cmdf"/>
+					<xsd:enumeration value="chemical/x-compass"/>
+					<xsd:enumeration value="chemical/x-crossfire"/>
+					<xsd:enumeration value="chemical/x-cml"/>
+					<xsd:enumeration value="chemical/x-csml"/>
+					<xsd:enumeration value="chemical/x-ctx"/>
+					<xsd:enumeration value="chemical/x-cxf"/>
+					<xsd:enumeration value="chemical/x-daylight-smiles"/>
+					<xsd:enumeration value="chemical/x-embl-dl-nucleotide"/>
+					<xsd:enumeration value="chemical/x-galactic-spc"/>
+					<xsd:enumeration value="Data/spcvue.htm"/>
+					<xsd:enumeration value="chemical/x-gamess-input"/>
+					<xsd:enumeration value="chemical/x-gaussian-input"/>
+					<xsd:enumeration value="chemical/x-gaussian-checkpoint"/>
+					<xsd:enumeration value="chemical/x-gaussian-cube"/>
+					<xsd:enumeration value="chemical/x-gcg8-sequence"/>
+					<xsd:enumeration value="chemical/x-genbank"/>
+					<xsd:enumeration value="chemical/x-isostar"/>
+					<xsd:enumeration value="chemical/x-jcamp-dx"/>
+					<xsd:enumeration value="chemical/x-kinemage"/>
+					<xsd:enumeration value="chemical/x-macmolecule"/>
+					<xsd:enumeration value="chemical/x-macromodel-input"/>
+					<xsd:enumeration value="chemical/x-mdl-molfile"/>
+					<xsd:enumeration value="chemical/x-mdl-rdfile"/>
+					<xsd:enumeration value="chemical/x-mdl-rxnfile"/>
+					<xsd:enumeration value="chemical/x-mdl-sdfile"/>
+					<xsd:enumeration value="chemical/x-mdl-tgf"/>
+					<xsd:enumeration value="chemical/x-mif"/>
+					<xsd:enumeration value="chemical/x-mol2"/>
+					<xsd:enumeration value="chemical/x-molconn-Z"/>
+					<xsd:enumeration value="chemical/x-mopac-input"/>
+					<xsd:enumeration value="chemical/x-mopac-graph"/>
+					<xsd:enumeration value="chemical/x-ncbi-asn1"/>
+					<xsd:enumeration value="chemical/x-ncbi-asn1-binary"/>
+					<xsd:enumeration value="chemical/x-pdb"/>
+					<xsd:enumeration value="chemical/x-swissprot"/>
+					<xsd:enumeration value="chemical/x-vamas-iso14976"/>
+					<xsd:enumeration value="chemical/x-vmd"/>
+					<xsd:enumeration value="chemical/x-xtel"/>
+					<xsd:enumeration value="chemical/x-xyz"/>
+					<xsd:enumeration value="model/vrml"/>
+					<xsd:enumeration value="audio/x-wav"/>
+					<xsd:enumeration value="video/x-flv"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="metadata_distribution_opts.att">
+		<xsd:annotation>
+			<xsd:documentation>Use to flag metadata for distribution. "query" is the default and
+				follows current protocol - bibliographic metadata is distributed to anyone in a
+				query response, bulk distribution is only allowed per CMS rules. "any" allows bulk
+				distribution of metadata to anyone using OAI-PMH queries.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="metadata_distribution_opts" use="optional" default="query">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="any"/>
+					<xsd:enumeration value="query"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="reference_distribution_opts.att">
+		<xsd:annotation>
+			<xsd:documentation>Use to flag references for distribution. "none" is the default and
+				follows current protocol - references are only distributed to everyone if the prefix
+				level permission is set, otherwise reference distribution is limited to the DOI
+				owner. Setting the value to "query" releases references to anyone making a query
+				request (this overrides any established prefix level permission). Value "any" allows
+				bulk distribution to anyone (using a CrossRef query account) using the OAI-PMH
+				protocol, and also releases references to anyone making a query
+				request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="reference_distribution_opts" use="optional" default="none">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="none"/>
+					<xsd:enumeration value="query"/>
+					<xsd:enumeration value="any"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<!-- =============================================================
+
+                     2. Schema-specific data types
+
+     ============================================================= -->
+	<xsd:complexType name="xrefFaces" mixed="true">
+		<xsd:choice minOccurs="0" maxOccurs="unbounded">
+			<xsd:group ref="face_markup"/>
+		</xsd:choice>
+	</xsd:complexType>
+	<xsd:group name="face_markup">
+		<xsd:annotation>
+			<xsd:documentation>The following are basic data types for face markup. Face markup that
+				appears in the title, subtitle, and original_language_title elements should be
+				retained when depositing metadata. Face markup in other elements (e.g. small caps in
+				author names) must be dropped. Face markup support includes bold (b), italic (i),
+				underline (u), over-line (ovl), superscript (sup), subscript (sub), small caps
+				(scp), and typewriter text (tt). See
+				http://help.crossref.org/#face_markup
+				
+MathML may also be included using the 'mml' namespace prefix.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:choice>
+			<xsd:element ref="b"/>
+			<xsd:element ref="i"/>
+			<xsd:element ref="u"/>
+			<xsd:element ref="ovl"/>
+			<xsd:element ref="sup"/>
+			<xsd:element ref="sub"/>
+			<xsd:element ref="scp"/>
+			<xsd:element ref="tt"/>
+			<xsd:element ref="font"/>
+			<xsd:element ref="mml:math"/>
+		</xsd:choice>
+	</xsd:group>
+	<xsd:element name="b" type="xrefFaces"/>
+	<xsd:element name="i" type="xrefFaces"/>
+	<xsd:element name="u" type="xrefFaces"/>
+	<xsd:element name="ovl" type="xrefFaces"/>
+	<xsd:element name="sup" type="xrefFaces"/>
+	<xsd:element name="sub" type="xrefFaces"/>
+	<xsd:element name="scp" type="xrefFaces"/>
+	<xsd:element name="tt" type="xrefFaces"/>
+	<xsd:element name="font" type="xrefFaces"/>
+	<xsd:simpleType name="xrefYear">
+		<xsd:annotation>
+			<xsd:documentation>The following are basic data types for date
+				parts.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:positiveInteger">
+			<xsd:maxInclusive value="2200"/>
+			<xsd:minInclusive value="1400"/>
+			<xsd:totalDigits value="4"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="xrefMonth">
+		<xsd:restriction base="xsd:positiveInteger">
+			<xsd:maxInclusive value="34"/>
+			<xsd:minInclusive value="01"/>
+			<xsd:totalDigits value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="xrefDay">
+		<xsd:restriction base="xsd:positiveInteger">
+			<xsd:maxInclusive value="31"/>
+			<xsd:minInclusive value="01"/>
+			<xsd:totalDigits value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!-- =============================================================
+
+                          3. Header elements
+
+     ============================================================= -->
+	<xsd:element name="doi_batch_id">
+		<xsd:annotation>
+			<xsd:documentation>Publisher generated ID that uniquely identifies the DOI submission
+				batch. It will be used as a reference in error messages sent by the MDDB, and can be
+				used for submission tracking. The publisher must insure that this number is unique
+				for every submission to CrossRef. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="100"/>
+				<xsd:minLength value="4"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="timestamp" type="xsd:nonNegativeInteger">
+		<xsd:annotation>
+			<xsd:documentation>Indicates version of a batch file instance or DOI. timestamp is used
+				to uniquely identify batch files and DOI values when a DOI has been updated one or
+				more times. timestamp is an integer representation of date and time that serves as a
+				version number for the record that is being deposited. Because CrossRef uses it as a
+				version number, the format need not follow any public standard and therefore the
+				publisher can determine the internal format. The schema format is a double of at
+				least 64 bits, insuring that a fully qualified date/time stamp of 19 digits can be
+				submitted. When depositing data, CrossRef will check to see if a DOI has already
+				been deposited for the specific doi value. If the newer data carries a time stamp
+				value that is equal to or greater than the old data based on a strict numeric
+				comparison, the new data will replace the old data. If the new data value is less
+				than the old data value, the new data will not replace the old data. timestamp is
+				optional in doi_data and required in head. The value from the head instance
+				timestamp will be used for all instances of doi_data that do not include a timestamp
+				element.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="depositor">
+		<xsd:annotation>
+			<xsd:documentation>Information about the organization submitting DOI metadata to
+				CrossRef</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="depositor_name"/>
+				<xsd:element ref="email_address"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="depositor_name">
+		<xsd:annotation>
+			<xsd:documentation>Name of the organization registering the DOIs. The name placed in
+				this element should match the name under which a depositing organization has
+				registered with CrossRef.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="130"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="email_address">
+		<xsd:annotation>
+			<xsd:documentation>e-mail address to which batch success and/or error messages are sent.
+				It is recommended that this address be unique to a position within the organization
+				submitting data (e.g. "doi@...") rather than unique to a person. In this way, the
+				alias for delivery of this mail can be changed as responsibility for submission of
+				DOI data within the organization changes from one person to another.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="200"/>
+				<xsd:minLength value="6"/>
+				<xsd:pattern
+					value="[\p{L}\p{N}!/+\-_]+(\.[\p{L}\p{N}!/+\-_]+)*@[\p{L}\p{N}!/+\-_]+(\.[\p{L}_-]+)+"
+				/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="registrant">
+		<xsd:annotation>
+			<xsd:documentation>The organization that owns the information being registered.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="255"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<!-- =============================================================
+
+                          4. Book elements
+
+     ============================================================= -->
+	<xsd:element name="component_number">
+		<xsd:annotation>
+			<xsd:documentation>The chapter, section, part, etc. number for a content item in a book.
+				Unlike volume and edition_number, component_number should include any additional
+				text that helps identify the type of component. In the example above, the text
+				"Section 8" appeared on the table of contents and it is reflected here. "8" is also
+				acceptable, however the former treatment is preferred. The type of the component is
+				given the component_type attribute of content_item.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="50"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="edition_number">
+		<xsd:annotation>
+			<xsd:documentation>The edition number of a book. edition_number should include only a
+				number and not additional text such as "edition". For example, you should submit
+				"3", not "third edition" or "3rd edition". Roman numerals are acceptable. Publishers
+				will update a print edition with a new edition number when more than ten percent of
+				the content has changed. However, publishers expect to continuously update online
+				editions of books without changing the edition number. <i>The ability to update the
+					electronic version independent of the print version could be problematic for
+					researchers. For example, if a research article cites the print version of a
+					chapter, and a researcher subsequently links to the online version of the same
+					chapter, the content may be different from the print version without the typical
+					indication of a new edition. This topic requires further discussion outside of
+					the scope of this specification.</i></xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="15"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<!-- =============================================================
+
+                          5. Journal elements
+
+     ============================================================= -->
+	<xsd:element name="issue">
+		<xsd:annotation>
+			<xsd:documentation>The issue number in which an article is published. Only one issue
+				name should be used for the issue. The issue number takes precedence over any other
+				name. For example, if an issue has only a seasonal name, then the season should be
+				listed in issue. However, if an issue has a number and a season, then only the
+				number should be listed in issue, and the season should be placed in month (see the
+				table in month, below, for proper encoding of the season) if the specific month of
+				publication is not known. Do not include the words "issue", "No" or "number" in this
+				element. When submitting DOIs for journal articles published online ahead of print,
+				you should submit the issue number, when known, even if the pagination information
+				for the entity is not yet known. Data may be alpha, numeric or a combination.
+				Examples: 74(3):1999 <journal_issue>
+					<publication_date media_type="print">
+						<year>1999</year>
+					</publication_date>
+					<journal_volume>
+						<volume>74</volume>
+					</journal_volume>
+					<issue>3</issue>
+				</journal_issue> Volume 74, Spring 1999 <journal_issue>
+					<publication_date media_type="print">
+						<year>1999</year>
+					</publication_date>
+					<journal_volume>
+						<volume>74</volume>
+					</journal_volume>
+					<issue>Spring</issue>
+				</journal_issue> Volume 74, issue 3 Spring 1999 <journal_issue>
+					<publication_date media_type="print">
+						<month>21</month>
+						<year>1999</year>
+					</publication_date>
+					<journal_volume>
+						<volume>74</volume>
+					</journal_volume>
+					<issue>3</issue>
+				</journal_issue></xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="32"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<!-- =============================================================
+
+       6. Elements shared by content types
+
+     ============================================================= -->
+	<xsd:element name="doi_data">
+		<xsd:annotation>
+			<xsd:documentation>The container for elements related directly to a DOI. doi_data
+				contains the doi, timestamp (version) and corresponding resource (URI) data for the
+				doi. Cases of single-resolution (i.e. one DOI with a single corresponding URI)
+				should be tagged with a doi/resource pair in doi_data. If additional resources are
+				to be proved the &lt;collection&gt; element may also be used. The single URL
+				provided in the &lt;resource&gt; is mandatory and serves as the single resolution
+				target for the DOI. Note: A timestamp value placed inside doi_data will override any
+				timestamp value placed in the &lt;head&gt; element. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="doi"/>
+				<xsd:element ref="timestamp" minOccurs="0"/>
+				<xsd:element ref="resource"/>
+				<xsd:element ref="collection" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="resource">
+		<xsd:annotation>
+			<xsd:documentation>The element that contains a URI associated with a DOI. URLs are
+				referred to as resources in the 2.0 CrossRef schema because they can be any valid
+				URI. Cases of single-resolution (i.e. one DOI with a single corresponding URI)
+				should be tagged with a doi/resource pair in doi_data. Only one resource is allowed
+				per doi_data, the exception being resource elements within a collection element.
+				Values for the "content_version" attribute are vor (version of record) and am
+				(advance manuscript). </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="resource_t">
+					<xsd:attributeGroup ref="mime_type.atts"/>
+					<xsd:attribute name="content_version">
+						<xsd:simpleType>
+							<xsd:restriction base="xsd:string">
+								<xsd:enumeration value="vor"/>
+								<xsd:enumeration value="am"/>
+							</xsd:restriction>
+						</xsd:simpleType>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:simpleType name="resource_t">
+		<xsd:restriction base="xsd:anyURI">
+			<xsd:maxLength value="2048"/>
+			<xsd:minLength value="1"/>
+			<xsd:pattern value="([hH][tT][tT][pP]|[hH][tT][tT][pP][sS]|[fF][tT][pP])://.*"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:element name="collection">
+		<xsd:annotation>
+			<xsd:documentation> A collection is a container for one or more items each holding a doi
+				or a resource (URI) which is related to the DOI in the ancestor &lt;doi_data&gt;
+				element. A collection must be qualified by a property attibute or the
+				multi-resolution attribute. property attributes: list-based: uses an interim page
+				and presents the list of items to the user (via Multiple Resolution) country-based:
+				proxy picks destination based on the country code of the user's location (this
+				option is not currently active, contact support@crossref.org for more info)
+				crawler-based: identifies resource to be crawled by the specified crawlers.
+				text-mining: identifies resource to be used for text and data mining unspecified:
+				identifies resource with unspecified usage syndication: identifies resource to be
+				used for syndication The multi-resolution attribute may be used to lock or unlock
+				DOIs for multiple resolution. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="item" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+			<xsd:attribute name="property" use="required">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:NMTOKEN">
+						<xsd:enumeration value="list-based"/>
+						<xsd:enumeration value="country-based"/>
+						<xsd:enumeration value="crawler-based"/>
+						<xsd:enumeration value="text-mining"/>
+						<xsd:enumeration value="unspecified"/>
+						<xsd:enumeration value="syndication"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="multi-resolution">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:NMTOKEN">
+						<xsd:enumeration value="lock"/>
+						<xsd:enumeration value="unlock"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="item">
+		<xsd:annotation>
+			<xsd:documentation>A container used to associate a collection, doi, or resource (URI)
+				with zero or more property elements. item is currently used for supplying as-crawled
+				URLs (http://help.crossref.org/#as-crawled-urls)</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:choice minOccurs="0">
+					<xsd:element ref="doi"/>
+					<xsd:element ref="resource"/>
+				</xsd:choice>
+			</xsd:sequence>
+			<xsd:attribute name="crawler" use="optional">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:NMTOKEN">
+						<xsd:enumeration value="altavista"/>
+						<xsd:enumeration value="google"/>
+						<xsd:enumeration value="msn"/>
+						<xsd:enumeration value="scirus"/>
+						<xsd:enumeration value="yahoo"/>
+						<xsd:enumeration value="iParadigms"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="label" use="optional">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:string">
+						<xsd:maxLength value="128"/>
+						<xsd:minLength value="3"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="country" use="optional">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:NMTOKEN">
+						<xsd:enumeration value="AX"/>
+						<xsd:enumeration value="AF"/>
+						<xsd:enumeration value="AL"/>
+						<xsd:enumeration value="DZ"/>
+						<xsd:enumeration value="AS"/>
+						<xsd:enumeration value="AD"/>
+						<xsd:enumeration value="AO"/>
+						<xsd:enumeration value="AI"/>
+						<xsd:enumeration value="AQ"/>
+						<xsd:enumeration value="AG"/>
+						<xsd:enumeration value="AR"/>
+						<xsd:enumeration value="AM"/>
+						<xsd:enumeration value="AW"/>
+						<xsd:enumeration value="AU"/>
+						<xsd:enumeration value="AT"/>
+						<xsd:enumeration value="AZ"/>
+						<xsd:enumeration value="BS"/>
+						<xsd:enumeration value="BH"/>
+						<xsd:enumeration value="BD"/>
+						<xsd:enumeration value="BB"/>
+						<xsd:enumeration value="BY"/>
+						<xsd:enumeration value="BE"/>
+						<xsd:enumeration value="BZ"/>
+						<xsd:enumeration value="BJ"/>
+						<xsd:enumeration value="BM"/>
+						<xsd:enumeration value="BT"/>
+						<xsd:enumeration value="BO"/>
+						<xsd:enumeration value="BA"/>
+						<xsd:enumeration value="BW"/>
+						<xsd:enumeration value="BV"/>
+						<xsd:enumeration value="BR"/>
+						<xsd:enumeration value="IO"/>
+						<xsd:enumeration value="BN"/>
+						<xsd:enumeration value="BG"/>
+						<xsd:enumeration value="BF"/>
+						<xsd:enumeration value="BI"/>
+						<xsd:enumeration value="KH"/>
+						<xsd:enumeration value="CM"/>
+						<xsd:enumeration value="CA"/>
+						<xsd:enumeration value="CV"/>
+						<xsd:enumeration value="KY"/>
+						<xsd:enumeration value="CF"/>
+						<xsd:enumeration value="TD"/>
+						<xsd:enumeration value="CL"/>
+						<xsd:enumeration value="CN"/>
+						<xsd:enumeration value="CX"/>
+						<xsd:enumeration value="CC"/>
+						<xsd:enumeration value="CO"/>
+						<xsd:enumeration value="KM"/>
+						<xsd:enumeration value="CD"/>
+						<xsd:enumeration value="CG"/>
+						<xsd:enumeration value="CK"/>
+						<xsd:enumeration value="CR"/>
+						<xsd:enumeration value="CI"/>
+						<xsd:enumeration value="HR"/>
+						<xsd:enumeration value="CU"/>
+						<xsd:enumeration value="CY"/>
+						<xsd:enumeration value="CZ"/>
+						<xsd:enumeration value="DK"/>
+						<xsd:enumeration value="DJ"/>
+						<xsd:enumeration value="DM"/>
+						<xsd:enumeration value="DO"/>
+						<xsd:enumeration value="EC"/>
+						<xsd:enumeration value="EG"/>
+						<xsd:enumeration value="SV"/>
+						<xsd:enumeration value="GQ"/>
+						<xsd:enumeration value="ER"/>
+						<xsd:enumeration value="EE"/>
+						<xsd:enumeration value="ET"/>
+						<xsd:enumeration value="FK"/>
+						<xsd:enumeration value="FO"/>
+						<xsd:enumeration value="FJ"/>
+						<xsd:enumeration value="FI"/>
+						<xsd:enumeration value="FR"/>
+						<xsd:enumeration value="GF"/>
+						<xsd:enumeration value="PF"/>
+						<xsd:enumeration value="TF"/>
+						<xsd:enumeration value="GA"/>
+						<xsd:enumeration value="GM"/>
+						<xsd:enumeration value="GE"/>
+						<xsd:enumeration value="DE"/>
+						<xsd:enumeration value="GH"/>
+						<xsd:enumeration value="GI"/>
+						<xsd:enumeration value="GR"/>
+						<xsd:enumeration value="GL"/>
+						<xsd:enumeration value="GD"/>
+						<xsd:enumeration value="GP"/>
+						<xsd:enumeration value="GU"/>
+						<xsd:enumeration value="GT"/>
+						<xsd:enumeration value="GN"/>
+						<xsd:enumeration value="GW"/>
+						<xsd:enumeration value="GY"/>
+						<xsd:enumeration value="HT"/>
+						<xsd:enumeration value="HM"/>
+						<xsd:enumeration value="HN"/>
+						<xsd:enumeration value="HK"/>
+						<xsd:enumeration value="HU"/>
+						<xsd:enumeration value="IS"/>
+						<xsd:enumeration value="IN"/>
+						<xsd:enumeration value="ID"/>
+						<xsd:enumeration value="IR"/>
+						<xsd:enumeration value="IQ"/>
+						<xsd:enumeration value="IE"/>
+						<xsd:enumeration value="IL"/>
+						<xsd:enumeration value="IT"/>
+						<xsd:enumeration value="JM"/>
+						<xsd:enumeration value="JP"/>
+						<xsd:enumeration value="JO"/>
+						<xsd:enumeration value="KZ"/>
+						<xsd:enumeration value="KE"/>
+						<xsd:enumeration value="KI"/>
+						<xsd:enumeration value="KP"/>
+						<xsd:enumeration value="KR"/>
+						<xsd:enumeration value="KW"/>
+						<xsd:enumeration value="KG"/>
+						<xsd:enumeration value="LA"/>
+						<xsd:enumeration value="LV"/>
+						<xsd:enumeration value="LB"/>
+						<xsd:enumeration value="LS"/>
+						<xsd:enumeration value="LR"/>
+						<xsd:enumeration value="LY"/>
+						<xsd:enumeration value="LI"/>
+						<xsd:enumeration value="LT"/>
+						<xsd:enumeration value="LU"/>
+						<xsd:enumeration value="MO"/>
+						<xsd:enumeration value="MK"/>
+						<xsd:enumeration value="MG"/>
+						<xsd:enumeration value="MW"/>
+						<xsd:enumeration value="MY"/>
+						<xsd:enumeration value="MV"/>
+						<xsd:enumeration value="ML"/>
+						<xsd:enumeration value="MT"/>
+						<xsd:enumeration value="MH"/>
+						<xsd:enumeration value="MQ"/>
+						<xsd:enumeration value="MR"/>
+						<xsd:enumeration value="MU"/>
+						<xsd:enumeration value="YT"/>
+						<xsd:enumeration value="MX"/>
+						<xsd:enumeration value="FM"/>
+						<xsd:enumeration value="MD"/>
+						<xsd:enumeration value="MC"/>
+						<xsd:enumeration value="MN"/>
+						<xsd:enumeration value="MS"/>
+						<xsd:enumeration value="MA"/>
+						<xsd:enumeration value="MZ"/>
+						<xsd:enumeration value="MM"/>
+						<xsd:enumeration value="NA"/>
+						<xsd:enumeration value="NR"/>
+						<xsd:enumeration value="NP"/>
+						<xsd:enumeration value="NL"/>
+						<xsd:enumeration value="AN"/>
+						<xsd:enumeration value="NC"/>
+						<xsd:enumeration value="NZ"/>
+						<xsd:enumeration value="NI"/>
+						<xsd:enumeration value="NE"/>
+						<xsd:enumeration value="NG"/>
+						<xsd:enumeration value="NU"/>
+						<xsd:enumeration value="NF"/>
+						<xsd:enumeration value="MP"/>
+						<xsd:enumeration value="NO"/>
+						<xsd:enumeration value="OM"/>
+						<xsd:enumeration value="PK"/>
+						<xsd:enumeration value="PW"/>
+						<xsd:enumeration value="PS"/>
+						<xsd:enumeration value="PA"/>
+						<xsd:enumeration value="PG"/>
+						<xsd:enumeration value="PY"/>
+						<xsd:enumeration value="PE"/>
+						<xsd:enumeration value="PH"/>
+						<xsd:enumeration value="PN"/>
+						<xsd:enumeration value="PL"/>
+						<xsd:enumeration value="PT"/>
+						<xsd:enumeration value="PR"/>
+						<xsd:enumeration value="QA"/>
+						<xsd:enumeration value="RE"/>
+						<xsd:enumeration value="RO"/>
+						<xsd:enumeration value="RU"/>
+						<xsd:enumeration value="RW"/>
+						<xsd:enumeration value="SH"/>
+						<xsd:enumeration value="KN"/>
+						<xsd:enumeration value="LC"/>
+						<xsd:enumeration value="PM"/>
+						<xsd:enumeration value="VC"/>
+						<xsd:enumeration value="WS"/>
+						<xsd:enumeration value="SM"/>
+						<xsd:enumeration value="ST"/>
+						<xsd:enumeration value="SA"/>
+						<xsd:enumeration value="SN"/>
+						<xsd:enumeration value="CS"/>
+						<xsd:enumeration value="SC"/>
+						<xsd:enumeration value="SL"/>
+						<xsd:enumeration value="SG"/>
+						<xsd:enumeration value="SK"/>
+						<xsd:enumeration value="SI"/>
+						<xsd:enumeration value="SB"/>
+						<xsd:enumeration value="SO"/>
+						<xsd:enumeration value="ZA"/>
+						<xsd:enumeration value="GS"/>
+						<xsd:enumeration value="ES"/>
+						<xsd:enumeration value="LK"/>
+						<xsd:enumeration value="SD"/>
+						<xsd:enumeration value="SR"/>
+						<xsd:enumeration value="SJ"/>
+						<xsd:enumeration value="SZ"/>
+						<xsd:enumeration value="SE"/>
+						<xsd:enumeration value="CH"/>
+						<xsd:enumeration value="SY"/>
+						<xsd:enumeration value="TW"/>
+						<xsd:enumeration value="TJ"/>
+						<xsd:enumeration value="TZ"/>
+						<xsd:enumeration value="TH"/>
+						<xsd:enumeration value="TL"/>
+						<xsd:enumeration value="TG"/>
+						<xsd:enumeration value="TK"/>
+						<xsd:enumeration value="TO"/>
+						<xsd:enumeration value="TT"/>
+						<xsd:enumeration value="TN"/>
+						<xsd:enumeration value="TR"/>
+						<xsd:enumeration value="TM"/>
+						<xsd:enumeration value="TC"/>
+						<xsd:enumeration value="TV"/>
+						<xsd:enumeration value="UG"/>
+						<xsd:enumeration value="UA"/>
+						<xsd:enumeration value="AE"/>
+						<xsd:enumeration value="GB"/>
+						<xsd:enumeration value="US"/>
+						<xsd:enumeration value="UM"/>
+						<xsd:enumeration value="UY"/>
+						<xsd:enumeration value="UZ"/>
+						<xsd:enumeration value="VU"/>
+						<xsd:enumeration value="VA"/>
+						<xsd:enumeration value="VE"/>
+						<xsd:enumeration value="VN"/>
+						<xsd:enumeration value="VG"/>
+						<xsd:enumeration value="VI"/>
+						<xsd:enumeration value="WF"/>
+						<xsd:enumeration value="EH"/>
+						<xsd:enumeration value="YE"/>
+						<xsd:enumeration value="ZM"/>
+						<xsd:enumeration value="ZW"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:simpleType name="property_t">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="2048"/>
+			<xsd:minLength value="0"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="property">
+		<xsd:annotation>
+			<xsd:documentation>property elements qualify the semantic meaning of a item or
+				collection. property elements consist of a type/value pair where the property type
+				is found in the type attribute and the value is found in the element content. The
+				property element is not currently in use. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="property_t">
+					<xsd:attribute name="type" type="xsd:string" use="required"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="contributors">
+		<xsd:annotation>
+			<xsd:documentation>The container for all who contributed to authoring or editing an
+				entity.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="organization"/>
+					<xsd:element ref="person_name"/>
+				</xsd:choice>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:simpleType name="organization_t">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="511"/>
+			<xsd:minLength value="1"/>
+			<xsd:whiteSpace value="collapse"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="organization">
+		<xsd:annotation>
+			<xsd:documentation>The name of an organization (as opposed to a person) that contributed
+				to authoring an entity. If multiple organizations authored an entity, each one
+				should be captured in a unique organization element. If an entity was authored by
+				individuals in addition to one or more organizations, person_name and organization
+				may be freely intermixed within contributors. contributor_role should be set, as
+				appropriate, to author or editor. When a contributor translated a work, set
+				contributor_role to "translator". "chair" should only be used for conference
+				proceedings to indicate a conference chair.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="organization_t">
+					<xsd:attributeGroup ref="contributor.atts"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="person_name">
+		<xsd:annotation>
+			<xsd:documentation>The name of a person (as opposed to an organization) that contributed
+				to authoring an entity. Authors with name suffixes should have the suffix captured
+				in suffix, not in surname. Author prefixes such as "Dr.", "Prof.", or "President"
+				should not be included in person_name or any other element. Author degrees (e.g.
+				M.D., Ph.D.) also should not be included in CrossRef submissions. contributor_role
+				should be set, as appropriate, to author or editor. When a contributor translated a
+				work, set contributor_role to "translator". "chair" should only be used for
+				conference proceedings to indicate a conference chair.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="given_name" minOccurs="0"/>
+				<xsd:element ref="surname"/>
+				<xsd:element ref="suffix" minOccurs="0"/>
+				<xsd:element ref="affiliation" minOccurs="0" maxOccurs="5"/>
+				<xsd:element ref="ORCID" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="alt-name" minOccurs="0"/>
+			</xsd:sequence>
+			<xsd:attributeGroup ref="contributor.atts"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="given_name">
+		<xsd:annotation>
+			<xsd:documentation>A contributor's given name. The given_name, combined with surname,
+				forms the name of an author or editor. given_name may be submitted as either
+				initials or a full name. Do not place given_name within the surname unless it is
+				unclear how to distinguish the given name from the surname, as may be the case in
+				non-Western names. Do not include titles such as "Dr.", "Prof.", or "President" in
+				given_name. These titles should not be submitted to CrossRef.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="35"/>
+				<xsd:minLength value="1"/>
+				<xsd:pattern value="[^\d\?]*"/>
+				<xsd:whiteSpace value="collapse"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="surname">
+		<xsd:annotation>
+			<xsd:documentation>The surname of an author or editor. The surname, combined with
+				given_name, forms the name of an author or editor. Whenever possible, the given name
+				should not be included in the surname element. In cases where the given name is not
+				clear, as may happen with non-Western names or some societies in which surnames are
+				not distinguished, you may place the entire name in surname, e.g.: <surname>Leonardo
+					da Vinci</surname> If an author is an organization, you should use organization,
+				not surname. Suffixes should be tagged with suffix. Author degrees (e.g. M.D.,
+				Ph.D.) should not be included in CrossRef submissions.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="45"/>
+				<xsd:minLength value="1"/>
+				<xsd:pattern value="[^\d\?]*[^\d\?\s]+[^\d\?]*"/>
+				<xsd:whiteSpace value="collapse"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="suffix">
+		<xsd:annotation>
+			<xsd:documentation>The suffix of an author name, e.g. junior or senior. A name suffix,
+				that typically denotes a generation distinction, is tagged with suffix. Author
+				degrees (e.g. M.D., Ph.D.) should not be included in CrossRef
+				submissions.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="10"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:simpleType name="orcid_t">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="https?://orcid.org/[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[X0-9]{1}"/>			
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:element name="ORCID">
+		<xsd:annotation>
+			<xsd:documentation>The ORCID for an author. The schema performs basic pattern validation, checksum validation is performed upon deposit via a system check.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="orcid_t">
+					<xsd:attribute default="false" name="authenticated" type="xsd:boolean"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="affiliation">
+		<xsd:annotation>
+			<xsd:documentation> The institution(s) with which a contributor is affiliated. This
+				element may hold the name and location of an affiliation with which a contributor is
+				affiliated. Please note the following points when using this element: 1. A
+				contributor may have up to five affiliations. Each affiliation should be in a unique
+				&lt;affiliation&gt; element. The following is correct: &lt;affiliation&gt;University
+				of New Mexico&lt;/affiliation&gt; &lt;affiliation&gt;Sandia National
+				Laboratories&lt;/affiliation&gt; The following is NOT correct
+				&lt;affiliation&gt;University of New Mexico; Sandia National
+				Laboratories&lt;/affiliation&gt; 2. The name of the institution is required in this
+				element. The location is optional. Both of the following are correct:
+				&lt;affiliation&gt;Harvard University&lt;/affiliation&gt; &lt;affiliation&gt;Harvard
+				University, Cambridge, MA&lt;/affiliation&gt; 3. Additional address information such
+				as a URL or email address should NOT be deposited in this element 4. Visual linking
+				indicators used in publication to connect authors with their affiliations such as
+				footnote symbols or initials should NOT be included in the &lt;affiliation&gt;
+				element 5. If you have only a single string that has the affiliation for multiple
+				contributors to a work and that string is not broken out into the individual
+				affliations for each author, please do NOT deposit the affilation information. This
+				element is to be used only for affiliation information that is directly connected to
+				the author with whom this information is included within the person_name element.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="512"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="alt-name">
+		<xsd:complexType>
+			<xsd:choice maxOccurs="unbounded">
+				<xsd:element ref="name"/>
+				<xsd:element ref="string-name"/>
+			</xsd:choice>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="name">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:choice>
+					<xsd:sequence>
+						<xsd:element ref="surname"/>
+						<xsd:element minOccurs="0" ref="given_name"/>
+					</xsd:sequence>
+					<xsd:element ref="given_name"/>
+				</xsd:choice>
+				<xsd:element minOccurs="0" ref="prefix"/>
+				<xsd:element minOccurs="0" ref="suffix"/>
+			</xsd:sequence>
+			<xsd:attribute name="content-type"/>
+			<xsd:attribute name="name-style" default="western">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:token">
+						<xsd:enumeration value="western"/>
+						<xsd:enumeration value="eastern"/>
+						<xsd:enumeration value="islensk"/>
+						<xsd:enumeration value="given-only"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="specific-use"/>
+			<!--using our language.atts attribute group instead of importing xml:lang-->
+			<xsd:attributeGroup ref="language.atts"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="string-name">
+		<xsd:complexType mixed="true">
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:element ref="degrees"/>
+				<xsd:element ref="given_name"/>
+				<xsd:element ref="prefix"/>
+				<xsd:element ref="surname"/>
+				<xsd:element ref="suffix"/>
+			</xsd:choice>
+			<xsd:attribute name="content-type"/>
+			<xsd:attribute name="name-style" default="western">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:token">
+						<xsd:enumeration value="western"/>
+						<xsd:enumeration value="eastern"/>
+						<xsd:enumeration value="islensk"/>
+						<xsd:enumeration value="given-only"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="specific-use"/>
+			<xsd:attributeGroup ref="language.atts"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="prefix">
+		<xsd:complexType mixed="true">
+			<xsd:attribute name="content-type"/>
+			<xsd:attribute name="specific-use"/>
+			<xsd:attributeGroup ref="language.atts"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="degrees">
+		<xsd:complexType mixed="true">
+			<xsd:attribute name="content-type"/>
+			<xsd:attribute name="specific-use"/>
+			<xsd:attributeGroup ref="language.atts"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<!--END NAME ELEMENTs-->
+
+
+
+	<xsd:element name="titles">
+		<xsd:annotation>
+			<xsd:documentation>A container for the title and original language title
+				elements.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:sequence>
+					<xsd:element ref="title"/>
+					<xsd:element ref="subtitle" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:sequence minOccurs="0">
+					<xsd:element ref="original_language_title"/>
+					<xsd:element ref="subtitle" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="title">
+		<xsd:annotation>
+			<xsd:documentation>The title of the entity being registered. When a title contains a
+				subtitle, it is preferable to capture the subtitle portion in the subtitle element.
+				Only minimal face markup is supported, see See http://help.crossref.org/#face_markup</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType mixed="true">
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:group ref="face_markup"/>
+			</xsd:choice>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="original_language_title">
+		<xsd:annotation>
+			<xsd:documentation>The title of an entity in its original language if the registration
+				is for a translation of a work. When providing the original language of a title, you
+				should set the language attribute.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType mixed="true">
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:group ref="face_markup"/>
+
+			</xsd:choice>
+			<xsd:attributeGroup ref="language.atts"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="subtitle">
+		<xsd:annotation>
+			<xsd:documentation>The sub-title portion of an entity title. When possible, it is better
+				to tag a title and subtitle with separate elements. If this information is not
+				available, it is acceptable to submit the title and subtitle all within the title
+				element with punctuation (preferably a colon) used to separate the subtitle from the
+				title. When a subtitle is tagged, the space and punctuation between the title and
+				subtitle text should not be included. The following examples illustrate correct and
+				incorrect tagging practices: Correct and optimal tagging: <title>The Human
+					Brain</title>
+				<subtitle>A Handbook</subtitle> Correct but not optimal tagging: <title>The Human
+					Brain: A Handbook</title> Incorrect: <title>The Human Brain: </title>
+				<subtitle>A Handbook</subtitle>
+				<title>The Human Brain</title>
+				<subtitle>: A Handbook</subtitle></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType mixed="true">
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:group ref="face_markup"/>
+
+			</xsd:choice>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="month" type="xrefMonth">
+		<xsd:annotation>
+			<xsd:documentation>Month of publication. The month must be expressed in numeric format
+				rather spelling out the name (e.g.. submit "10", not "October"). The month must be
+				expressed with a leading zero if it is less than 10 (e.g. submit "05", not "5").
+				When a journal issue has both an issue number and a season, the issue number should
+				be placed in issue. If the month of publication is not known, the season should be
+				placed in month as a two-digit value as follows: Season Value Spring 21 Summer 22
+				Autumn 23 Winter 24 First Quarter 31 Second Quarter 32 Third Quarter 33 Fourth
+				Quarter 34 In cases when an issue covers multiple months, e.g. "March-April",
+				include only the digits for the first month of the range.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="day" type="xrefDay">
+		<xsd:annotation>
+			<xsd:documentation>Day of publication. The should must be expressed with a leading zero
+				if it is less than 10 (e.g. submit "05", not "5").</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="year" type="xrefYear">
+		<xsd:annotation>
+			<xsd:documentation>Year of publication.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="publication_date">
+		<xsd:annotation>
+			<xsd:documentation>The date of publication. In all cases, multiple dates are allowed to
+				allow for different dates of publication for online and print versions. This element
+				was previously called date, but was renamed publication_date to distinguish more
+				clearly from conference_date.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="date_t"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="date_t">
+		<xsd:sequence>
+			<xsd:element ref="month" minOccurs="0"/>
+			<xsd:element ref="day" minOccurs="0"/>
+			<xsd:element ref="year"/>
+		</xsd:sequence>
+		<xsd:attribute name="media_type" default="print">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:NMTOKEN">
+					<xsd:enumeration value="online"/>
+					<xsd:enumeration value="print"/>
+					<xsd:enumeration value="other"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:complexType>
+	<xsd:element name="pages">
+		<xsd:annotation>
+			<xsd:documentation>The container for information about page ranges. When an entity has
+				non-contiguous page information, you should capture the first page range in
+				first_page and last_page. Any additional page information should be captured in
+				other_pages. Punctuation is only allowed in other_pages. It should not appear in
+				first_page and last_page. Page number letter prefixes or suffixes should be
+				included. Roman numeral pages are permitted in both upper case and lower case. Data
+				may be alpha, numeric or a combination.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="first_page"/>
+				<xsd:element ref="last_page" minOccurs="0"/>
+				<xsd:element ref="other_pages" minOccurs="0"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="first_page">
+		<xsd:annotation>
+			<xsd:documentation>First page number where an entity is located. Data may be alpha,
+				numeric or a combination.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="32"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="last_page">
+		<xsd:annotation>
+			<xsd:documentation>The last page number of an entity. last_page should not be used when
+				the last page number is the same as the first page number (i.e. when the entire
+				entity fits on one page). Do not include punctuation for a page range in last_page.
+				If the entity has non-contiguous paging, use last_page for the last page of the
+				first range and place all other page information into other_pages. Data may be
+				alpha, numeric or a combination.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="32"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="other_pages">
+		<xsd:annotation>
+			<xsd:documentation>Used to capture additional page information when items do not
+				encompass contiguous page ranges. When an entity has non-contiguous page
+				information, you should capture the first page range in first_page and last_page.
+				Any additional page information should be captured in other_pages. You should
+				include commas or hyphens to express discrete pages or page ranges. endash entities
+				should be converted to ASCII hyphens. Spaces should not be included. Note that
+				punctuation should never appear in first_page and last_page. Data may be alpha,
+				numeric or a combination.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="100"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:simpleType name="doi_t">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="2048"/>
+			<xsd:minLength value="6"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="doi">
+            <xsd:annotation>
+			<xsd:documentation>DOI for an entity being registered with CrossRef.  In 2008 CrossRef restricted DOI suffix 
+				characters to the following: "a-z", "A-Z", "0-9" and "-._;()/" 
+				
+				Existing DOIs with suffix characters outside of the allowed set are still supported.  For additional
+				information on DOI syntax, see http://help.crossref.org/#ID5755</xsd:documentation>
+            </xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="doi_t"/>
+		</xsd:simpleType>
+	</xsd:element>
+
+	<!--additions for CrossMark -->
+	<xsd:simpleType name="cm_domain">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="1024"/>
+			<xsd:minLength value="4"/>
+			<xsd:pattern
+				value="[A-Za-z0-9_]+([-.][A-Za-z0-9_]+)*\.[A-Za-z0-9_]+([-.][A-Za-z0-9_]+)*"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="cm_update_type">
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="addendum"/>
+			<xsd:enumeration value="clarification"/>
+			<xsd:enumeration value="correction"/>
+			<xsd:enumeration value="corrigendum"/>
+			<xsd:enumeration value="erratum"/>
+			<xsd:enumeration value="expression_of_concern"/>
+			<xsd:enumeration value="new_edition"/>
+			<xsd:enumeration value="new_version"/>
+			<xsd:enumeration value="partial_retraction"/>
+			<xsd:enumeration value="removal"/>
+			<xsd:enumeration value="retraction"/>
+			<xsd:enumeration value="withdrawal"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="cm_assertion">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="1024"/>
+			<xsd:minLength value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="cm_assertion_name">
+		<xsd:restriction base="xsd:NCName">
+			<xsd:maxLength value="150"/>
+			<xsd:minLength value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="cm_assertion_label">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="150"/>
+			<xsd:minLength value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="cm_assertion_group_name">
+		<xsd:restriction base="xsd:NCName">
+			<xsd:maxLength value="150"/>
+			<xsd:minLength value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="cm_assertion_group_label">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="150"/>
+			<xsd:minLength value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="isbn_t">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="17"/>
+			<xsd:minLength value="10"/>
+			<xsd:pattern value="(978-)?\d[\d \-]+[\dX]"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="isbn">
+		<xsd:annotation>
+			<xsd:documentation>The ISBN assigned to an entity. If a multi-volume work has one ISBN
+				per volume and a unique ISBN for the series, all may be registered. The ISBN for the
+				series must be in series_metadata, and the ISBN for each volume in
+				proceedings_metadata, or book_metadata, respectively. The text "ISBN" should not be
+				included in the ISBN element in CrossRef submissions. Although not required, the
+				ISBN number should retain spaces or hyphens that appear in the formatted number
+				because they aid in human-readability. For more information, please see
+				http://www.isbn.org/standards/home/isbn/international/hyphenation- instructions.asp
+				or http://www.isbn.org.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="isbn_t">
+					<xsd:attributeGroup ref="media_type.atts"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="noisbn">
+		<xsd:annotation>
+			<xsd:documentation>Identifies books or conference proceedings that have no ISBN
+				assigned. In very limited cases a book may never have an ISBN, this is particularly
+				true for older texts. Conference proceedings, however, may regularly have a volume
+				number but no ISBN or volume title. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="reason" use="required">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:NMTOKEN">
+						<xsd:enumeration value="archive_volume"/>
+						<xsd:enumeration value="monograph"/>
+						<xsd:enumeration value="simple_series"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:simpleType name="issn_t">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="9"/>
+			<xsd:minLength value="8"/>
+			<xsd:pattern value="\d{4}-?\d{3}[\dX]"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="issn">
+		<xsd:annotation>
+			<xsd:documentation>The ISSN assigned to an entity. The ISSN must consist of eight digits
+				(where the last digit may be an X), or it must consist of eight digits in two groups
+				of four with a hyphen between the two groups. Spaces or other delimiters should not
+				be included in an ISSN. For more information, please see
+				http://www.issn.org:8080/English/pub/getting- checking/checking or
+				http://www.issn.org. The text "ISSN" should not be included in the issn element in
+				CrossRef submissions. CrossRef validates all ISSNs supplied in deposits, only valid
+				ISSNs will be accepted.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="issn_t">
+					<xsd:attributeGroup ref="media_type.atts"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="coden">
+		<xsd:annotation>
+			<xsd:documentation>The coden assigned to a journal or conference
+				proceedings.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="6"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="volume">
+		<xsd:annotation>
+			<xsd:documentation>The volume number of a published journal, or the number of a printed
+				volume for a book or conference proceedings. A journal volume is contained in the
+				journal_volume element to allow for the assignment of a DOI to an entire journal
+				volume. Do not include the words "Volume" or "vol." in this element. Data may be
+				alpha, numeric or a combination. Roman numerals are acceptable. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="32"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+
+
+	<!--archiving elements-->
+	<xsd:element name="archive_locations">
+		<xsd:annotation>
+			<xsd:documentation>Container element for archive. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element maxOccurs="unbounded" minOccurs="0" ref="archive"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="archive">
+		<xsd:annotation>
+			<xsd:documentation>Used to indicate the designated archiving organization(s) for an
+				item. Values for the name attribute are CLOCKSS, LOCKSS Portico, KB, DWT (Deep Web
+				Technologies), Internet Archive,WebCite</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="name" use="required">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:string">
+						<xsd:enumeration value="CLOCKSS"/>
+						<xsd:enumeration value="LOCKSS"/>
+						<xsd:enumeration value="Portico"/>
+						<xsd:enumeration value="KB"/>
+						<xsd:enumeration value="Internet Archive"/>
+						<xsd:enumeration value="DWT"/>
+                                                <xsd:enumeration value="WebCite"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="approval_date">
+		<xsd:annotation>
+			<xsd:documentation> The date on which a dissertation was accepted by the institution
+				awarding the degree, a report was approved, or a standard was accepted.
+				approval_date includes the same elements as publication_date, but it has no
+				attributes. It is a distinct element from publication_date to reflect that an
+				important but different semantic meeting from publication_date </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="date_t"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<!-- =============================================================
+
+           7. Elements used for citation deposit and XML queries
+
+     ============================================================= -->
+	<xsd:element name="citation_list">
+		<xsd:annotation>
+			<xsd:documentation>A list of articles, books, and other items cited by the parent item
+				for which the DOI in the doi_data is being deposited. Some articles may have
+				multiple lists of citations (e.g. main reference list, appendix reference list,
+				etc.). All citations for one article should be included in a single citation_list
+				regardless of whether one or more citation lists were in the original item. When
+				combining multiple reference lists from an item into one citation_list element, but
+				sure to give each citation a unique key attribute value. For example, if an appendix
+				in an item has a separate citation list that restarts numbering at 1, these
+				citations should be given key attributes such as "ab1" rather than "b1". Some
+				articles may contain "Further Reading" or "Bibliography" lists. The distinguishing
+				factor in these lists is that the references have not been cited from the
+				article—they only provide a list of additional related reading material. It will be
+				left to the discretion of the publisher if these items are to be considered
+				citations and should be deposited. NOTE: If a citation_list element is given and is
+				empty then all citations for the given DOI will be deleted, otherwise any existing
+				citations for the given DOI are left intact in the database. It is quite common that
+				a publisher wants to fix the DOI's metadata without resubmitting the citations.
+				Leaving out the citation_list element will do that. Also note that any given
+				citations will override older citations for the given DOI so citation_lists are not
+				cumulative over multiple records or submissions. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="citation" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<!--
+    citation is used to deposit each citation in the reference list of the
+    item for which the DOI is being deposited. The citations in the list will
+    be run by the CrossRef system as queries looking for the DOI of the
+    articles being cited.
+
+    NOTE: Because the citation list is used to support forward linking, the
+    more information supplied in the citation the better the chance of
+    finding a match.
+
+    For each citation that is deposited, one of four models should be used:
+    1. Parsed journal data
+    2. Parsed book or conference data
+    3. DOI
+    4. Unstructured citation (not yet supported for resolution)
+
+    When parsed journal, book or conference data is deposited, CrossRef will
+    perform a lookup to find the DOI.
+
+    Each citation must be given a unique ID in the key attribute. It is
+    recommended that this number be the citation number if the reference list
+    is numbered in the published article, or the underlying XML ID if the
+    reference list is name/date style in article.
+
+    When submitting a journal citation, it should include an issn, journal_title
+    or both. journal_title only is preferred over issn only. In addition the
+    first author and first_page number should be submitted. The first_page number
+    is preferred, but for those citations that are "in press", the author should
+    be submitted. All elements are optional, however for best linking results, as
+    much information as is known should be submitted.
+
+    When submitting a book or conference citation, it should include an isbn,
+    series_title, volume_title, or any combination of these three elements as may
+    be available. All elements are optional, however for best linking results, as
+    much information as is known should be submitted.
+
+    When a DOI is already known for a citation, you may submit just the doi without
+    additional information.
+
+    When parsed information is not available for a citation, or the citation is of
+    a type other than journal, book, or conference proceeding that is supported by
+    CrossRef (e.g. standard, patent, thesis, newspaper, personal communication, etc.),
+    it may be submitted using the unstructured_citation element. CrossRef does not
+    yet resolve these citations, but will hold the data for possible resolution in
+    the future. When submitting unstructured citations, it is helpful, but not required
+    to include all available face markup (e.g. bold, italic, etc) as this will make
+    possible future parsing of the unstructured citation more accurate. In such cases,
+    it is preferred, but not required, if the citation number (when Vancouver style is
+    used) be removed from the unparsed citation. This number can be submitted using the
+    key attribute
+
+    Only the first author of a citation should be submitted, not the entire author list.
+    Only the surname is required. Initials may be included, but are not recommended
+    because the best linking results can be provided if initials are omitted. Author
+    titles, roles and generation information should not be included. If the first author
+    is an organization, the organization name should be submitted in the author element.
+
+    cYear has a loose text model that can accommodate non-standard years such as year
+    ranges such as "1998-1999". Note that years such as "1998a" or "1999b" should be deposited
+    without the letter, e.g. "1998" or "1999", whenever possible.
+
+    Citations that are "in press" should be submitted with as much information as is available.
+ -->
+	<xsd:complexType name="citation_t">
+		<xsd:all>
+			<xsd:element ref="issn" minOccurs="0"/>
+			<xsd:element ref="journal_title" minOccurs="0"/>
+			<xsd:element ref="author" minOccurs="0"/>
+			<xsd:element ref="volume" minOccurs="0"/>
+			<xsd:element ref="issue" minOccurs="0"/>
+			<xsd:element ref="first_page" minOccurs="0"/>
+			<xsd:element ref="cYear" minOccurs="0"/>
+			<xsd:element ref="doi" minOccurs="0"/>
+			<!-- book/conf.    specific elements -->
+			<xsd:element ref="isbn" minOccurs="0"/>
+			<xsd:element ref="series_title" minOccurs="0"/>
+			<xsd:element ref="volume_title" minOccurs="0"/>
+			<xsd:element ref="edition_number" minOccurs="0"/>
+			<xsd:element ref="component_number" minOccurs="0"/>
+			<!--  end of book/conf. specific elements-->
+			<xsd:element ref="article_title" minOccurs="0"/>
+			<!--standard-specific elements-->
+			<xsd:element ref="standard_designator" minOccurs="0"/>
+			<xsd:element ref="standards_body" minOccurs="0" maxOccurs="1"/>
+			<!-- Citation text as it appears in    the    article    , future placeholder -->
+			<xsd:element ref="unstructured_citation" minOccurs="0"/>
+		</xsd:all>
+	</xsd:complexType>
+	<!--
+    The citation element is used to deposit each citation in a citation list
+    -->
+	<xsd:element name="citation">
+		<xsd:annotation>
+			<xsd:documentation>citation is used to deposit each citation in the reference list of
+				the item for which the DOI is being deposited. The citations in the list will be run
+				by the CrossRef system as queries looking for the DOI of the articles being cited.
+				NOTE: Because the citation list is used to support forward linking, the more
+				information supplied in the citation the better the chance of finding a match. For
+				each citation that is deposited, one of four models should be used: 1. Parsed
+				journal data 2. Parsed book or conference data 3. DOI 4. Unstructured citation (not
+				yet supported for resolution) When parsed journal, book or conference data is
+				deposited, CrossRef will perform a lookup to find the DOI. Each citation must be
+				given a unique ID in the key attribute. It is recommended that this number be the
+				citation number if the reference list is numbered in the published article, or the
+				underlying XML ID if the reference list is name/date style in article. When
+				submitting a journal citation, it should include an issn, journal_title or both.
+				journal_title only is preferred over issn only. In addition the first author and
+				first_page number should be submitted. The first_page number is preferred, but for
+				those citations that are "in press", the author should be submitted. All elements
+				are optional, however for best linking results, as much information as is known
+				should be submitted. When submitting a book or conference citation, it should
+				include an isbn, series_title, volume_title, or any combination of these three
+				elements as may be available. All elements are optional, however for best linking
+				results, as much information as is known should be submitted. When a DOI is already
+				known for a citation, you may submit just the doi without additional information.
+				When parsed information is not available for a citation, or the citation is of a
+				type other than journal, book, or conference proceeding that is supported by
+				CrossRef (e.g. standard, patent, thesis, newspaper, personal communication, etc.),
+				it may be submitted using the unstructured_citation element. CrossRef is able to
+				process some unstructured citations. When submitting unstructured citations, it is
+				helpful, but not required to include all available face markup (e.g. bold, italic,
+				etc) as this will make possible future parsing of the unstructured citation more
+				accurate. In such cases, it is preferred, but not required, if the citation number
+				(when Vancouver style is used) be removed from the unparsed citation. This number
+				can be submitted using the key attribute Only the first author of a citation should
+				be submitted, not the entire author list. Only the surname is required. Initials may
+				be included, but are not recommended because the best linking results can be
+				provided if initials are omitted. Author titles, roles and generation information
+				should not be included. If the first author is an organization, the organization
+				name should be submitted in the author element. cYear has a loose text model that
+				can accommodate non-standard years such as year ranges such as "1998-1999". Note
+				that years such as "1998a" or "1999b" should be deposited without the letter, e.g.
+				"1998" or "1999", whenever possible. Citations that are "in press" should be
+				submitted with as much information as is available.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="citation_t">
+					<xsd:attributeGroup ref="citation_key.atts"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<!-- =============================================================
+
+           Attributes used for citation deposit and XML queries
+
+     ============================================================= -->
+
+	<xsd:attributeGroup name="citation_key.atts">
+		<xsd:annotation>
+			<xsd:documentation>citation_key allows the publisher to assign a unique ID to each
+				citation that is deposited. It is recommended that this attribute be given the
+				reference number if the publication uses reference numbers. For those publications
+				that use name/date style citations, it is recommended that this attribute be used to
+				indicate the sequential number of the citation in the reference list. However, some
+				schema must be utilized as this is a required attribute. The system will use this
+				key value to track the specific reference query and will return this value along
+				with the DOI.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="key" use="required">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:minLength value="1"/>
+                                        <xsd:maxLength value="128"/>
+					<xsd:whiteSpace value="collapse" />
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<!-- =============================================================
+
+           Sub-elements use for citation deposit and XML queries
+
+     ============================================================= -->
+	<xsd:element name="unstructured_citation">
+		<xsd:annotation>
+			<xsd:documentation>A citation that is to an item other than a journal article, book, or
+				conference paper and cannot be structured with the CrossRef citation model. Also, it
+				is used for a citation to a journal article, book, or conference paper for which the
+				depositing publisher does not have structured information. unstructured_citation
+				allows a publisher to deposit references for which no structural information is
+				available. These may be journal, book, or conference references for which the
+				supplier did not provide markup, or other types of references (e.g. standards,
+				patents, etc) which are not supported by CrossRef. This structure permits publishers
+				to deposit complete reference lists, without regard to the availability of markup,
+				or the need to parse references beyond those types that CrossRef supports.
+				CrossRef's ability to process unstructured citations is limited, for details see
+				http://help.crossref.org/#ID38855</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType mixed="true">
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:group ref="face_markup"/>
+			</xsd:choice>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="journal_title" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>Journal title in a citation. Only used in the citation element.
+				Journal title in citation deposits is used for both abbreviated and spelled out
+				journal names. No attribute is required to distinguish between name types. Both
+					<journal_title>Proc. Natl. Acad. Sci. U.S.A.</journal_title> and
+					<journal_title>Proceedings of the National Academy of Sciences of the United
+					States of America</journal_title> are valid journal titles to use in this
+				element.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="series_title" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>Book series title in a citation. Only used in the citation element.
+				series_title is an element for the deposit of book or conference series titles in
+				citations without the hierarchy required by the series_metadata element. Note that
+				face markup is not permitted when this element is deposited as part of a
+				citation.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="volume_title" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>Book volume title in a citation. Only used in the citation element.
+				volume_title is an element for the deposit of book or conference volume titles in
+				citations without the hierarchy required by the titles element. Note that face
+				markup is not permitted when this element is deposited as part of a
+				citation.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="author" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>First author in a citation. Only used in the citation element. The
+				author element tags one author name in a citation without the hierarchy required by
+				the contributors or person_name elements Only the first author should be deposited
+				for each item. The author surname is required. Author initials may be added but are
+				not recommended because queries work best when only the last name is provided. For
+				example, the author "John Doe" can be deposited as <author>Doe</author> or
+					<author>Doe J</author>, but the former style is recommended. If the author of a
+				work is an organization rather than a person, the organization may be deposited as
+				in: <author>World Health Organization</author></xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="cYear" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>Year of publication in citation. Unlike the year element, cYear has a
+				loose text model that can accommodate non-standard years such as year ranges such as
+				"1998-1999". Note that years such as "1998a" or "1999b" should be deposited without
+				the letter, e.g. "1998" or "1999". The letter is used for internal source document
+				linking in name/date (Harvard) style documents rather than external cross reference
+				linking to the original item.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="article_title" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>Article title in a citation. Use care to remove face markup (such as
+				italic applied to genus or species names) from article titles as this markup is not
+				supported by CrossRef.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<!-- =============================================================
+
+           8. Elements used to deposit components
+
+     ============================================================= -->
+
+	<xsd:element name="sa_component">
+		<xsd:annotation>
+			<xsd:documentation>The element for depositing a stand alone component. The parent DOI
+				must already exist (created in an earlier deposit or via some other registration
+				process).</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="component_list"/>
+			</xsd:sequence>
+			<xsd:attribute name="parent_doi" use="required">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:string">
+						<xsd:maxLength value="2048"/>
+						<xsd:minLength value="6"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="component_list">
+		<xsd:annotation>
+			<xsd:documentation>The wrapper element for including a group of components under a
+				journal article, conference proceeding, book chapter, stand alone component,
+				dissertation, technical report or working paper, standard, or
+				database.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="component" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="component">
+		<xsd:annotation>
+			<xsd:documentation>A container element that allows registration of supplemental
+				information for a journal article, book chapter, or conference paper such as
+				figures, tables, videos, or data sets. Currently, the deposit of components
+				primarily achieves only the first objective as the CrossRef system is not setup yet
+				to support queries for components. The metadata associated with a component is
+				intended to enable simple lookup searches of components in the future. When
+				deposited as part of the metadata for a higher level work the parent DOI is
+				implicitly known via the XML hierarchy. When deposited separately the DOI of the
+				higher level work must be provided explicitly (see sa_component) All descriptive
+				elements are optional allowing for the creation of simple anonymous DOIs. The
+				'parent_relation' attribute is mandatory and refers to the DOI described in the
+				component's direct parent.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="titles" minOccurs="0"/>
+				<xsd:element ref="contributors" minOccurs="0"/>
+				<xsd:element ref="publication_date" minOccurs="0"/>
+				<xsd:element ref="description" minOccurs="0"/>
+				<xsd:element ref="format" minOccurs="0"/>
+				<xsd:element ref="ai:program" minOccurs="0"/>
+				<xsd:choice>
+					<xsd:element ref="doi_data"/>
+					<xsd:element ref="doi"/>
+				</xsd:choice>
+
+			</xsd:sequence>
+			<xsd:attribute name="parent_relation" use="required">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:NMTOKEN">
+						<xsd:enumeration value="isPartOf"/>
+						<xsd:enumeration value="isReferencedBy"/>
+						<xsd:enumeration value="isRequiredBy"/>
+						<xsd:enumeration value="isTranslationOf"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="reg-agency" use="optional">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:string"/>
+
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attributeGroup ref="language.atts"/>
+			<xsd:attribute name="component_size">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:nonNegativeInteger"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="unassigned_content">
+		<xsd:annotation>
+			<xsd:documentation>Normally book content that is published as a series is required to
+				have a series title with an ISSN and a book title and/or a book volume number along
+				with a book ISBN. An exception is when book chapters are published on line first
+				prior to being assigned to a specific book in which case only the series title (and
+				ISSN) is known at time of DOI registration. Element unassigned_content is used as a
+				placeholder to force recognition of this condition and thus prevent accidental
+				omission of book level title information. When unassigned_content is present the
+				system will allow omission of the ISBN. If unassigned_content is not present the
+				system will require an ISBN for the book title.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="type" use="required">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:NMTOKEN">
+						<xsd:enumeration value="aheadOfPrint"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="description">
+		<xsd:annotation>
+			<xsd:documentation>A narrative description of a file (e.g. a figure caption or
+				video description) which may be independent of the host document context. The
+				description element may be present more than once to provide alternative language
+				values.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType mixed="true">
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:group ref="face_markup"/>
+			</xsd:choice>
+			<xsd:attributeGroup ref="language.atts"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:simpleType name="format_t">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="130"/>
+			<xsd:minLength value="0"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="format">
+		<xsd:annotation>
+			<xsd:documentation>A narrative description of a component's file format and/or the file
+				extension (for mime types refer to http://www.iana.org/assignments/media-types/) The
+				format element may contain only the mime_type attribute, or in addition it may
+				contain a narrative description of the file format. Be sure to use the narrative
+				portion to description only the format of the component and not the actual content
+				of the component (use description to describe the component's
+				content).</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="format_t">
+					<xsd:attributeGroup ref="mime_type.atts"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<!-- =============================================================
+		
+		9. CrossMark Elements
+		
+		============================================================= -->
+	<xsd:element name="crossmark">
+		<xsd:annotation>
+			<xsd:documentation>Container element for CrossMark data.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence minOccurs="0">
+				<xsd:element ref="crossmark_version" minOccurs="0"/>
+				<xsd:element ref="crossmark_policy"/>
+				<xsd:element ref="crossmark_domains" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="crossmark_domain_exclusive" minOccurs="0">
+					<xsd:annotation>
+						<xsd:documentation>Required element. Some publishers encourage broad third
+							party hosting of the publisher's content. Other publishers do not. And
+							still others vary their policy depending on whether a particular article
+							has been published under an OA policy or not. This boolean flag allows
+							the publisher to indicate whether the CrossMarked content will only
+							legitimately be updated on the CrossMark domain (true) or whether the
+							publisher encourages updating the content on other sites as well
+							(false).</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:sequence minOccurs="0">
+					<xsd:element ref="updates" minOccurs="0"/>
+					<xsd:element ref="custom_metadata" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="crossmark_policy" type="doi_t">
+		<xsd:annotation>
+			<xsd:documentation>A DOI which points to a publisher's CrossMark policy document.
+				Publishers might have different policies for different
+				publications.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="crossmark_version" type="xsd:string"/>
+	<xsd:element name="crossmark_domains">
+		<xsd:annotation>
+			<xsd:documentation>Container element for crossmark_domain. A list of domains where the
+				publisher maintains updates and corrections to their content. Minimally, one of
+				these should include the Internet domain name of the publisher's web site(s), but
+				the publisher might also decide to include 3rd party aggregators (e.g. Ebsco,
+				IngentaConnect) or archives with which the publisher has agreements to update the
+				content </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element maxOccurs="unbounded" ref="crossmark_domain"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="crossmark_domain">
+		<xsd:annotation>
+			<xsd:documentation>This should be a simple Internet domain name or subdomain name (e.g.
+				www.psychoceramics.org or psychoceramics.org). It is used to identify when a
+				referring URL is coming from a CrossMark domain. A "crossmark_domain" is made up of
+				two subelements; a "domain" and a "filter". The domain is required but the filter is
+				optional and is only needed for use in situations where content from multiple
+				publishers/publications is on the same host with the same domain name (e.g. an
+				aggregator) and one needs to use the referrer's URI "path" to further determine
+				whether the content in a crossmark domain.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="domain"/>
+				<xsd:element minOccurs="0" ref="filter"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="domain" type="cm_domain">
+		<xsd:annotation>
+			<xsd:documentation>Required element. This should be a simple Internet domain name or
+				subdomain name (e.g. www.psychoceramics.org or psychoceramics.org). It is used to
+				identify when a referring URL is coming from a CrossMark domain.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="filter" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>Optional element. The filter element is used to disambiguate content
+				in situations where multiple publishers share the same host (e.g. when on an
+				aggregated platform). It should contain a substring of the path that can be used to
+				uniquely identify a publisher's or publication's content. For instance, using the
+				string "alpsp" here would help the CrossMark system distinguish between ALPSP
+				publications on the ingentaconnect host and other publications on the same
+				host.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="crossmark_domain_exclusive" type="xsd:boolean"/>
+	<xsd:element name="updates">
+		<xsd:annotation>
+			<xsd:documentation>Optional element. A document might provide updates (e.g. corrections,
+				clarifications, retractions) to several other documents. When this is the case, the
+				DOIs of the documents that are being *updated* should be listed
+				here.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element maxOccurs="unbounded" ref="update"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="update">
+		<xsd:annotation>
+			<xsd:documentation>The DOI of the content being updated (e.g. corrected, retracted,
+				etc.) In the CrossMark Terms and Conditions "updates" are defined as changes that
+				are likely to "change the reader’s interpretation or crediting of the work." That
+				is, *editorially significant* changes. "Updates" should not include minor changes to
+				spelling, punctuation, formatting, etc. Attributes: label: Required attribute. This
+				should be a human-readable version of the "type" attribute. This is what gets
+				displayed in the CrossMark dialog when there is an update. type: Required attribute.
+				This attribute should be used to give the machine-readable name of the update type.
+				The human-readable version of the type should be but in the "label" attribute. There
+				are many "types" of updates. "Corrections, "clarifications", "retractions" and
+				"withdrawals" are just a few of the better-known types. For these common types we
+				recommend you use the values "correction", "clarification", "retraction" and
+				"withdrawal" respectively as per your editorial policy. However, different
+				publishers sometimes have to support different, custom update types- for instance,
+				"protocol amendments", "letters of concern", "comments", etc. The attribute supports
+				custom types as well. date: The date of the update will be displayed in the
+				CrossMark dialog and can help the researcher easily tell whther they are likley to
+				have seen the update.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType mixed="true">
+			<xsd:simpleContent>
+				<xsd:extension base="doi_t">
+					<xsd:attribute name="type" use="required" type="cm_update_type">
+						<xsd:annotation>
+							<xsd:documentation>Required attribute. This attribute should be used to
+								list the update type. Allowed update types are:
+									<ul>
+										<li>addendum</li>
+										<li>clarification</li>
+										<li>correction</li>
+										<li>corrigendum</li>
+										<li>erratum</li>
+										<li>expression_of_concern</li>
+										<li>new_edition</li>
+										<li>new_version</li>
+										<li>partial_retraction</li>
+										<li>removal</li>
+										<li>retraction</li>
+										<li>withdrawal</li>
+									</ul>
+							
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="date" use="required" type="xsd:date">
+						<xsd:annotation>
+							<xsd:documentation>Required attribute. The date of the update will be
+								displayed in the CrossMark dialog and can help the researcher easily
+								tell whther they are likley to have seen the
+								update.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="custom_metadata">
+		<xsd:annotation>
+			<xsd:documentation>Optional element. Publishers are encouraged to provided any
+				non-bibliographical metadata that they feel might help the researcher evaluate and
+				make better use of the content that the Crossmark record refers to. For example,
+				publishers might want to provide funding information, clinical trial numbers,
+				information about the peer-review process or a summary of the publication history of
+				the document.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:choice>
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" ref="assertion"/>
+					<xsd:element maxOccurs="unbounded" ref="fr:program" minOccurs="0"/>
+					<xsd:element maxOccurs="unbounded" ref="ai:program" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" ref="fr:program"/>
+					<xsd:element maxOccurs="unbounded" ref="ai:program" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:element ref="ai:program"/>
+			</xsd:choice>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="assertion">
+		<xsd:annotation>
+			<xsd:documentation>An assertion is a piece of custom, non-bibliographic metadata that
+				the publisher is asserting about the content to which the CrossMark refers.
+				assertion attributes: explanation: If the publisher wants to provide a further
+				explanation of what the particular "assertion" means, they can link to such an
+				explanation by providing an appropriate url on the "explanation" attribute.
+				group_label: This is the human-readable form of the "group_name" attribute. This is
+				what will be displayed in the group headings on the CrossMark metadata record
+				dialog. group_name: Some assertions could be logically "grouped" together in the
+				CrossMark dialog. For instance, if the publisher is recording several pieces of
+				metadata related to funding sources (source name, percentage, grant number), they
+				may want to make sure that these three assertions are grouped next to each-other in
+				the CrossMark dialog. The group_name attribute is the machine-readable value that
+				will be used for grouping such assertions. label: This is the human-readable version
+				of the name attribute which will be displayed in the CrossMark dialog. If this
+				attribute is missing, then the value of the assertion will *not* be displayed in the
+				dialog. Publishers may want to "hide" assertions this way in cases where the
+				assertion value is too large or too complex to display in the dialog, but where the
+				assertion is nonetheless valuable enough to include in API queries and metadata
+				dumps (e.g. detailed licensing terms). name: This is the machine-readable name of
+				the assertion. Use the "label" attribute to provide a human-readable version of the
+				name. order: The publisher may want to control the order in which assertions are
+				displayed to the user in the CrossMark dialog. All assertions will be sorted by this
+				element if it is present.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType mixed="true">
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:group ref="face_markup"/>
+			</xsd:choice>
+			<xsd:attribute name="explanation" type="xsd:anyURI">
+				<xsd:annotation>
+					<xsd:documentation>Optional attribute. If the publisher wants to provide a
+						further explanation of what the particular "assertion" means, they can link
+						to such an explanation by providing an appropriate url on the "explanation"
+						attribute.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="group_label" type="cm_assertion_group_label">
+				<xsd:annotation>
+					<xsd:documentation>Optional attribute. This is the human-readable form of the
+						"group_name" attribute. This is what will be displayed in the group headings
+						on the CrossMark metadata record dialog.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="group_name" type="cm_assertion_group_name">
+				<xsd:annotation>
+					<xsd:documentation>Optional attribute. Some assertions could be logically
+						"grouped" together in the CrossMark dialog. For instance, if the publisher
+						is recording several pieces of metadata related to funding sources (source
+						name, percentage, grant number), they may want to make sure that these three
+						assertions are grouped next to each-other in the CrossMark dialog. The
+						group_name attribute is the machine-readable value that will be used for
+						grouping such assertions.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="label" type="cm_assertion_label">
+				<xsd:annotation>
+					<xsd:documentation>Optional attribute. This is the human-readable version of the
+						name attribute which will be displayed in the CrossMark dialog. If this
+						attribute is missing, then the value of the assertion will *not* be
+						displayed in the dialog. Publishers may want to "hide" assertions this way
+						in cases where the assertion value is too large or too complex to display in
+						the dialog, but where the assertion is nonetheless valuable enough to
+						include in API queries and metadata dumps (e.g. detailed licensing
+						terms)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="name" use="required" type="cm_assertion_name">
+				<xsd:annotation>
+					<xsd:documentation>Required attribute. This is the machine-readable name of the
+						assertion. Use the "label" attribute to provide a human-readable version of
+						the name.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="order" type="xsd:integer">
+				<xsd:annotation>
+					<xsd:documentation>Optional attribute. The publisher may want to control the
+						order in which assertions are displayed to the user in the CrossMark dialog.
+						All assertions will be sorted by this element if it is
+						present.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="href" type="xsd:anyURI">
+				<xsd:annotation>
+					<xsd:documentation>Optional attribute</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<!-- =============================================================
+		
+		10. Elements for Standards
+		
+		============================================================= -->
+	<xsd:element name="designators">
+		<xsd:annotation>
+			<xsd:documentation>A wrapper for designators or other primary identifiers for a
+				standard.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="as_published" minOccurs="1" maxOccurs="1"/>
+				<xsd:element ref="alt_as_published" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="supersedes" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="adopted_from" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="revision_of" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="as_published" type="designator_t">
+		<xsd:annotation>
+			<xsd:documentation>Designator or other primary identifier for the standard being
+				deposited. Required.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:element name="alt_as_published">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="designator_t">
+					<xsd:attribute name="reason" use="required">
+						<xsd:simpleType>
+							<xsd:list>
+								<xsd:simpleType>
+									<xsd:restriction base="xsd:NMTOKEN">
+										<xsd:enumeration value="editorial"/>
+										<xsd:enumeration value="revision"/>
+										<xsd:enumeration value="reapproval"/>
+										<xsd:enumeration value="correction"/>
+										<xsd:enumeration value="amendment"/>
+									</xsd:restriction>
+								</xsd:simpleType>
+							</xsd:list>
+						</xsd:simpleType>
+					</xsd:attribute>
+					<xsd:attribute name="publishedYear" use="required">
+						<xsd:simpleType>
+							<xsd:restriction base="xsd:gYear"/>
+						</xsd:simpleType>
+					</xsd:attribute>
+					<xsd:attribute name="approvedYear" use="required">
+						<xsd:simpleType>
+							<xsd:restriction base="xsd:gYear"/>
+						</xsd:simpleType>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="supersedes">
+		<xsd:annotation>
+			<xsd:documentation>Designator for standard replacing the standard being deposited.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="designatorvalue_t">
+					<xsd:attribute name="publishedYear" type="xsd:gYear"/>
+					<xsd:attribute name="approvedYear" type="xsd:gYear"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="adopted_from">
+		<xsd:annotation>
+			<xsd:documentation>Designator for standard from which the current deposit is adopted.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="designatorvalue_t">
+					<xsd:attribute name="publishedYear" type="xsd:gYear"/>
+					<xsd:attribute name="approvedYear" type="xsd:gYear"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="revision_of">
+		<xsd:annotation>
+			<xsd:documentation>Designator for the previous revision of the standard being deposited.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="designatorvalue_t">
+					<xsd:attribute name="publishedYear" type="xsd:gYear"/>
+					<xsd:attribute name="approvedYear" type="xsd:gYear"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="standards_body">
+		<xsd:annotation>
+			<xsd:documentation>A wrapper for standards body information.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="standards_body_name"/>
+				<xsd:element ref="standards_body_acronym"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="standards_body_name">
+		<xsd:annotation>
+			<xsd:documentation>Name of the standards organization / publisher.
+				Required.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="standards_body_acronym">
+		<xsd:annotation>
+			<xsd:documentation>Acronym for standards body. Will be used for query matching -
+				required.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+
+	<xsd:simpleType name="designatorvalue_t">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="150"/>
+			<xsd:minLength value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:complexType name="designator_t">
+		<xsd:sequence>
+			<xsd:element ref="designator" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="altScript" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:element name="designator" type="designatorvalue_t"/>
+	<xsd:element name="altScript" type="designatorvalue_t"/>
+	<xsd:element name="standard_designator" type="designatorvalue_t"/>
+
+</xsd:schema>

--- a/mycore-pi/src/main/resources/xsd/crossref/4.4.1/common4.4.1.xsd
+++ b/mycore-pi/src/main/resources/xsd/crossref/4.4.1/common4.4.1.xsd
@@ -1,0 +1,2910 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:fr="http://www.crossref.org/fundref.xsd"
+	xmlns:ct="http://www.crossref.org/clinicaltrials.xsd"
+    xmlns:ai="http://www.crossref.org/AccessIndicators.xsd"
+	xmlns:mml="http://www.w3.org/1998/Math/MathML">
+
+	<!-- =============================================================
+
+                          Introduction
+
+     Crossref Schema Version 4.4.1
+
+     Developed for Crossref (www.crossref.org) by
+
+     Inera Incorporated
+     Newton, MA 02460
+     http://www.inera.com
+     email: info@inera.com
+
+
+     ============================================================= -->
+	<!-- =============================================================
+
+                          File Organization
+
+     This schema is organized into the following sections:
+     1. Shared attributes
+     2. Schema-specific data types
+     3. Header elements
+     4. Book elements
+     5. Journal elements
+     6. Elements common to journals, books or conferences
+     7. Elements used for citation deposit and XML queries
+     8. Elements used to deposit components
+     9. CrossMark-specific elements
+     10. Standard-specific elements
+
+     ============================================================= -->
+	<!-- =============================================================
+
+                          Change History
+
+    Changes record version, author initials, date, and comments
+    
+  4.3.0 - 4.4.1 (PDF) 3/1/18 update language.atts
+  4.4.1 10/12/2017 added scn_policy tag family
+  4.4.1 10/5/2017  added peer review report content
+  4.4.0 (PDF) 7/13/2017 added application/vnd.ms-asf as mime type  
+  4.3.1-4.4.0 (PDF) 6/5/2017 change ORCID to accept both http and https
+  4.3.0 - 4.4.0 (PDF) 5/15/2017 make crossmark_domains optional, limit crossmark_domain_exclusive to 1
+  4.3.7  (CSK) August 2015   Added linked clinical trials
+  4.3.5, 4.3.6 (PDF) 5/14/2015 added text/rtf as mime type
+  4.3.6 (PDF) 5/13/2015 relax surname validation to accommodate some author names with '?' and digits.
+  4.3.5,6 (PDF) 3/31/2015 added ai:program to components
+  4.3.1,2,4,5,6 (PDF) 3/2/2015 removed redundant ORCID validation
+  4.3.6  (CSK)  12/2/14  reworked standard designator
+  4.3.5	(PDF) 10/9/2014 updated standard_designator and child elements, moved mml:math to xrefFaces to fix problem with depositing mathML and other markup, restricted CrossMark update types to an enumerated list, removed cm_update_label
+  4.3.1,2,4 (PDF) 6/24/2014 minor change to ORCID regex to only allow X
+  4.3.4 (PDF) 5/27/2014 added unspecified and syndication as values for property attribute, removed tdm as value for content_version
+  4.3.2,4 (PDF) 4/14/2014 changed superseded_by to supersedes
+  4.3.4 (PDF) 3/26/2014 moved standard_designator, standards_body, and child elements to common file, added standard_designator and standards_body to citation; added type attribute to standard_designator
+  4.3.1,,2,4 (PDF) 3/13/2014 added application/epub+zip to mime_type.atts
+  4.3.4 (PDF) 12/19/2013 changed 'KLB' to 'KB'
+  4.3.4 (PDF) 12/10/2013 added archive_location and archive; changed name to depositor_name to support JATS-like name changes, added alt-name, name elements 
+  4.3.4 (PDF) 12/10/2013 added archive_location and archive; changed name to depositor_name to support JATS-like name changes, added alt-name, name elements 
+  4.3.4 (PDF) 12/10/2013 added archive_location and archive; changed name to depositor_name to support JATS-like name changes, added alt-name, name elements 
+  4.3.2 (PDF) 9/17/2013 added content_version attribute to <resource> element
+  4.3.2 (PDF) 5/1/2013 changed openAI.xsd to AccessIndicators.xsd
+  4.3.2 (PDF) 4/10/2013 added reference_distribution_opt and metadata_distribution_opt attribute
+  4.3.2 (PDF) 4/10/2013 added openAI.xsd namespace and import (for Open Access Indicators program)
+  4.3.2 (PDF) 4/9/2013  added "text-mining" value to the property attribute of the <collection> element, optional mime-type attribute to the <resource> element 
+  4.3.2 (PDF) added reg-agency attribute to component
+  4.3.1 (PDF) added application/eps and application/vnd.openxmlformats-officedocument.wordprocessingml.document
+  				as mime types
+  4.3.1 (PDF) 10/4/2012 added ORCID to contributors 
+  4.3.1 (PDF) 9/12/2012 extended surname length to 45 chars
+  4.3.0 (PDF) 7/11/2012 added video/mp4 as mime type
+  4.3.0 (PDF) 12/21/2011 added video/x-flv and audio/x-wav  as mime types
+  4.3.0 (PDF) 12/9/2011 moved all CrossMark elements from main deposit schema to accommodate CrossMark-only deposits
+
+  4.3.0 (PDF) 7/27/2011 added IsTranslationOf and language attribute to components
+  
+  4.3.0 (PDF) 6/29/2011 added CrossMark elements
+  
+  4.3.0 (CSK) 1/31/2011  changed volume and issue to 32 characters
+
+     4.3.0 (CSK)  6/10/2010  Added video/wmv
+
+   4.3.0 (CSK) 3/4/08 Changed to rev 4.3.0 to match the main schema version.
+
+	1.0.5 (BDR) 7/17/07 Changed surname and given_name elements to disallow digits and "?"
+						so as to avoid incorrectly encoded special characters and also affiliation
+						link numbers in author names
+
+   1.0.4.2 (CSK) 8/28/06  Changed element resource data type to anyURI
+                                        moved <collection> from under <collection> back to <item>
+
+    1.0.4.1(CSK) 8/23/06  Added basic 13 digit ISBN capability
+
+    1.0.4 (BDR) 3/24/06  Updated to work with database element
+                         Changed description in component element
+                         to only allow one occurance
+          (BDR) 4/6/06   Added affiliation element to person_name
+
+    1.0.3.4 (CSK) 2/6/2006  Restructured publication_date element to
+                          use a date type.
+
+    1.0.3.3 (CSK) 7/28/05 Included Bruce's fixes to email and  isbn pattern
+
+    1.0.3.2 (CSK)  5/19/05 Added video/avi to mime_type.atts
+
+    1.0.3.2 (HS) added article_title
+
+    1.0.3.1 (CSK) minor revision, backward compatible
+
+    1/25/05   Added chemical mime types
+
+    1.0.3 (CSK)
+
+    7/20/04  Added elements for the deposit of components (section #8)
+    12/7/04  Added size attribute to component
+    12/7/04  Added minOccurs=0 attribute to the <citation_list> child element <citation>
+
+
+    1.0.2 (CSK)   7/16/04
+
+    Moved elments resource,item,collection,property_t and property from the
+    main schema file to this include file to faciliate creating a schema
+    for the deposit of only multiple resolution data.
+
+    1.0.1 (HS)  4/2/03
+
+    Modified "year" model in citation_t to be cYear to support
+    non numeric years in references (e.g. 1998a , 1999-2000)
+
+    3.0.0 (BDR) 10/17/03 (CSK) 12/23/03
+
+    Created with elements from CrossRef Deposit Schema 2.0.6 based
+    largely on elements from section 1, 2 3, and 8 of that parent file.
+    This file now serves as an included module to the parent file
+    and other schemas from CrossRef.
+
+     ============================================================= -->
+	<!-- =============================================================
+
+                          1. Shared attributes
+
+     ============================================================= -->
+
+	<xsd:import namespace="http://www.w3.org/1998/Math/MathML" schemaLocation="http://www.w3.org/Math/XMLSchema/mathml3/mathml3.xsd"/>
+	<xsd:import namespace="http://www.crossref.org/fundref.xsd" schemaLocation="fundref.xsd"/>
+	<xsd:import namespace="http://www.crossref.org/AccessIndicators.xsd" schemaLocation="AccessIndicators.xsd"/>
+	<xsd:import namespace="http://www.crossref.org/clinicaltrials.xsd" schemaLocation="clinicaltrials.xsd"/>
+	
+	
+	<xsd:attributeGroup name="publication_type.atts">
+		<xsd:attribute name="publication_type" default="full_text">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:NMTOKEN">
+					<xsd:enumeration value="abstract_only"/>
+					<xsd:enumeration value="full_text"/>
+					<xsd:enumeration value="bibliographic_record"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="media_type.atts">
+		<xsd:attribute name="media_type" default="print">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:NMTOKEN">
+					<xsd:enumeration value="print"/>
+					<xsd:enumeration value="electronic"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="contributor.atts">
+		<xsd:attribute name="sequence" use="required">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:NMTOKEN">
+					<xsd:enumeration value="first"/>
+					<xsd:enumeration value="additional"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="contributor_role" use="required">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:NMTOKEN">
+					<xsd:enumeration value="author"/>
+					<xsd:enumeration value="editor"/>
+					<xsd:enumeration value="chair"/>
+					<xsd:enumeration value="reviewer"/>
+					<xsd:enumeration value="review-assistant"/>
+					<xsd:enumeration value="stats-reviewer"/>
+					<xsd:enumeration value="reviewer-external"/>
+					<xsd:enumeration value="reader"/>
+					<xsd:enumeration value="translator"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="name-style" use="optional">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:token">
+					<xsd:enumeration value="western"/>
+					<xsd:enumeration value="eastern"/>
+					<xsd:enumeration value="islensk"/>
+					<xsd:enumeration value="given-only"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="language.atts"/>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="language.atts">
+		<xsd:annotation>
+			<xsd:documentation>Language attributes are based on ISO 639</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="language" use="optional">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:NMTOKEN">
+					<xsd:enumeration value="aa"/>
+					<xsd:enumeration value="ab"/>
+					<xsd:enumeration value="ae"/>
+					<xsd:enumeration value="af"/>
+					<xsd:enumeration value="ak"/>
+					<xsd:enumeration value="am"/>
+					<xsd:enumeration value="an"/>
+					<xsd:enumeration value="ar"/>
+					<xsd:enumeration value="as"/>
+					<xsd:enumeration value="av"/>
+					<xsd:enumeration value="ay"/>
+					<xsd:enumeration value="az"/>
+					<xsd:enumeration value="ba"/>
+					<xsd:enumeration value="be"/>
+					<xsd:enumeration value="bg"/>
+					<xsd:enumeration value="bh"/>
+					<xsd:enumeration value="bi"/>
+					<xsd:enumeration value="bm"/>
+					<xsd:enumeration value="bn"/>
+					<xsd:enumeration value="bo"/>
+					<xsd:enumeration value="br"/>
+					<xsd:enumeration value="bs"/>
+					<xsd:enumeration value="ca"/>
+					<xsd:enumeration value="ce"/>
+					<xsd:enumeration value="ch"/>
+					<xsd:enumeration value="co"/>
+					<xsd:enumeration value="cr"/>
+					<xsd:enumeration value="cs"/>
+					<xsd:enumeration value="cu"/>
+					<xsd:enumeration value="cv"/>
+					<xsd:enumeration value="cy"/>
+					<xsd:enumeration value="da"/>
+					<xsd:enumeration value="de"/>
+					<xsd:enumeration value="dv"/>
+					<xsd:enumeration value="dz"/>
+					<xsd:enumeration value="ee"/>
+					<xsd:enumeration value="el"/>
+					<xsd:enumeration value="en"/>
+					<xsd:enumeration value="eo"/>
+					<xsd:enumeration value="es"/>
+					<xsd:enumeration value="et"/>
+					<xsd:enumeration value="eu"/>
+					<xsd:enumeration value="fa"/>
+					<xsd:enumeration value="ff"/>
+					<xsd:enumeration value="fi"/>
+					<xsd:enumeration value="fj"/>
+					<xsd:enumeration value="fo"/>
+					<xsd:enumeration value="fr"/>
+					<xsd:enumeration value="fy"/>
+					<xsd:enumeration value="ga"/>
+					<xsd:enumeration value="gd"/>
+					<xsd:enumeration value="gl"/>
+					<xsd:enumeration value="gn"/>
+					<xsd:enumeration value="gu"/>
+					<xsd:enumeration value="gv"/>
+					<xsd:enumeration value="ha"/>
+					<xsd:enumeration value="he"/>
+					<xsd:enumeration value="hi"/>
+					<xsd:enumeration value="ho"/>
+					<xsd:enumeration value="hr"/>
+					<xsd:enumeration value="ht"/>
+					<xsd:enumeration value="hu"/>
+					<xsd:enumeration value="hy"/>
+					<xsd:enumeration value="hz"/>
+					<xsd:enumeration value="ia"/>
+					<xsd:enumeration value="id"/>
+					<xsd:enumeration value="ie"/>
+					<xsd:enumeration value="ig"/>
+					<xsd:enumeration value="ii"/>
+					<xsd:enumeration value="ik"/>
+					<xsd:enumeration value="io"/>
+					<xsd:enumeration value="is"/>
+					<xsd:enumeration value="it"/>
+					<xsd:enumeration value="iu"/>
+					<xsd:enumeration value="ja"/>
+					<xsd:enumeration value="jw"/>
+					<xsd:enumeration value="ka"/>
+					<xsd:enumeration value="kg"/>
+					<xsd:enumeration value="ki"/>
+					<xsd:enumeration value="kj"/>
+					<xsd:enumeration value="kk"/>
+					<xsd:enumeration value="kl"/>
+					<xsd:enumeration value="km"/>
+					<xsd:enumeration value="kn"/>
+					<xsd:enumeration value="ko"/>
+					<xsd:enumeration value="kr"/>
+					<xsd:enumeration value="ks"/>
+					<xsd:enumeration value="ku"/>
+					<xsd:enumeration value="kv"/>
+					<xsd:enumeration value="kw"/>
+					<xsd:enumeration value="ky"/>
+					<xsd:enumeration value="la"/>
+					<xsd:enumeration value="lb"/>
+					<xsd:enumeration value="lg"/>
+					<xsd:enumeration value="li"/>
+					<xsd:enumeration value="ln"/>
+					<xsd:enumeration value="lo"/>
+					<xsd:enumeration value="lt"/>
+					<xsd:enumeration value="lu"/>
+					<xsd:enumeration value="lv"/>
+					<xsd:enumeration value="mg"/>
+					<xsd:enumeration value="mu"/>
+					<xsd:enumeration value="mi"/>
+					<xsd:enumeration value="mk"/>
+					<xsd:enumeration value="ml"/>
+					<xsd:enumeration value="mn"/>
+					<xsd:enumeration value="mr"/>
+					<xsd:enumeration value="ms"/>
+					<xsd:enumeration value="mt"/>
+					<xsd:enumeration value="my"/>
+					<xsd:enumeration value="na"/>
+					<xsd:enumeration value="nb"/>
+					<xsd:enumeration value="nd"/>
+					<xsd:enumeration value="ne"/>
+					<xsd:enumeration value="ng"/>
+					<xsd:enumeration value="nl"/>
+					<xsd:enumeration value="nn"/>
+					<xsd:enumeration value="no"/>
+					<xsd:enumeration value="nr"/>
+					<xsd:enumeration value="nv"/>
+					<xsd:enumeration value="ny"/>
+					<xsd:enumeration value="oc"/>
+					<xsd:enumeration value="oj"/>
+					<xsd:enumeration value="om"/>
+					<xsd:enumeration value="or"/>
+					<xsd:enumeration value="os"/>
+					<xsd:enumeration value="pa"/>
+					<xsd:enumeration value="pi"/>
+					<xsd:enumeration value="pl"/>
+					<xsd:enumeration value="ps"/>
+					<xsd:enumeration value="pt"/>
+					<xsd:enumeration value="qu"/>
+					<xsd:enumeration value="rm"/>
+					<xsd:enumeration value="rn"/>
+					<xsd:enumeration value="ro"/>
+					<xsd:enumeration value="ru"/>
+					<xsd:enumeration value="rw"/>
+					<xsd:enumeration value="sa"/>
+					<xsd:enumeration value="sc"/>
+					<xsd:enumeration value="sd"/>
+					<xsd:enumeration value="se"/>
+					<xsd:enumeration value="sg"/>
+					<xsd:enumeration value="si"/>
+					<xsd:enumeration value="sk"/>
+					<xsd:enumeration value="sl"/>
+					<xsd:enumeration value="sm"/>
+					<xsd:enumeration value="sn"/>
+					<xsd:enumeration value="so"/>
+					<xsd:enumeration value="sq"/>
+					<xsd:enumeration value="sr"/>
+					<xsd:enumeration value="ss"/>
+					<xsd:enumeration value="st"/>
+					<xsd:enumeration value="su"/>
+					<xsd:enumeration value="sv"/>
+					<xsd:enumeration value="sw"/>
+					<xsd:enumeration value="ta"/>
+					<xsd:enumeration value="te"/>
+					<xsd:enumeration value="tg"/>
+					<xsd:enumeration value="th"/>
+					<xsd:enumeration value="ti"/>
+					<xsd:enumeration value="tk"/>
+					<xsd:enumeration value="tl"/>
+					<xsd:enumeration value="tn"/>
+					<xsd:enumeration value="to"/>
+					<xsd:enumeration value="tr"/>
+					<xsd:enumeration value="ts"/>
+					<xsd:enumeration value="tt"/>
+					<xsd:enumeration value="tw"/>
+					<xsd:enumeration value="ty"/>
+					<xsd:enumeration value="ug"/>
+					<xsd:enumeration value="uk"/>
+					<xsd:enumeration value="ur"/>
+					<xsd:enumeration value="uz"/>
+					<xsd:enumeration value="ve"/>
+					<xsd:enumeration value="vi"/>
+					<xsd:enumeration value="vo"/>
+					<xsd:enumeration value="wa"/>
+					<xsd:enumeration value="wo"/>
+					<xsd:enumeration value="xh"/>
+					<xsd:enumeration value="yi"/>
+					<xsd:enumeration value="yo"/>
+					<xsd:enumeration value="za"/>
+					<xsd:enumeration value="zh"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="mime_type.atts">
+		<xsd:annotation>
+			<xsd:documentation>Mime types for component format. For mime types refer to
+				http://www.iana.org/assignments/media-types/</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="mime_type" use="optional">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+                                    <xsd:enumeration value="text/css"/>
+                                    <xsd:enumeration value="text/csv"/>
+                                    <xsd:enumeration value="text/enriched"/>
+                                    <xsd:enumeration value="text/html"/>
+                                    <xsd:enumeration value="text/plain"/>
+                                    <xsd:enumeration value="text/richtext"/>
+                                    <xsd:enumeration value="text/rtf"/>
+                                    <xsd:enumeration value="text/sgml"/>
+                                    <xsd:enumeration value="text/tab-separated-values"/>
+                                    <xsd:enumeration value="text/xml"/>
+                                    <xsd:enumeration value="text/xml-external-parsed-entity"/>
+					<xsd:enumeration value="multipart/mixed"/>
+					<xsd:enumeration value="multipart/alternative"/>
+					<xsd:enumeration value="multipart/digest"/>
+					<xsd:enumeration value="multipart/parallel"/>
+					<xsd:enumeration value="multipart/appledouble"/>
+					<xsd:enumeration value="multipart/header-set"/>
+					<xsd:enumeration value="multipart/form-data"/>
+					<xsd:enumeration value="multipart/report"/>
+					<xsd:enumeration value="multipart/voice-message"/>
+					<xsd:enumeration value="multipart/signed"/>
+					<xsd:enumeration value="multipart/encrypted"/>
+					<xsd:enumeration value="multipart/byteranges"/>
+					<xsd:enumeration value="application/eps"/>
+					<xsd:enumeration value="application/epub+zip"/>
+					<xsd:enumeration value="application/octet-stream"/>
+					<xsd:enumeration value="application/postscript"/>
+					<xsd:enumeration value="application/rtf"/>
+					<xsd:enumeration value="application/applefile"/>
+					<xsd:enumeration value="application/mac-binhex40"/>
+					<xsd:enumeration value="application/wordperfect5.1"/>
+					<xsd:enumeration value="application/pdf"/>
+					<xsd:enumeration value="application/x-gzip"/>
+					<xsd:enumeration value="application/zip"/>
+					<xsd:enumeration value="application/gzip"/>
+					<xsd:enumeration value="application/macwriteii"/>
+					<xsd:enumeration value="application/msword"/>
+					<xsd:enumeration value="application/sgml"/>
+					<xsd:enumeration value="application/cals-1840"/>
+					<xsd:enumeration value="application/pgp-encrypted"/>
+					<xsd:enumeration value="application/pgp-signature"/>
+					<xsd:enumeration value="application/pgp-keys"/>
+					<xsd:enumeration value="application/sgml-open-catalog"/>
+					<xsd:enumeration value="application/rc"/>
+					<xsd:enumeration value="application/xml"/>
+					<xsd:enumeration value="application/xml-external-parsed-entity"/>
+					<xsd:enumeration value="application/xml-dtd"/>
+					<xsd:enumeration value="application/batch-SMTP"/>
+					<xsd:enumeration value="application/ipp"/>
+					<xsd:enumeration value="application/ocsp-request"/>
+					<xsd:enumeration value="application/ocsp-response"/>
+                                        <xsd:enumeration value="application/vnd.wolfram.mathematica"/>
+                                        <xsd:enumeration value="application/vnd.wolfram.mathematica.package"/>
+                                        <xsd:enumeration value="application/vnd.wolfram.player"/>
+					<xsd:enumeration value="application/vnd.oasis.opendocument.text"/>
+					<xsd:enumeration value="application/vnd.oasis.opendocument.presentation"/>
+					<xsd:enumeration value="application/vnd.oasis.opendocument.spreadsheet"/>
+                                        <xsd:enumeration value="application/vnd.ms-asf"/>
+					<xsd:enumeration value="application/vnd.ms-excel"/>
+					<xsd:enumeration value="application/vnd.ms-powerpoint"/>
+					<xsd:enumeration value="application/vnd.openxmlformats-officedocument.presentationml.presentation"/>
+					<xsd:enumeration value="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/>
+					<xsd:enumeration value="application/vnd.openxmlformats-officedocument.wordprocessingml.document"/>
+					<xsd:enumeration value="application/epub+zip"/>
+					<xsd:enumeration value="application/regex.clinical-trial-number"/>
+					<xsd:enumeration value="image/fits"/>
+					<xsd:enumeration value="image/jpeg"/>
+					<xsd:enumeration value="image/gif"/>
+					<xsd:enumeration value="image/ief"/>
+					<xsd:enumeration value="image/g3fax"/>
+					<xsd:enumeration value="image/tiff"/>
+					<xsd:enumeration value="image/Graphics-Metafile"/>
+					<xsd:enumeration value="image/png"/>
+					<xsd:enumeration value="audio/basic"/>
+					<xsd:enumeration value="audio/32kadpcm"/>
+					<xsd:enumeration value="audio/mpeg"/>
+					<xsd:enumeration value="audio/parityfec"/>
+					<xsd:enumeration value="audio/MP4A-LATM"/>
+					<xsd:enumeration value="audio/mpa-robust"/>
+					<xsd:enumeration value="video/x-ms-wmv"/>
+					<xsd:enumeration value="video/avi"/>
+					<xsd:enumeration value="video/mpeg"/>
+					<xsd:enumeration value="video/quicktime"/>
+					<xsd:enumeration value="video/pointer"/>
+					<xsd:enumeration value="video/parityfec"/>
+					<xsd:enumeration value="video/MP4V-ES"/>
+					<xsd:enumeration value="video/mp4"/>
+					<xsd:enumeration value="chemical/x-alchemy"/>
+					<xsd:enumeration value="chemical/x-cache-csf"/>
+					<xsd:enumeration value="chemical/x-cactvs-binary"/>
+					<xsd:enumeration value="chemical/x-cactvs-binary"/>
+					<xsd:enumeration value="chemical/x-cactvs-binary"/>
+					<xsd:enumeration value="chemical/x-cdx"/>
+					<xsd:enumeration value="chemical/x-cerius"/>
+					<xsd:enumeration value="chemical/x-chemdraw"/>
+					<xsd:enumeration value="chemical/x-cif"/>
+					<xsd:enumeration value="chemical/x-mmcif"/>
+					<xsd:enumeration value="chemical/x-chem3d"/>
+					<xsd:enumeration value="chemical/x-cmdf"/>
+					<xsd:enumeration value="chemical/x-compass"/>
+					<xsd:enumeration value="chemical/x-crossfire"/>
+					<xsd:enumeration value="chemical/x-cml"/>
+					<xsd:enumeration value="chemical/x-csml"/>
+					<xsd:enumeration value="chemical/x-ctx"/>
+					<xsd:enumeration value="chemical/x-cxf"/>
+					<xsd:enumeration value="chemical/x-daylight-smiles"/>
+					<xsd:enumeration value="chemical/x-embl-dl-nucleotide"/>
+					<xsd:enumeration value="chemical/x-galactic-spc"/>
+					<xsd:enumeration value="chemical/x-gamess-input"/>
+					<xsd:enumeration value="chemical/x-gaussian-input"/>
+					<xsd:enumeration value="chemical/x-gaussian-checkpoint"/>
+					<xsd:enumeration value="chemical/x-gaussian-cube"/>
+					<xsd:enumeration value="chemical/x-gcg8-sequence"/>
+					<xsd:enumeration value="chemical/x-genbank"/>
+					<xsd:enumeration value="chemical/x-isostar"/>
+					<xsd:enumeration value="chemical/x-jcamp-dx"/>
+					<xsd:enumeration value="chemical/x-kinemage"/>
+					<xsd:enumeration value="chemical/x-macmolecule"/>
+					<xsd:enumeration value="chemical/x-macromodel-input"/>
+					<xsd:enumeration value="chemical/x-mdl-molfile"/>
+					<xsd:enumeration value="chemical/x-mdl-rdfile"/>
+					<xsd:enumeration value="chemical/x-mdl-rxnfile"/>
+					<xsd:enumeration value="chemical/x-mdl-sdfile"/>
+					<xsd:enumeration value="chemical/x-mdl-tgf"/>
+					<xsd:enumeration value="chemical/x-mif"/>
+					<xsd:enumeration value="chemical/x-mol2"/>
+					<xsd:enumeration value="chemical/x-molconn-Z"/>
+					<xsd:enumeration value="chemical/x-mopac-input"/>
+					<xsd:enumeration value="chemical/x-mopac-graph"/>
+					<xsd:enumeration value="chemical/x-ncbi-asn1"/>
+					<xsd:enumeration value="chemical/x-ncbi-asn1-binary"/>
+					<xsd:enumeration value="chemical/x-pdb"/>
+					<xsd:enumeration value="chemical/x-swissprot"/>
+					<xsd:enumeration value="chemical/x-vamas-iso14976"/>
+					<xsd:enumeration value="chemical/x-vmd"/>
+					<xsd:enumeration value="chemical/x-xtel"/>
+					<xsd:enumeration value="chemical/x-xyz"/>
+					<xsd:enumeration value="model/vrml"/>
+					<xsd:enumeration value="audio/x-wav"/>
+					<xsd:enumeration value="video/x-flv"/>
+                                        <xsd:enumeration value="Data/spcvue.htm"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="metadata_distribution_opts.att">
+		<xsd:annotation>
+			<xsd:documentation>Use to flag metadata for distribution. "query" is the default and
+				follows current protocol - bibliographic metadata is distributed to anyone in a
+				query response, bulk distribution is only allowed per CMS rules. "any" allows bulk
+				distribution of metadata to anyone using OAI-PMH queries.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="metadata_distribution_opts" use="optional" default="query">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="any"/>
+					<xsd:enumeration value="query"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<xsd:attributeGroup name="reference_distribution_opts.att">
+		<xsd:annotation>
+			<xsd:documentation>Use to flag references for distribution. "none" is the default and
+				follows current protocol - references are only distributed to everyone if the prefix
+				level permission is set, otherwise reference distribution is limited to the DOI
+				owner. Setting the value to "query" releases references to anyone making a query
+				request (this overrides any established prefix level permission). Value "any" allows
+				bulk distribution to anyone (using a CrossRef query account) using the OAI-PMH
+				protocol, and also releases references to anyone making a query
+				request.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="reference_distribution_opts" use="optional" default="none">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="none"/>
+					<xsd:enumeration value="query"/>
+					<xsd:enumeration value="any"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+	<!-- =============================================================
+
+                     2. Schema-specific data types
+
+     ============================================================= -->
+	<xsd:complexType name="xrefFaces" mixed="true">
+		<xsd:choice minOccurs="0" maxOccurs="unbounded">
+			<xsd:group ref="face_markup"/>
+		</xsd:choice>
+	</xsd:complexType>
+	<xsd:group name="face_markup">
+		<xsd:annotation>
+			<xsd:documentation>The following are basic data types for face markup. Face markup that
+				appears in the title, subtitle, and original_language_title elements should be
+				retained when depositing metadata. Face markup in other elements (e.g. small caps in
+				author names) must be dropped. Face markup support includes bold (b), italic (i),
+				underline (u), over-line (ovl), superscript (sup), subscript (sub), small caps
+				(scp), and typewriter text (tt). See https://support.crossref.org/hc/en-us/articles/214532023
+				
+MathML may also be included using the 'mml' namespace prefix.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:choice>
+			<xsd:element ref="b"/>
+			<xsd:element ref="i"/>
+			<xsd:element ref="u"/>
+			<xsd:element ref="ovl"/>
+			<xsd:element ref="sup"/>
+			<xsd:element ref="sub"/>
+			<xsd:element ref="scp"/>
+			<xsd:element ref="tt"/>
+			<xsd:element ref="font"/>
+			<xsd:element ref="mml:math"/>
+		</xsd:choice>
+	</xsd:group>
+	<xsd:element name="b" type="xrefFaces"/>
+	<xsd:element name="i" type="xrefFaces"/>
+	<xsd:element name="u" type="xrefFaces"/>
+	<xsd:element name="ovl" type="xrefFaces"/>
+	<xsd:element name="sup" type="xrefFaces"/>
+	<xsd:element name="sub" type="xrefFaces"/>
+	<xsd:element name="scp" type="xrefFaces"/>
+	<xsd:element name="tt" type="xrefFaces"/>
+	<xsd:element name="font" type="xrefFaces"/>
+	<xsd:simpleType name="xrefYear">
+		<xsd:annotation>
+			<xsd:documentation>The following are basic data types for date
+				parts.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:positiveInteger">
+			<xsd:maxInclusive value="2200"/>
+			<xsd:minInclusive value="1400"/>
+			<xsd:totalDigits value="4"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="xrefMonth">
+		<xsd:restriction base="xsd:positiveInteger">
+			<xsd:maxInclusive value="34"/>
+			<xsd:minInclusive value="01"/>
+			<xsd:totalDigits value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="xrefDay">
+		<xsd:restriction base="xsd:positiveInteger">
+			<xsd:maxInclusive value="31"/>
+			<xsd:minInclusive value="01"/>
+			<xsd:totalDigits value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<!-- =============================================================
+
+                          3. Header elements
+
+     ============================================================= -->
+	<xsd:element name="doi_batch_id">
+		<xsd:annotation>
+			<xsd:documentation>Publisher generated ID that uniquely identifies the DOI submission
+				batch. It will be used as a reference in error messages sent by the MDDB, and can be
+				used for submission tracking. The publisher must insure that this number is unique
+				for every submission to CrossRef. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="100"/>
+				<xsd:minLength value="4"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="timestamp" type="xsd:nonNegativeInteger">
+		<xsd:annotation>
+			<xsd:documentation>Indicates version of a batch file instance or DOI. timestamp is used
+				to uniquely identify batch files and DOI values when a DOI has been updated one or
+				more times. timestamp is an integer representation of date and time that serves as a
+				version number for the record that is being deposited. Because CrossRef uses it as a
+				version number, the format need not follow any public standard and therefore the
+				publisher can determine the internal format. The schema format is a double of at
+				least 64 bits, insuring that a fully qualified date/time stamp of 19 digits can be
+				submitted. When depositing data, CrossRef will check to see if a DOI has already
+				been deposited for the specific doi value. If the newer data carries a time stamp
+				value that is equal to or greater than the old data based on a strict numeric
+				comparison, the new data will replace the old data. If the new data value is less
+				than the old data value, the new data will not replace the old data. timestamp is
+				optional in doi_data and required in head. The value from the head instance
+				timestamp will be used for all instances of doi_data that do not include a timestamp
+				element.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="depositor">
+		<xsd:annotation>
+			<xsd:documentation>Information about the organization submitting DOI metadata to
+				CrossRef</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="depositor_name"/>
+				<xsd:element ref="email_address"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="depositor_name">
+		<xsd:annotation>
+			<xsd:documentation>Name of the organization registering the DOIs. The name placed in
+				this element should match the name under which a depositing organization has
+				registered with CrossRef.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="130"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="email_address">
+		<xsd:annotation>
+			<xsd:documentation>e-mail address to which batch success and/or error messages are sent.
+				It is recommended that this address be unique to a position within the organization
+				submitting data (e.g. "doi@...") rather than unique to a person. In this way, the
+				alias for delivery of this mail can be changed as responsibility for submission of
+				DOI data within the organization changes from one person to another.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="200"/>
+				<xsd:minLength value="6"/>
+				<xsd:pattern
+					value="[\p{L}\p{N}!/+\-_]+(\.[\p{L}\p{N}!/+\-_]+)*@[\p{L}\p{N}!/+\-_]+(\.[\p{L}_-]+)+"
+				/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="registrant">
+		<xsd:annotation>
+			<xsd:documentation>The organization that owns the information being registered.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="255"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<!-- =============================================================
+
+                          4. Book elements
+
+     ============================================================= -->
+	<xsd:element name="component_number">
+		<xsd:annotation>
+			<xsd:documentation>The chapter, section, part, etc. number for a content item in a book.
+				Unlike volume and edition_number, component_number should include any additional
+				text that helps identify the type of component. In the example above, the text
+				"Section 8" appeared on the table of contents and it is reflected here. "8" is also
+				acceptable, however the former treatment is preferred. The type of the component is
+				given the component_type attribute of content_item.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="50"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="edition_number">
+		<xsd:annotation>
+			<xsd:documentation>The edition number of a book. edition_number should include only a
+				number and not additional text such as "edition". For example, you should submit
+				"3", not "third edition" or "3rd edition". Roman numerals are acceptable. Publishers
+				will update a print edition with a new edition number when more than ten percent of
+				the content has changed. However, publishers expect to continuously update online
+				editions of books without changing the edition number. <i>The ability to update the
+					electronic version independent of the print version could be problematic for
+					researchers. For example, if a research article cites the print version of a
+					chapter, and a researcher subsequently links to the online version of the same
+					chapter, the content may be different from the print version without the typical
+					indication of a new edition. This topic requires further discussion outside of
+					the scope of this specification.</i></xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="15"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<!-- =============================================================
+
+                          5. Journal elements
+
+     ============================================================= -->
+	<xsd:element name="issue">
+		<xsd:annotation>
+			<xsd:documentation>The issue number in which an article is published. Only one issue
+				name should be used for the issue. The issue number takes precedence over any other
+				name. For example, if an issue has only a seasonal name, then the season should be
+				listed in issue. However, if an issue has a number and a season, then only the
+				number should be listed in issue, and the season should be placed in month (see the
+				table in month, below, for proper encoding of the season) if the specific month of
+				publication is not known. Do not include the words "issue", "No" or "number" in this
+				element. When submitting DOIs for journal articles published online ahead of print,
+				you should submit the issue number, when known, even if the pagination information
+				for the entity is not yet known. Data may be alpha, numeric or a combination.
+				Examples: 74(3):1999 <journal_issue>
+					<publication_date media_type="print">
+						<year>1999</year>
+					</publication_date>
+					<journal_volume>
+						<volume>74</volume>
+					</journal_volume>
+					<issue>3</issue>
+				</journal_issue> Volume 74, Spring 1999 <journal_issue>
+					<publication_date media_type="print">
+						<year>1999</year>
+					</publication_date>
+					<journal_volume>
+						<volume>74</volume>
+					</journal_volume>
+					<issue>Spring</issue>
+				</journal_issue> Volume 74, issue 3 Spring 1999 <journal_issue>
+					<publication_date media_type="print">
+						<month>21</month>
+						<year>1999</year>
+					</publication_date>
+					<journal_volume>
+						<volume>74</volume>
+					</journal_volume>
+					<issue>3</issue>
+				</journal_issue></xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="32"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<!-- =============================================================
+
+       6. Elements shared by content types
+
+     ============================================================= -->
+	<xsd:element name="doi_data">
+		<xsd:annotation>
+			<xsd:documentation>The container for elements related directly to a DOI. doi_data
+				contains the doi, timestamp (version) and corresponding resource (URI) data for the
+				doi. Cases of single-resolution (i.e. one DOI with a single corresponding URI)
+				should be tagged with a doi/resource pair in doi_data. If additional resources are
+				to be proved the &lt;collection&gt; element may also be used. The single URL
+				provided in the &lt;resource&gt; is mandatory and serves as the single resolution
+				target for the DOI. Note: A timestamp value placed inside doi_data will override any
+				timestamp value placed in the &lt;head&gt; element. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="doi"/>
+				<xsd:element ref="timestamp" minOccurs="0"/>
+				<xsd:element ref="resource"/>
+				<xsd:element ref="collection" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="resource">
+		<xsd:annotation>
+			<xsd:documentation>The element that contains a URI associated with a DOI. URLs are
+				referred to as resources in the 2.0 CrossRef schema because they can be any valid
+				URI. Cases of single-resolution (i.e. one DOI with a single corresponding URI)
+				should be tagged with a doi/resource pair in doi_data. Only one resource is allowed
+				per doi_data, the exception being resource elements within a collection element.
+				Values for the "content_version" attribute are vor (version of record) and am
+				(advance manuscript). </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="resource_t">
+					<xsd:attributeGroup ref="mime_type.atts"/>
+					<xsd:attribute name="content_version">
+						<xsd:simpleType>
+							<xsd:restriction base="xsd:string">
+								<xsd:enumeration value="vor"/>
+								<xsd:enumeration value="am"/>
+							</xsd:restriction>
+						</xsd:simpleType>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:simpleType name="resource_t">
+		<xsd:restriction base="xsd:anyURI">
+			<xsd:maxLength value="2048"/>
+			<xsd:minLength value="1"/>
+			<xsd:pattern value="([hH][tT][tT][pP]|[hH][tT][tT][pP][sS]|[fF][tT][pP])://.*"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:element name="collection">
+		<xsd:annotation>
+			<xsd:documentation> A collection is a container for one or more items each holding a doi
+				or a resource (URI) which is related to the DOI in the ancestor &lt;doi_data&gt;
+				element. A collection must be qualified by a property attibute or the
+				multi-resolution attribute. property attributes: list-based: uses an interim page
+				and presents the list of items to the user (via Multiple Resolution) country-based:
+				proxy picks destination based on the country code of the user's location (this
+				option is not currently active, contact support@crossref.org for more info)
+				crawler-based: identifies resource to be crawled by the specified crawlers.
+				text-mining: identifies resource to be used for text and data mining unspecified:
+				identifies resource with unspecified usage syndication: identifies resource to be
+				used for syndication The multi-resolution attribute may be used to lock or unlock
+				DOIs for multiple resolution. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="item" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+			<xsd:attribute name="property" use="required">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:NMTOKEN">
+						<xsd:enumeration value="list-based"/>
+						<xsd:enumeration value="country-based"/>
+						<xsd:enumeration value="crawler-based"/>
+						<xsd:enumeration value="text-mining"/>
+						<xsd:enumeration value="unspecified"/>
+						<xsd:enumeration value="syndication"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="multi-resolution">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:NMTOKEN">
+						<xsd:enumeration value="lock"/>
+						<xsd:enumeration value="unlock"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="item">
+		<xsd:annotation>
+			<xsd:documentation>A container used to associate a collection, doi, or resource (URI)
+				with zero or more property elements. item is currently used for supplying as-crawled
+				URLs (https://support.crossref.org/hc/en-us/articles/214018806)</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:choice minOccurs="0">
+					<xsd:element ref="doi"/>
+					<xsd:element ref="resource"/>
+				</xsd:choice>
+			</xsd:sequence>
+			<xsd:attribute name="crawler" use="optional">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:NMTOKEN">
+						<xsd:enumeration value="altavista"/>
+						<xsd:enumeration value="google"/>
+						<xsd:enumeration value="msn"/>
+						<xsd:enumeration value="scirus"/>
+						<xsd:enumeration value="yahoo"/>
+						<xsd:enumeration value="iParadigms"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="label" use="optional">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:string">
+						<xsd:maxLength value="128"/>
+						<xsd:minLength value="3"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="country" use="optional">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:NMTOKEN">
+						<xsd:enumeration value="AD"/>
+						<xsd:enumeration value="AE"/>
+						<xsd:enumeration value="AF"/>
+						<xsd:enumeration value="AG"/>
+						<xsd:enumeration value="AI"/>
+						<xsd:enumeration value="AL"/>
+						<xsd:enumeration value="AM"/>
+						<xsd:enumeration value="AN"/>
+						<xsd:enumeration value="AO"/>
+						<xsd:enumeration value="AQ"/>
+						<xsd:enumeration value="AR"/>
+						<xsd:enumeration value="AS"/>
+						<xsd:enumeration value="AT"/>
+						<xsd:enumeration value="AU"/>
+						<xsd:enumeration value="AW"/>
+						<xsd:enumeration value="AX"/>
+						<xsd:enumeration value="AZ"/>
+						<xsd:enumeration value="BA"/>
+						<xsd:enumeration value="BB"/>
+						<xsd:enumeration value="BD"/>
+						<xsd:enumeration value="BE"/>
+						<xsd:enumeration value="BF"/>
+						<xsd:enumeration value="BG"/>
+						<xsd:enumeration value="BH"/>
+						<xsd:enumeration value="BI"/>
+						<xsd:enumeration value="BJ"/>
+						<xsd:enumeration value="BL"/>
+						<xsd:enumeration value="BM"/>
+						<xsd:enumeration value="BN"/>
+						<xsd:enumeration value="BO"/>
+						<xsd:enumeration value="BQ"/>
+						<xsd:enumeration value="BR"/>
+						<xsd:enumeration value="BS"/>
+						<xsd:enumeration value="BT"/>
+						<xsd:enumeration value="BV"/>
+						<xsd:enumeration value="BW"/>
+						<xsd:enumeration value="BY"/>
+						<xsd:enumeration value="BZ"/>
+						<xsd:enumeration value="CA"/>
+						<xsd:enumeration value="CC"/>
+						<xsd:enumeration value="CD"/>
+						<xsd:enumeration value="CF"/>
+						<xsd:enumeration value="CG"/>
+						<xsd:enumeration value="CH"/>
+						<xsd:enumeration value="CI"/>
+						<xsd:enumeration value="CK"/>
+						<xsd:enumeration value="CL"/>
+						<xsd:enumeration value="CM"/>
+						<xsd:enumeration value="CN"/>
+						<xsd:enumeration value="CO"/>
+						<xsd:enumeration value="CR"/>
+						<xsd:enumeration value="CS"/>
+						<xsd:enumeration value="CU"/>
+						<xsd:enumeration value="CV"/>
+						<xsd:enumeration value="CX"/>
+						<xsd:enumeration value="CY"/>
+						<xsd:enumeration value="CZ"/>
+						<xsd:enumeration value="DE"/>
+						<xsd:enumeration value="DJ"/>
+						<xsd:enumeration value="DK"/>
+						<xsd:enumeration value="DM"/>
+						<xsd:enumeration value="DO"/>
+						<xsd:enumeration value="DZ"/>
+						<xsd:enumeration value="EC"/>
+						<xsd:enumeration value="EE"/>
+						<xsd:enumeration value="EG"/>
+						<xsd:enumeration value="EH"/>
+						<xsd:enumeration value="ER"/>
+						<xsd:enumeration value="ES"/>
+						<xsd:enumeration value="ET"/>
+						<xsd:enumeration value="FI"/>
+						<xsd:enumeration value="FJ"/>
+						<xsd:enumeration value="FK"/>
+						<xsd:enumeration value="FM"/>
+						<xsd:enumeration value="FO"/>
+						<xsd:enumeration value="FR"/>
+						<xsd:enumeration value="GA"/>
+						<xsd:enumeration value="GB"/>
+						<xsd:enumeration value="GD"/>
+						<xsd:enumeration value="GE"/>
+						<xsd:enumeration value="GF"/>
+						<xsd:enumeration value="GG"/>
+						<xsd:enumeration value="GH"/>
+						<xsd:enumeration value="GI"/>
+						<xsd:enumeration value="GL"/>
+						<xsd:enumeration value="GM"/>
+						<xsd:enumeration value="GN"/>
+						<xsd:enumeration value="GP"/>
+						<xsd:enumeration value="GQ"/>
+						<xsd:enumeration value="GR"/>
+						<xsd:enumeration value="GS"/>
+						<xsd:enumeration value="GT"/>
+						<xsd:enumeration value="GU"/>
+						<xsd:enumeration value="GW"/>
+						<xsd:enumeration value="GY"/>
+						<xsd:enumeration value="HK"/>
+						<xsd:enumeration value="HM"/>
+						<xsd:enumeration value="HN"/>
+						<xsd:enumeration value="HR"/>
+						<xsd:enumeration value="HT"/>
+						<xsd:enumeration value="HU"/>
+						<xsd:enumeration value="ID"/>
+						<xsd:enumeration value="IE"/>
+						<xsd:enumeration value="IL"/>
+						<xsd:enumeration value="IM"/>
+						<xsd:enumeration value="IN"/>
+						<xsd:enumeration value="IO"/>
+						<xsd:enumeration value="IQ"/>
+						<xsd:enumeration value="IR"/>
+						<xsd:enumeration value="IS"/>
+						<xsd:enumeration value="IT"/>
+						<xsd:enumeration value="JE"/>
+						<xsd:enumeration value="JM"/>
+						<xsd:enumeration value="JO"/>
+						<xsd:enumeration value="JP"/>
+						<xsd:enumeration value="KE"/>
+						<xsd:enumeration value="KG"/>
+						<xsd:enumeration value="KH"/>
+						<xsd:enumeration value="KI"/>
+						<xsd:enumeration value="KM"/>
+						<xsd:enumeration value="KN"/>
+						<xsd:enumeration value="KP"/>
+						<xsd:enumeration value="KR"/>
+						<xsd:enumeration value="KW"/>
+						<xsd:enumeration value="KY"/>
+						<xsd:enumeration value="KZ"/>
+						<xsd:enumeration value="LA"/>
+						<xsd:enumeration value="LB"/>
+						<xsd:enumeration value="LC"/>
+						<xsd:enumeration value="LI"/>
+						<xsd:enumeration value="LK"/>
+						<xsd:enumeration value="LR"/>
+						<xsd:enumeration value="LS"/>
+						<xsd:enumeration value="LT"/>
+						<xsd:enumeration value="LU"/>
+						<xsd:enumeration value="LV"/>
+						<xsd:enumeration value="LY"/>
+						<xsd:enumeration value="MA"/>
+						<xsd:enumeration value="MC"/>
+						<xsd:enumeration value="MD"/>
+						<xsd:enumeration value="ME"/>
+						<xsd:enumeration value="MF"/>
+						<xsd:enumeration value="MG"/>
+						<xsd:enumeration value="MH"/>
+						<xsd:enumeration value="MK"/>
+						<xsd:enumeration value="ML"/>
+						<xsd:enumeration value="MM"/>
+						<xsd:enumeration value="MN"/>
+						<xsd:enumeration value="MO"/>
+						<xsd:enumeration value="MP"/>
+						<xsd:enumeration value="MQ"/>
+						<xsd:enumeration value="MR"/>
+						<xsd:enumeration value="MS"/>
+						<xsd:enumeration value="MT"/>
+						<xsd:enumeration value="MU"/>
+						<xsd:enumeration value="MV"/>
+						<xsd:enumeration value="MW"/>
+						<xsd:enumeration value="MX"/>
+						<xsd:enumeration value="MY"/>
+						<xsd:enumeration value="MZ"/>
+						<xsd:enumeration value="NA"/>
+						<xsd:enumeration value="NC"/>
+						<xsd:enumeration value="NE"/>
+						<xsd:enumeration value="NF"/>
+						<xsd:enumeration value="NG"/>
+						<xsd:enumeration value="NI"/>
+						<xsd:enumeration value="NL"/>
+						<xsd:enumeration value="NO"/>
+						<xsd:enumeration value="NP"/>
+						<xsd:enumeration value="NR"/>
+						<xsd:enumeration value="NU"/>
+						<xsd:enumeration value="NZ"/>
+						<xsd:enumeration value="OM"/>
+						<xsd:enumeration value="PA"/>
+						<xsd:enumeration value="PE"/>
+						<xsd:enumeration value="PF"/>
+						<xsd:enumeration value="PG"/>
+						<xsd:enumeration value="PH"/>
+						<xsd:enumeration value="PK"/>
+						<xsd:enumeration value="PL"/>
+						<xsd:enumeration value="PM"/>
+						<xsd:enumeration value="PN"/>
+						<xsd:enumeration value="PR"/>
+						<xsd:enumeration value="PS"/>
+						<xsd:enumeration value="PT"/>
+						<xsd:enumeration value="PW"/>
+						<xsd:enumeration value="PY"/>
+						<xsd:enumeration value="QA"/>
+						<xsd:enumeration value="RE"/>
+						<xsd:enumeration value="RO"/>
+						<xsd:enumeration value="RS"/>
+						<xsd:enumeration value="RU"/>
+						<xsd:enumeration value="RW"/>
+						<xsd:enumeration value="SA"/>
+						<xsd:enumeration value="SB"/>
+						<xsd:enumeration value="SC"/>
+						<xsd:enumeration value="SD"/>
+						<xsd:enumeration value="SE"/>
+						<xsd:enumeration value="SG"/>
+						<xsd:enumeration value="SH"/>
+						<xsd:enumeration value="SI"/>
+						<xsd:enumeration value="SJ"/>
+						<xsd:enumeration value="SK"/>
+						<xsd:enumeration value="SL"/>
+						<xsd:enumeration value="SM"/>
+						<xsd:enumeration value="SN"/>
+						<xsd:enumeration value="SO"/>
+						<xsd:enumeration value="SR"/>
+						<xsd:enumeration value="SS"/>
+						<xsd:enumeration value="ST"/>
+						<xsd:enumeration value="SV"/>
+						<xsd:enumeration value="SX"/>
+						<xsd:enumeration value="SY"/>
+						<xsd:enumeration value="SZ"/>
+						<xsd:enumeration value="TC"/>
+						<xsd:enumeration value="TD"/>
+						<xsd:enumeration value="TF"/>
+						<xsd:enumeration value="TG"/>
+						<xsd:enumeration value="TH"/>
+						<xsd:enumeration value="TJ"/>
+						<xsd:enumeration value="TK"/>
+						<xsd:enumeration value="TL"/>
+						<xsd:enumeration value="TM"/>
+						<xsd:enumeration value="TN"/>
+						<xsd:enumeration value="TO"/>
+						<xsd:enumeration value="TR"/>
+						<xsd:enumeration value="TT"/>
+						<xsd:enumeration value="TV"/>
+						<xsd:enumeration value="TW"/>
+						<xsd:enumeration value="TZ"/>
+						<xsd:enumeration value="UA"/>
+						<xsd:enumeration value="UG"/>
+						<xsd:enumeration value="UM"/>
+						<xsd:enumeration value="US"/>
+						<xsd:enumeration value="UY"/>
+						<xsd:enumeration value="UZ"/>
+						<xsd:enumeration value="VA"/>
+						<xsd:enumeration value="VC"/>
+						<xsd:enumeration value="VE"/>
+						<xsd:enumeration value="VG"/>
+						<xsd:enumeration value="VI"/>
+						<xsd:enumeration value="VN"/>
+						<xsd:enumeration value="VU"/>
+						<xsd:enumeration value="WF"/>
+						<xsd:enumeration value="WS"/>
+						<xsd:enumeration value="YE"/>
+						<xsd:enumeration value="YT"/>
+						<xsd:enumeration value="ZA"/>
+						<xsd:enumeration value="ZM"/>
+						<xsd:enumeration value="ZW"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:simpleType name="property_t">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="2048"/>
+			<xsd:minLength value="0"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="property">
+		<xsd:annotation>
+			<xsd:documentation>property elements qualify the semantic meaning of a item or
+				collection. property elements consist of a type/value pair where the property type
+				is found in the type attribute and the value is found in the element content. The
+				property element is not currently in use. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="property_t">
+					<xsd:attribute name="type" type="xsd:string" use="required"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="contributors">
+		<xsd:annotation>
+			<xsd:documentation>The container for all who contributed to authoring or editing an
+				entity.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element ref="organization"/>
+					<xsd:element ref="person_name"/>
+					<xsd:element ref="anonymous"/>		
+				</xsd:choice>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:simpleType name="organization_t">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="511"/>
+			<xsd:minLength value="1"/>
+			<xsd:whiteSpace value="collapse"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="organization">
+		<xsd:annotation>
+			<xsd:documentation>The name of an organization (as opposed to a person) that contributed
+				to authoring an entity. If multiple organizations authored an entity, each one
+				should be captured in a unique organization element. If an entity was authored by
+				individuals in addition to one or more organizations, person_name and organization
+				may be freely intermixed within contributors. contributor_role should be set, as
+				appropriate, to author or editor. When a contributor translated a work, set
+				contributor_role to "translator". "chair" should only be used for conference
+				proceedings to indicate a conference chair.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="organization_t">
+					<xsd:attributeGroup ref="contributor.atts"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="person_name">
+		<xsd:annotation>
+			<xsd:documentation>The name of a person (as opposed to an organization) that contributed
+				to authoring an entity. Authors with name suffixes should have the suffix captured
+				in suffix, not in surname. Author prefixes such as "Dr.", "Prof.", or "President"
+				should not be included in person_name or any other element. Author degrees (e.g.
+				M.D., Ph.D.) also should not be included in CrossRef submissions. contributor_role
+				should be set, as appropriate, to author or editor. When a contributor translated a
+				work, set contributor_role to "translator". "chair" should only be used for
+				conference proceedings to indicate a conference chair.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="given_name" minOccurs="0"/>
+				<xsd:element ref="surname"/>
+				<xsd:element ref="suffix" minOccurs="0"/>
+				<xsd:element ref="affiliation" minOccurs="0" maxOccurs="5"/>
+				<xsd:element ref="ORCID" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="alt-name" minOccurs="0"/>
+			</xsd:sequence>
+			<xsd:attributeGroup ref="contributor.atts"/>
+		</xsd:complexType>
+	</xsd:element>
+
+
+	<xsd:element name="anonymous">
+		<xsd:annotation>
+			<xsd:documentation> </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="affiliation" minOccurs="0" maxOccurs="5"/>
+			</xsd:sequence>
+			<xsd:attributeGroup ref="contributor.atts"/>
+		</xsd:complexType>
+	</xsd:element>	
+	
+	
+	<xsd:element name="given_name">
+		<xsd:annotation>
+			<xsd:documentation>A contributor's given name. The given_name, combined with surname,
+				forms the name of an author or editor. given_name may be submitted as either
+				initials or a full name. Do not place given_name within the surname unless it is
+				unclear how to distinguish the given name from the surname, as may be the case in
+				non-Western names. Do not include titles such as "Dr.", "Prof.", or "President" in
+				given_name. These titles should not be submitted to CrossRef.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="60"/>
+				<xsd:minLength value="1"/>
+				<xsd:pattern value="[^\d\?]*"/>
+				<xsd:whiteSpace value="collapse"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="surname">
+		<xsd:annotation>
+			<xsd:documentation>The surname of an author or editor. The surname, combined with
+				given_name, forms the name of an author or editor. Whenever possible, the given name
+				should not be included in the surname element. In cases where the given name is not
+				clear, as may happen with non-Western names or some societies in which surnames are
+				not distinguished, you may place the entire name in surname, e.g.: <surname>Leonardo
+					da Vinci</surname> If an author is an organization, you should use organization,
+				not surname. Suffixes should be tagged with suffix. Author degrees (e.g. M.D.,
+				Ph.D.) should not be included in CrossRef submissions.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="60"/>
+				<xsd:minLength value="1"/>
+				<xsd:pattern value="[^\d\?]*[^\?\s]+[^\d]*"/>
+				<xsd:whiteSpace value="collapse"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="suffix">
+		<xsd:annotation>
+			<xsd:documentation>The suffix of an author name, e.g. junior or senior. A name suffix,
+				that typically denotes a generation distinction, is tagged with suffix. Author
+				degrees (e.g. M.D., Ph.D.) should not be included in CrossRef
+				submissions.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="10"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:simpleType name="orcid_t">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="https?://orcid.org/[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[X0-9]{1}"/>			
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:element name="ORCID">
+		<xsd:annotation>
+			<xsd:documentation>The ORCID for an author. The schema performs basic pattern validation, checksum validation is performed upon deposit via a system check.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="orcid_t">
+					<xsd:attribute default="false" name="authenticated" type="xsd:boolean"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="affiliation">
+		<xsd:annotation>
+			<xsd:documentation> The institution(s) with which a contributor is affiliated. This
+				element may hold the name and location of an affiliation with which a contributor is
+				affiliated. Please note the following points when using this element: 1. A
+				contributor may have up to five affiliations. Each affiliation should be in a unique
+				&lt;affiliation&gt; element. The following is correct: &lt;affiliation&gt;University
+				of New Mexico&lt;/affiliation&gt; &lt;affiliation&gt;Sandia National
+				Laboratories&lt;/affiliation&gt; The following is NOT correct
+				&lt;affiliation&gt;University of New Mexico; Sandia National
+				Laboratories&lt;/affiliation&gt; 2. The name of the institution is required in this
+				element. The location is optional. Both of the following are correct:
+				&lt;affiliation&gt;Harvard University&lt;/affiliation&gt; &lt;affiliation&gt;Harvard
+				University, Cambridge, MA&lt;/affiliation&gt; 3. Additional address information such
+				as a URL or email address should NOT be deposited in this element 4. Visual linking
+				indicators used in publication to connect authors with their affiliations such as
+				footnote symbols or initials should NOT be included in the &lt;affiliation&gt;
+				element 5. If you have only a single string that has the affiliation for multiple
+				contributors to a work and that string is not broken out into the individual
+				affliations for each author, please do NOT deposit the affilation information. This
+				element is to be used only for affiliation information that is directly connected to
+				the author with whom this information is included within the person_name element.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="512"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="alt-name">
+		<xsd:complexType>
+			<xsd:choice maxOccurs="unbounded">
+				<xsd:element ref="name"/>
+				<xsd:element ref="string-name"/>
+			</xsd:choice>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="name">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:choice>
+					<xsd:sequence>
+						<xsd:element ref="surname"/>
+						<xsd:element minOccurs="0" ref="given_name"/>
+					</xsd:sequence>
+					<xsd:element ref="given_name"/>
+				</xsd:choice>
+				<xsd:element minOccurs="0" ref="prefix"/>
+				<xsd:element minOccurs="0" ref="suffix"/>
+			</xsd:sequence>
+			<xsd:attribute name="content-type"/>
+			<xsd:attribute name="name-style" default="western">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:token">
+						<xsd:enumeration value="western"/>
+						<xsd:enumeration value="eastern"/>
+						<xsd:enumeration value="islensk"/>
+						<xsd:enumeration value="given-only"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="specific-use"/>
+			<!--using our language.atts attribute group instead of importing xml:lang-->
+			<xsd:attributeGroup ref="language.atts"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="string-name">
+		<xsd:complexType mixed="true">
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:element ref="degrees"/>
+				<xsd:element ref="given_name"/>
+				<xsd:element ref="prefix"/>
+				<xsd:element ref="surname"/>
+				<xsd:element ref="suffix"/>
+			</xsd:choice>
+			<xsd:attribute name="content-type"/>
+			<xsd:attribute name="name-style" default="western">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:token">
+						<xsd:enumeration value="western"/>
+						<xsd:enumeration value="eastern"/>
+						<xsd:enumeration value="islensk"/>
+						<xsd:enumeration value="given-only"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="specific-use"/>
+			<xsd:attributeGroup ref="language.atts"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="prefix">
+		<xsd:complexType mixed="true">
+			<xsd:attribute name="content-type"/>
+			<xsd:attribute name="specific-use"/>
+			<xsd:attributeGroup ref="language.atts"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="degrees">
+		<xsd:complexType mixed="true">
+			<xsd:attribute name="content-type"/>
+			<xsd:attribute name="specific-use"/>
+			<xsd:attributeGroup ref="language.atts"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<!--END NAME ELEMENTs-->
+
+
+
+	<xsd:element name="titles">
+		<xsd:annotation>
+			<xsd:documentation>A container for the title and original language title
+				elements.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:sequence>
+					<xsd:element ref="title"/>
+					<xsd:element ref="subtitle" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:sequence minOccurs="0">
+					<xsd:element ref="original_language_title"/>
+					<xsd:element ref="subtitle" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="title">
+		<xsd:annotation>
+			<xsd:documentation>The title of the entity being registered. When a title contains a
+				subtitle, it is preferable to capture the subtitle portion in the subtitle element.
+				Only minimal face markup is supported, see https://support.crossref.org/hc/en-us/articles/214532023</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType mixed="true">
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:group ref="face_markup"/>
+			</xsd:choice>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="original_language_title">
+		<xsd:annotation>
+			<xsd:documentation>The title of an entity in its original language if the registration
+				is for a translation of a work. When providing the original language of a title, you
+				should set the language attribute.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType mixed="true">
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:group ref="face_markup"/>
+
+			</xsd:choice>
+			<xsd:attributeGroup ref="language.atts"/>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="subtitle">
+		<xsd:annotation>
+			<xsd:documentation>The sub-title portion of an entity title. When possible, it is better
+				to tag a title and subtitle with separate elements. If this information is not
+				available, it is acceptable to submit the title and subtitle all within the title
+				element with punctuation (preferably a colon) used to separate the subtitle from the
+				title. When a subtitle is tagged, the space and punctuation between the title and
+				subtitle text should not be included. The following examples illustrate correct and
+				incorrect tagging practices: Correct and optimal tagging: <title>The Human
+					Brain</title>
+				<subtitle>A Handbook</subtitle> Correct but not optimal tagging: <title>The Human
+					Brain: A Handbook</title> Incorrect: <title>The Human Brain: </title>
+				<subtitle>A Handbook</subtitle>
+				<title>The Human Brain</title>
+				<subtitle>: A Handbook</subtitle></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType mixed="true">
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:group ref="face_markup"/>
+
+			</xsd:choice>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="month" type="xrefMonth">
+		<xsd:annotation>
+			<xsd:documentation>Month of publication. The month must be expressed in numeric format
+				rather spelling out the name (e.g.. submit "10", not "October"). The month must be
+				expressed with a leading zero if it is less than 10 (e.g. submit "05", not "5").
+				When a journal issue has both an issue number and a season, the issue number should
+				be placed in issue. If the month of publication is not known, the season should be
+				placed in month as a two-digit value as follows: Season Value Spring 21 Summer 22
+				Autumn 23 Winter 24 First Quarter 31 Second Quarter 32 Third Quarter 33 Fourth
+				Quarter 34 In cases when an issue covers multiple months, e.g. "March-April",
+				include only the digits for the first month of the range.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	
+	<!--============  Date related elements ========== -->
+	
+	<xsd:element name="day" type="xrefDay">
+		<xsd:annotation>
+			<xsd:documentation>Day of publication. The should must be expressed with a leading zero
+				if it is less than 10 (e.g. submit "05", not "5").</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="year" type="xrefYear">
+		<xsd:annotation>
+			<xsd:documentation>Year of publication.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="database_date">
+		<xsd:annotation>
+			<xsd:documentation>database_date records key dates in the life of a database or dataset item.
+				
+				Within database_date, creation_date is the date the item was first created, publication_date is the date the item was first published, and update_date is the date the item was last updated.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="creation_date" minOccurs="0"/>
+				<xsd:element ref="publication_date" minOccurs="0"/>
+				<xsd:element ref="update_date" minOccurs="0"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="creation_date">
+		<xsd:annotation>
+			<xsd:documentation>The date a database or dataset item was created.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="date_t"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	
+	<xsd:element name="content_date">
+		<xsd:annotation>
+			<xsd:documentation>The date a content item was created.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="date_t"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	
+	<xsd:element name="posted_date">
+		<xsd:annotation>
+			<xsd:documentation>The date a pre-print was posted to a repository.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="date_t"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	
+	<xsd:element name="acceptance_date">
+		<xsd:annotation>
+			<xsd:documentation>The date a manuscript was accepted for publication.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="date_t"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	
+	<xsd:element name="update_date">
+		<xsd:annotation>
+			<xsd:documentation>The date a database or dataset item was updated.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="date_t"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	
+	<xsd:element name="publication_date">
+		<xsd:annotation>
+			<xsd:documentation>The date of publication. In all cases, multiple dates are allowed to
+				allow for different dates of publication for online and print versions. This element
+				was previously called date, but was renamed publication_date to distinguish more
+				clearly from conference_date.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="date_t"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="date_t">
+		<xsd:sequence>
+			<xsd:element ref="month" minOccurs="0"/>
+			<xsd:element ref="day" minOccurs="0"/>
+			<xsd:element ref="year"/>
+		</xsd:sequence>
+		<xsd:attribute name="media_type" default="print">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:NMTOKEN">
+					<xsd:enumeration value="online"/>
+					<xsd:enumeration value="print"/>
+					<xsd:enumeration value="other"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:complexType>
+	
+	
+	<xsd:element name="review_date">
+		<xsd:annotation>
+			<xsd:documentation>The date a review was published to a repository.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="month"  />
+				<xsd:element ref="day"/>
+				<xsd:element ref="year"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	
+	<!--============   end various dates ========== -->
+	
+	<xsd:element name="pages">
+		<xsd:annotation>
+			<xsd:documentation>The container for information about page ranges. When an entity has
+				non-contiguous page information, you should capture the first page range in
+				first_page and last_page. Any additional page information should be captured in
+				other_pages. Punctuation is only allowed in other_pages. It should not appear in
+				first_page and last_page. Page number letter prefixes or suffixes should be
+				included. Roman numeral pages are permitted in both upper case and lower case. Data
+				may be alpha, numeric or a combination.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="first_page"/>
+				<xsd:element ref="last_page" minOccurs="0"/>
+				<xsd:element ref="other_pages" minOccurs="0"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="first_page">
+		<xsd:annotation>
+			<xsd:documentation>First page number where an entity is located. Data may be alpha,
+				numeric or a combination.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="32"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="last_page">
+		<xsd:annotation>
+			<xsd:documentation>The last page number of an entity. last_page should not be used when
+				the last page number is the same as the first page number (i.e. when the entire
+				entity fits on one page). Do not include punctuation for a page range in last_page.
+				If the entity has non-contiguous paging, use last_page for the last page of the
+				first range and place all other page information into other_pages. Data may be
+				alpha, numeric or a combination.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="32"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="other_pages">
+		<xsd:annotation>
+			<xsd:documentation>Used to capture additional page information when items do not
+				encompass contiguous page ranges. When an entity has non-contiguous page
+				information, you should capture the first page range in first_page and last_page.
+				Any additional page information should be captured in other_pages. You should
+				include commas or hyphens to express discrete pages or page ranges. endash entities
+				should be converted to ASCII hyphens. Spaces should not be included. Note that
+				punctuation should never appear in first_page and last_page. Data may be alpha,
+				numeric or a combination.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="100"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:simpleType name="doi_t">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="2048"/>
+			<xsd:minLength value="6"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="doi">
+		<xsd:annotation>
+			<xsd:documentation>DOI for an entity being registered with CrossRef.  In 2008 CrossRef restricted DOI suffix 
+				characters to the following: "a-z", "A-Z", "0-9" and "-._;()/" 
+				
+				Existing DOIs with suffix characters outside of the allowed set are still supported.  For additional
+				information on DOI syntax, see https://support.crossref.org/hc/en-us/articles/214669823</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="doi_t"/>
+		</xsd:simpleType>
+	</xsd:element>
+
+	<!--additions for CrossMark -->
+	<xsd:simpleType name="cm_domain">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="1024"/>
+			<xsd:minLength value="4"/>
+			<xsd:pattern
+				value="[A-Za-z0-9_]+([-.][A-Za-z0-9_]+)*\.[A-Za-z0-9_]+([-.][A-Za-z0-9_]+)*"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="cm_update_type">
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="addendum"/>
+			<xsd:enumeration value="clarification"/>
+			<xsd:enumeration value="correction"/>
+			<xsd:enumeration value="corrigendum"/>
+			<xsd:enumeration value="erratum"/>
+			<xsd:enumeration value="expression_of_concern"/>
+			<xsd:enumeration value="new_edition"/>
+			<xsd:enumeration value="new_version"/>
+			<xsd:enumeration value="partial_retraction"/>
+			<xsd:enumeration value="removal"/>
+			<xsd:enumeration value="retraction"/>
+			<xsd:enumeration value="withdrawal"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="cm_assertion">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="1024"/>
+			<xsd:minLength value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="cm_assertion_name">
+		<xsd:restriction base="xsd:NCName">
+			<xsd:maxLength value="150"/>
+			<xsd:minLength value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="cm_assertion_label">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="150"/>
+			<xsd:minLength value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="cm_assertion_group_name">
+		<xsd:restriction base="xsd:NCName">
+			<xsd:maxLength value="150"/>
+			<xsd:minLength value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="cm_assertion_group_label">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="150"/>
+			<xsd:minLength value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="isbn_t">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="17"/>
+			<xsd:minLength value="10"/>
+			<xsd:pattern value="(978-)?\d[\d \-]+[\dX]"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="isbn">
+		<xsd:annotation>
+			<xsd:documentation>The ISBN assigned to an entity. If a multi-volume work has one ISBN
+				per volume and a unique ISBN for the series, all may be registered. The ISBN for the
+				series must be in series_metadata, and the ISBN for each volume in
+				proceedings_metadata, or book_metadata, respectively. The text "ISBN" should not be
+				included in the ISBN element in CrossRef submissions. Although not required, the
+				ISBN number should retain spaces or hyphens that appear in the formatted number
+				because they aid in human-readability. For more information, please see
+				http://www.isbn.org/standards/home/isbn/international/hyphenation- instructions.asp
+				or http://www.isbn.org.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="isbn_t">
+					<xsd:attributeGroup ref="media_type.atts"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="noisbn">
+		<xsd:annotation>
+			<xsd:documentation>Identifies books or conference proceedings that have no ISBN
+				assigned. In very limited cases a book may never have an ISBN, this is particularly
+				true for older texts. Conference proceedings, however, may regularly have a volume
+				number but no ISBN or volume title. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="reason" use="required">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:NMTOKEN">
+						<xsd:enumeration value="archive_volume"/>
+						<xsd:enumeration value="monograph"/>
+						<xsd:enumeration value="simple_series"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+	
+	<xsd:simpleType name="issn_t">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="9"/>
+			<xsd:minLength value="8"/>
+			<xsd:pattern value="\d{4}-?\d{3}[\dX]"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:element name="issn">
+		<xsd:annotation>
+			<xsd:documentation>The ISSN assigned to an entity. The ISSN must consist of eight digits
+				(where the last digit may be an X), or it must consist of eight digits in two groups
+				of four with a hyphen between the two groups. Spaces or other delimiters should not
+				be included in an ISSN. For more information, please see
+				http://www.issn.org:8080/English/pub/getting- checking/checking or
+				http://www.issn.org. The text "ISSN" should not be included in the issn element in
+				CrossRef submissions. CrossRef validates all ISSNs supplied in deposits, only valid
+				ISSNs will be accepted.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="issn_t">
+					<xsd:attributeGroup ref="media_type.atts"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="coden">
+		<xsd:annotation>
+			<xsd:documentation>The coden assigned to a journal or conference
+				proceedings.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="6"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+	<xsd:element name="volume">
+		<xsd:annotation>
+			<xsd:documentation>The volume number of a published journal, or the number of a printed
+				volume for a book or conference proceedings. A journal volume is contained in the
+				journal_volume element to allow for the assignment of a DOI to an entire journal
+				volume. Do not include the words "Volume" or "vol." in this element. Data may be
+				alpha, numeric or a combination. Roman numerals are acceptable. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleType>
+			<xsd:restriction base="xsd:string">
+				<xsd:maxLength value="32"/>
+				<xsd:minLength value="1"/>
+			</xsd:restriction>
+		</xsd:simpleType>
+	</xsd:element>
+
+
+	<!--archiving elements-->
+	<xsd:element name="archive_locations">
+		<xsd:annotation>
+			<xsd:documentation>Container element for archive. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element maxOccurs="unbounded" minOccurs="0" ref="archive"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="archive">
+		<xsd:annotation>
+			<xsd:documentation>Used to indicate the designated archiving organization(s) for an
+				item. Values for the name attribute are CLOCKSS, LOCKSS Portico, KB, DWT (Deep Web
+				Technologies), Internet Archive</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="name" use="required">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:string">
+						<xsd:enumeration value="CLOCKSS"/>
+						<xsd:enumeration value="LOCKSS"/>
+						<xsd:enumeration value="Portico"/>
+						<xsd:enumeration value="KB"/>
+						<xsd:enumeration value="Internet Archive"/>
+						<xsd:enumeration value="DWT"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="approval_date">
+		<xsd:annotation>
+			<xsd:documentation> The date on which a dissertation was accepted by the institution
+				awarding the degree, a report was approved, or a standard was accepted.
+				approval_date includes the same elements as publication_date, but it has no
+				attributes. It is a distinct element from publication_date to reflect that an
+				important but different semantic meeting from publication_date </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="date_t"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<!-- =============================================================
+
+           7. Elements used for citation deposit and XML queries
+
+     ============================================================= -->
+	<xsd:element name="citation_list">
+		<xsd:annotation>
+			<xsd:documentation>A list of articles, books, and other items cited by the parent item
+				for which the DOI in the doi_data is being deposited. Some articles may have
+				multiple lists of citations (e.g. main reference list, appendix reference list,
+				etc.). All citations for one article should be included in a single citation_list
+				regardless of whether one or more citation lists were in the original item. When
+				combining multiple reference lists from an item into one citation_list element, but
+				sure to give each citation a unique key attribute value. For example, if an appendix
+				in an item has a separate citation list that restarts numbering at 1, these
+				citations should be given key attributes such as "ab1" rather than "b1". Some
+				articles may contain "Further Reading" or "Bibliography" lists. The distinguishing
+				factor in these lists is that the references have not been cited from the
+				article—they only provide a list of additional related reading material. It will be
+				left to the discretion of the publisher if these items are to be considered
+				citations and should be deposited. NOTE: If a citation_list element is given and is
+				empty then all citations for the given DOI will be deleted, otherwise any existing
+				citations for the given DOI are left intact in the database. It is quite common that
+				a publisher wants to fix the DOI's metadata without resubmitting the citations.
+				Leaving out the citation_list element will do that. Also note that any given
+				citations will override older citations for the given DOI so citation_lists are not
+				cumulative over multiple records or submissions. </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="citation" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="citation_t">
+		<xsd:all>
+			<xsd:element ref="issn" minOccurs="0"/>
+			<xsd:element ref="journal_title" minOccurs="0"/>
+			<xsd:element ref="author" minOccurs="0"/>
+			<xsd:element ref="volume" minOccurs="0"/>
+			<xsd:element ref="issue" minOccurs="0"/>
+			<xsd:element ref="first_page" minOccurs="0"/>
+			<xsd:element ref="elocation_id" minOccurs="0"/>
+			<xsd:element ref="cYear" minOccurs="0"/>
+			<xsd:element ref="doi" minOccurs="0"/>
+			<!-- book/conf.    specific elements -->
+			<xsd:element ref="isbn" minOccurs="0"/>
+			<xsd:element ref="series_title" minOccurs="0"/>
+			<xsd:element ref="volume_title" minOccurs="0"/>
+			<xsd:element ref="edition_number" minOccurs="0"/>
+			<xsd:element ref="component_number" minOccurs="0"/>
+			<!--  end of book/conf. specific elements-->
+			<xsd:element ref="article_title" minOccurs="0"/>
+			<!--standard-specific elements-->
+			<xsd:element ref="std_designator" minOccurs="0"/>
+			<xsd:element ref="standards_body" minOccurs="0" maxOccurs="1"/>
+			<!-- Citation text as it appears in    the    article    , future placeholder -->
+			<xsd:element ref="unstructured_citation" minOccurs="0"/>
+		</xsd:all>
+	</xsd:complexType>
+	<!--
+    The citation element is used to deposit each citation in a citation list
+    -->
+	<xsd:element name="citation">
+		<xsd:annotation>
+			<xsd:documentation>citation is used to deposit each citation in the reference list of the item for which the DOI is being deposited. For details see: https://crossref.zendesk.com/hc/en-us/articles/215578403  </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="citation_t">
+					<xsd:attributeGroup ref="citation_key.atts"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<!-- =============================================================
+
+           Attributes used for citation deposit and XML queries
+
+     ============================================================= -->
+
+	<xsd:attributeGroup name="citation_key.atts">
+		<xsd:annotation>
+			<xsd:documentation>citation_key allows the publisher to assign a unique ID to each
+				citation that is deposited. It is recommended that this attribute be given the
+				reference number if the publication uses reference numbers. For those publications
+				that use name/date style citations, it is recommended that this attribute be used to
+				indicate the sequential number of the citation in the reference list. However, some
+				schema must be utilized as this is a required attribute. The system will use this
+				key value to track the specific reference query and will return this value along
+				with the DOI.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="key" type="xsd:string" use="required"/>
+	</xsd:attributeGroup>
+	<!-- =============================================================
+
+           Sub-elements use for citation deposit and XML queries
+
+     ============================================================= -->
+	<xsd:element name="unstructured_citation">
+		<xsd:annotation>
+			<xsd:documentation>A citation that is to an item other than a journal article, book, or
+				conference paper and cannot be structured with the CrossRef citation model. Also, it
+				is used for a citation to a journal article, book, or conference paper for which the
+				depositing publisher does not have structured information. unstructured_citation
+				allows a publisher to deposit references for which no structural information is
+				available. These may be journal, book, or conference references for which the
+				supplier did not provide markup, or other types of references (e.g. standards,
+				patents, etc) which are not supported by CrossRef. This structure permits publishers
+				to deposit complete reference lists, without regard to the availability of markup,
+				or the need to parse references beyond those types that CrossRef supports.
+				CrossRef's ability to process unstructured citations is limited, for details see
+				https://support.crossref.org/hc/en-us/articles/215007383</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType mixed="true">
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:group ref="face_markup"/>
+			</xsd:choice>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="journal_title" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>Journal title in a citation. Only used in the citation element.
+				Journal title in citation deposits is used for both abbreviated and spelled out
+				journal names. No attribute is required to distinguish between name types. Both
+					<journal_title>Proc. Natl. Acad. Sci. U.S.A.</journal_title> and
+					<journal_title>Proceedings of the National Academy of Sciences of the United
+					States of America</journal_title> are valid journal titles to use in this
+				element.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="series_title" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>Book series title in a citation. Only used in the citation element.
+				series_title is an element for the deposit of book or conference series titles in
+				citations without the hierarchy required by the series_metadata element. Note that
+				face markup is not permitted when this element is deposited as part of a
+				citation.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="volume_title" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>Book volume title in a citation. Only used in the citation element.
+				volume_title is an element for the deposit of book or conference volume titles in
+				citations without the hierarchy required by the titles element. Note that face
+				markup is not permitted when this element is deposited as part of a
+				citation.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="author" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>First author in a citation. Only used in the citation element. The
+				author element tags one author name in a citation without the hierarchy required by
+				the contributors or person_name elements Only the first author should be deposited
+				for each item. The author surname is required. Author initials may be added but are
+				not recommended because queries work best when only the last name is provided. For
+				example, the author "John Doe" can be deposited as <author>Doe</author> or
+					<author>Doe J</author>, but the former style is recommended. If the author of a
+				work is an organization rather than a person, the organization may be deposited as
+				in: <author>World Health Organization</author></xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="cYear" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>Year of publication in citation. Unlike the year element, cYear has a
+				loose text model that can accommodate non-standard years such as year ranges such as
+				"1998-1999". Note that years such as "1998a" or "1999b" should be deposited without
+				the letter, e.g. "1998" or "1999". The letter is used for internal source document
+				linking in name/date (Harvard) style documents rather than external cross reference
+				linking to the original item.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="article_title" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>Article title in a citation. Use care to remove face markup (such as
+				italic applied to genus or species names) from article titles as this markup is not
+				supported by CrossRef.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+    <xsd:element name="elocation_id" type="xsd:string">
+         <xsd:annotation>
+            <xsd:documentation>article number or other page identifier for an article that does not have page numbers, used typically for electronic-only journals.</xsd:documentation>
+         </xsd:annotation>
+    </xsd:element>
+	<!-- =============================================================
+
+           8. Elements used to deposit components
+
+     ============================================================= -->
+
+	<xsd:element name="sa_component">
+		<xsd:annotation>
+			<xsd:documentation>The element for depositing a stand alone component. The parent DOI
+				must already exist (created in an earlier deposit or via some other registration
+				process).</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="component_list"/>
+			</xsd:sequence>
+			<xsd:attribute name="parent_doi" use="required">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:string">
+						<xsd:maxLength value="2048"/>
+						<xsd:minLength value="6"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="component_list">
+		<xsd:annotation>
+			<xsd:documentation>The wrapper element for including a group of components under a
+				journal article, conference proceeding, book chapter, stand alone component,
+				dissertation, technical report or working paper, standard, or
+				database.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="component" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="component">
+		<xsd:annotation>
+			<xsd:documentation>A container element that allows registration of supplemental
+				information for a journal article, book chapter, or conference paper such as
+				figures, tables, videos, or data sets. Currently, the deposit of components
+				primarily achieves only the first objective as the CrossRef system is not setup yet
+				to support queries for components. The metadata associated with a component is
+				intended to enable simple lookup searches of components in the future. When
+				deposited as part of the metadata for a higher level work the parent DOI is
+				implicitly known via the XML hierarchy. When deposited separately the DOI of the
+				higher level work must be provided explicitly (see sa_component) All descriptive
+				elements are optional allowing for the creation of simple anonymous DOIs. The
+				'parent_relation' attribute is mandatory and refers to the DOI described in the
+				component's direct parent.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="titles" minOccurs="0"/>
+				<xsd:element ref="contributors" minOccurs="0"/>
+				<xsd:element ref="publication_date" minOccurs="0"/>
+				<xsd:element ref="description" minOccurs="0"/>
+				<xsd:element ref="format" minOccurs="0"/>
+				<xsd:element ref="ai:program" minOccurs="0"/>
+				<xsd:choice>
+					<xsd:element ref="doi_data"/>
+					<xsd:element ref="doi"/>
+				</xsd:choice>
+
+			</xsd:sequence>
+			<xsd:attribute name="parent_relation" use="required">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:NMTOKEN">
+						<xsd:enumeration value="isPartOf"/>
+						<xsd:enumeration value="isReferencedBy"/>
+						<xsd:enumeration value="isRequiredBy"/>
+						<xsd:enumeration value="isTranslationOf"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="reg-agency" use="optional">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:string"/>
+
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attributeGroup ref="language.atts"/>
+			<xsd:attribute name="component_size">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:nonNegativeInteger"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="unassigned_content">
+		<xsd:annotation>
+			<xsd:documentation>Normally book content that is published as a series is required to
+				have a series title with an ISSN and a book title and/or a book volume number along
+				with a book ISBN. An exception is when book chapters are published on line first
+				prior to being assigned to a specific book in which case only the series title (and
+				ISSN) is known at time of DOI registration. Element unassigned_content is used as a
+				placeholder to force recognition of this condition and thus prevent accidental
+				omission of book level title information. When unassigned_content is present the
+				system will allow omission of the ISBN. If unassigned_content is not present the
+				system will require an ISBN for the book title.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="type" use="required">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:NMTOKEN">
+						<xsd:enumeration value="aheadOfPrint"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="description">
+		<xsd:annotation>
+			<xsd:documentation>A narrative description of a file (e.g. a figure caption or
+				video description) which may be independent of the host document context. The
+				description element may be present more than once to provide alternative language
+				values.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType mixed="true">
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:group ref="face_markup"/>
+			</xsd:choice>
+			<xsd:attributeGroup ref="language.atts"/>
+		</xsd:complexType>
+	</xsd:element>
+	
+	<xsd:element name="intent_statement">
+		<xsd:annotation>
+			<xsd:documentation>Publisher's custom statement for their intent to publish content for which a pre-register DOI has been created</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType mixed="true">
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:group ref="face_markup"/>
+			</xsd:choice>
+			<xsd:attributeGroup ref="language.atts"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="competing_interest_statement">
+		<xsd:annotation>
+			<xsd:documentation>Statement of competing interest supplied by a review author during the review process.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType mixed="true">
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:group ref="face_markup"/>
+			</xsd:choice>
+			<xsd:attributeGroup ref="language.atts"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="running_number" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>Running numbers to specify the various reports (ex: RC1 to RC4) </xsd:documentation>
+			</xsd:annotation>
+	</xsd:element>	
+	
+	
+	<xsd:simpleType name="format_t">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="130"/>
+			<xsd:minLength value="0"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:element name="format">
+		<xsd:annotation>
+			<xsd:documentation>A narrative description of a component's file format and/or the file
+				extension (for mime types refer to http://www.iana.org/assignments/media-types/) The
+				format element may contain only the mime_type attribute, or in addition it may
+				contain a narrative description of the file format. Be sure to use the narrative
+				portion to description only the format of the component and not the actual content
+				of the component (use description to describe the component's
+				content).</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="format_t">
+					<xsd:attributeGroup ref="mime_type.atts"/>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<!-- =============================================================
+		
+		9. CrossMark Elements
+		
+		============================================================= -->
+	<xsd:element name="crossmark">
+		<xsd:annotation>
+			<xsd:documentation>Container element for CrossMark data.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence minOccurs="0">
+				<xsd:element ref="crossmark_version" minOccurs="0"/>
+				<xsd:element ref="crossmark_policy"/>
+				<xsd:element ref="crossmark_domains" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="crossmark_domain_exclusive" minOccurs="0">
+					<xsd:annotation>
+						<xsd:documentation>Some publishers encourage broad third
+							party hosting of the publisher's content. Other publishers do not. And
+							still others vary their policy depending on whether a particular article
+							has been published under an OA policy or not. This boolean flag allows
+							the publisher to indicate whether the CrossMarked content will only
+							legitimately be updated on the CrossMark domain (true) or whether the
+							publisher encourages updating the content on other sites as well
+							(false).</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:sequence minOccurs="0">
+					<xsd:element ref="updates" minOccurs="0"/>
+					<xsd:element ref="custom_metadata" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="crossmark_policy" type="doi_t">
+		<xsd:annotation>
+			<xsd:documentation>A DOI which points to a publisher's CrossMark policy document.
+				Publishers might have different policies for different
+				publications.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="crossmark_version" type="xsd:string"/>
+	<xsd:element name="crossmark_domains">
+		<xsd:annotation>
+			<xsd:documentation>Container element for crossmark_domain. A list of domains where the
+				publisher maintains updates and corrections to their content. Minimally, one of
+				these should include the Internet domain name of the publisher's web site(s), but
+				the publisher might also decide to include 3rd party aggregators (e.g. Ebsco,
+				IngentaConnect) or archives with which the publisher has agreements to update the
+				content </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element maxOccurs="unbounded" ref="crossmark_domain"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="crossmark_domain">
+		<xsd:annotation>
+			<xsd:documentation>This should be a simple Internet domain name or subdomain name (e.g.
+				www.psychoceramics.org or psychoceramics.org). It is used to identify when a
+				referring URL is coming from a CrossMark domain. A "crossmark_domain" is made up of
+				two subelements; a "domain" and a "filter". The domain is required but the filter is
+				optional and is only needed for use in situations where content from multiple
+				publishers/publications is on the same host with the same domain name (e.g. an
+				aggregator) and one needs to use the referrer's URI "path" to further determine
+				whether the content in a crossmark domain.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="domain"/>
+				<xsd:element minOccurs="0" ref="filter"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="domain" type="cm_domain">
+		<xsd:annotation>
+			<xsd:documentation>Required element. This should be a simple Internet domain name or
+				subdomain name (e.g. www.psychoceramics.org or psychoceramics.org). It is used to
+				identify when a referring URL is coming from a CrossMark domain.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="filter" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>Optional element. The filter element is used to disambiguate content
+				in situations where multiple publishers share the same host (e.g. when on an
+				aggregated platform). It should contain a substring of the path that can be used to
+				uniquely identify a publisher's or publication's content. For instance, using the
+				string "alpsp" here would help the CrossMark system distinguish between ALPSP
+				publications on the ingentaconnect host and other publications on the same
+				host.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="crossmark_domain_exclusive" type="xsd:boolean"/>
+	<xsd:element name="updates">
+		<xsd:annotation>
+			<xsd:documentation>Optional element. A document might provide updates (e.g. corrections,
+				clarifications, retractions) to several other documents. When this is the case, the
+				DOIs of the documents that are being *updated* should be listed
+				here.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element maxOccurs="unbounded" ref="update"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="update">
+		<xsd:annotation>
+			<xsd:documentation>The DOI of the content being updated (e.g. corrected, retracted,
+				etc.) In the CrossMark Terms and Conditions "updates" are defined as changes that
+				are likely to "change the reader’s interpretation or crediting of the work." That
+				is, *editorially significant* changes. "Updates" should not include minor changes to
+				spelling, punctuation, formatting, etc. Attributes: label: Required attribute. This
+				should be a human-readable version of the "type" attribute. This is what gets
+				displayed in the CrossMark dialog when there is an update. type: Required attribute.
+				This attribute should be used to give the machine-readable name of the update type.
+				The human-readable version of the type should be but in the "label" attribute. There
+				are many "types" of updates. "Corrections, "clarifications", "retractions" and
+				"withdrawals" are just a few of the better-known types. For these common types we
+				recommend you use the values "correction", "clarification", "retraction" and
+				"withdrawal" respectively as per your editorial policy. However, different
+				publishers sometimes have to support different, custom update types- for instance,
+				"protocol amendments", "letters of concern", "comments", etc. The attribute supports
+				custom types as well. date: The date of the update will be displayed in the
+				CrossMark dialog and can help the researcher easily tell whther they are likley to
+				have seen the update.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType mixed="true">
+			<xsd:simpleContent>
+				<xsd:extension base="doi_t">
+					<xsd:attribute name="type" use="required" type="cm_update_type">
+						<xsd:annotation>
+							<xsd:documentation>Required attribute. This attribute should be used to
+								list the update type. Allowed update types are:
+									<ul>
+										<li>addendum</li>
+										<li>clarification</li>
+										<li>correction</li>
+										<li>corrigendum</li>
+										<li>erratum</li>
+										<li>expression_of_concern</li>
+										<li>new_edition</li>
+										<li>new_version</li>
+										<li>partial_retraction</li>
+										<li>removal</li>
+										<li>retraction</li>
+										<li>withdrawal</li>
+									</ul>
+							
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="date" use="required" type="xsd:date">
+						<xsd:annotation>
+							<xsd:documentation>Required attribute. The date of the update will be
+								displayed in the CrossMark dialog and can help the researcher easily
+								tell whther they are likley to have seen the
+								update.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="custom_metadata">
+		<xsd:annotation>
+			<xsd:documentation>Optional element. Publishers are encouraged to provided any
+				non-bibliographical metadata that they feel might help the researcher evaluate and
+				make better use of the content that the Crossmark record refers to. For example,
+				publishers might want to provide funding information, clinical trial numbers,
+				information about the peer-review process or a summary of the publication history of
+				the document.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:choice>
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" minOccurs="1" ref="assertion"/>
+					<xsd:element maxOccurs="1" ref="fr:program" minOccurs="0" />
+					<xsd:element maxOccurs="1" ref="ai:program" minOccurs="0"/>
+					<xsd:element maxOccurs="1" ref="ct:program" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" ref="fr:program" minOccurs="1"/>
+					<xsd:element maxOccurs="1" ref="ai:program" minOccurs="0"/>
+					<xsd:element maxOccurs="1" ref="ct:program" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" ref="ai:program" minOccurs="1"/>
+					<xsd:element maxOccurs="1" ref="ct:program" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:element ref="ct:program" minOccurs="1" maxOccurs="1"/>
+			</xsd:choice>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="assertion">
+		<xsd:annotation>
+			<xsd:documentation>An assertion is a piece of custom, non-bibliographic metadata that
+				the publisher is asserting about the content to which the CrossMark refers.
+				assertion attributes: explanation: If the publisher wants to provide a further
+				explanation of what the particular "assertion" means, they can link to such an
+				explanation by providing an appropriate url on the "explanation" attribute.
+				group_label: This is the human-readable form of the "group_name" attribute. This is
+				what will be displayed in the group headings on the CrossMark metadata record
+				dialog. group_name: Some assertions could be logically "grouped" together in the
+				CrossMark dialog. For instance, if the publisher is recording several pieces of
+				metadata related to funding sources (source name, percentage, grant number), they
+				may want to make sure that these three assertions are grouped next to each-other in
+				the CrossMark dialog. The group_name attribute is the machine-readable value that
+				will be used for grouping such assertions. label: This is the human-readable version
+				of the name attribute which will be displayed in the CrossMark dialog. If this
+				attribute is missing, then the value of the assertion will *not* be displayed in the
+				dialog. Publishers may want to "hide" assertions this way in cases where the
+				assertion value is too large or too complex to display in the dialog, but where the
+				assertion is nonetheless valuable enough to include in API queries and metadata
+				dumps (e.g. detailed licensing terms). name: This is the machine-readable name of
+				the assertion. Use the "label" attribute to provide a human-readable version of the
+				name. order: The publisher may want to control the order in which assertions are
+				displayed to the user in the CrossMark dialog. All assertions will be sorted by this
+				element if it is present.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType mixed="true">
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:group ref="face_markup"/>
+			</xsd:choice>
+			<xsd:attribute name="explanation" type="xsd:anyURI">
+				<xsd:annotation>
+					<xsd:documentation>Optional attribute. If the publisher wants to provide a
+						further explanation of what the particular "assertion" means, they can link
+						to such an explanation by providing an appropriate url on the "explanation"
+						attribute.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="group_label" type="cm_assertion_group_label">
+				<xsd:annotation>
+					<xsd:documentation>Optional attribute. This is the human-readable form of the
+						"group_name" attribute. This is what will be displayed in the group headings
+						on the CrossMark metadata record dialog.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="group_name" type="cm_assertion_group_name">
+				<xsd:annotation>
+					<xsd:documentation>Optional attribute. Some assertions could be logically
+						"grouped" together in the CrossMark dialog. For instance, if the publisher
+						is recording several pieces of metadata related to funding sources (source
+						name, percentage, grant number), they may want to make sure that these three
+						assertions are grouped next to each-other in the CrossMark dialog. The
+						group_name attribute is the machine-readable value that will be used for
+						grouping such assertions.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="label" type="cm_assertion_label">
+				<xsd:annotation>
+					<xsd:documentation>Optional attribute. This is the human-readable version of the
+						name attribute which will be displayed in the CrossMark dialog. If this
+						attribute is missing, then the value of the assertion will *not* be
+						displayed in the dialog. Publishers may want to "hide" assertions this way
+						in cases where the assertion value is too large or too complex to display in
+						the dialog, but where the assertion is nonetheless valuable enough to
+						include in API queries and metadata dumps (e.g. detailed licensing
+						terms)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="name" use="required" type="cm_assertion_name">
+				<xsd:annotation>
+					<xsd:documentation>Required attribute. This is the machine-readable name of the
+						assertion. Use the "label" attribute to provide a human-readable version of
+						the name.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="order" type="xsd:integer">
+				<xsd:annotation>
+					<xsd:documentation>Optional attribute. The publisher may want to control the
+						order in which assertions are displayed to the user in the CrossMark dialog.
+						All assertions will be sorted by this element if it is
+						present.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="href" type="xsd:anyURI">
+				<xsd:annotation>
+					<xsd:documentation>Optional attribute</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<!-- =============================================================
+		
+		10. Elements for Standards
+		
+		============================================================= -->
+	<xsd:element name="designators">
+		<xsd:annotation>
+			<xsd:documentation>A wrapper for designators or other primary identifiers for a
+				standard.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:choice>
+					<xsd:sequence>
+						<xsd:choice>
+							<xsd:element ref="std_family_designator" minOccurs="0" maxOccurs="1"/>
+						<xsd:choice>
+					   	   <xsd:element ref="std_set_designator" minOccurs="0" maxOccurs="1"/>
+						   <xsd:element ref="std_undated_designator" minOccurs="0" maxOccurs="1"/>	
+						</xsd:choice>
+						</xsd:choice>
+					</xsd:sequence>
+					<xsd:sequence>
+				  		<xsd:element ref="std_as_published" minOccurs="0" maxOccurs="1"/>					
+						<xsd:element ref="std_alt_as_published" minOccurs="0" maxOccurs="unbounded"/>
+					</xsd:sequence>
+				</xsd:choice>
+				<xsd:element ref="std_supersedes" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="std_adopted_from" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="std_revision_of" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="std_as_published">
+		<xsd:annotation>
+			<xsd:documentation>Designator or other primary identifier for the standard being
+				deposited. Required.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="std_designator_t">
+ 					   <xsd:attribute name="family" type="xsd:string"/>
+				   	   <xsd:attribute name="set" type="xsd:string"/>
+		               <xsd:attribute name="undated" type="xsd:string"/>	
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	
+	</xsd:element>
+
+	<xsd:element name="std_alt_as_published">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="std_designator_t">
+					<xsd:attribute name="reason" use="required">
+						<xsd:simpleType>
+							<xsd:list>
+								<xsd:simpleType>
+									<xsd:restriction base="xsd:NMTOKEN">
+										<xsd:enumeration value="editorial"/>
+										<xsd:enumeration value="revision"/>
+										<xsd:enumeration value="reapproval"/>
+										<xsd:enumeration value="correction"/>
+										<xsd:enumeration value="amendment"/>
+									</xsd:restriction>
+								</xsd:simpleType>
+							</xsd:list>
+						</xsd:simpleType>
+					</xsd:attribute>
+					<xsd:attribute name="approvedMonth" use="optional">
+						<xsd:simpleType>
+							<xsd:restriction base="xsd:positiveInteger">
+								<xsd:maxInclusive value="12"/>
+								<xsd:minInclusive value="01"/>
+								<xsd:totalDigits value="2"/>
+							</xsd:restriction>
+						</xsd:simpleType>
+					</xsd:attribute>
+					<xsd:attribute name="approvedYear" use="required">
+						<xsd:simpleType>
+							<xsd:restriction base="xsd:gYear"/>
+						</xsd:simpleType>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="std_family_designator"  type="std_designator_t">
+		<xsd:annotation>
+			<xsd:documentation>Provides for defining a DOI for a broad grouping of standards.
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	
+	<xsd:element name="std_set_designator">
+		<xsd:annotation>
+			<xsd:documentation>Provides for defining a DOI for a set of standards (sometimes know as truncated form).
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="std_designator_t">
+					<xsd:attribute name="family" type="xsd:string"/>
+ 				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+		
+	</xsd:element>
+	<xsd:element name="std_undated_designator">
+		<xsd:annotation>
+			<xsd:documentation>Provides for defining a DOI for a group of closely related standard documents (undated form is a stem for any dated form)
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="std_designator_t">
+					<xsd:attribute name="family" type="xsd:string"/>
+					<xsd:attribute name="set" type="xsd:string"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="std_supersedes"  type="std_designatorvalue_t">
+		<xsd:annotation>
+			<xsd:documentation>Designator for standard being replaced by the standard being deposited.
+			</xsd:documentation>
+		</xsd:annotation>
+	 </xsd:element>
+	<xsd:element name="std_adopted_from"  type="std_designatorvalue_t">
+		<xsd:annotation>
+			<xsd:documentation>Designator for standard from which the current deposit is adopted.
+			</xsd:documentation>
+		</xsd:annotation>
+ 	</xsd:element>
+	<xsd:element name="std_revision_of" type="std_designatorvalue_t">
+		<xsd:annotation>
+			<xsd:documentation>Designator for the previous revision of the standard being deposited. (note: use alt_as_published for revisions within designators having common stem)
+			</xsd:documentation>
+		</xsd:annotation>
+ 	</xsd:element>
+	<xsd:element name="standards_body">
+		<xsd:annotation>
+			<xsd:documentation>A wrapper for standards body information.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="standards_body_name"/>
+				<xsd:element ref="standards_body_acronym"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="standards_body_name">
+		<xsd:annotation>
+			<xsd:documentation>Name of the standards organization / publisher.
+				Required.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:element name="standards_body_acronym">
+		<xsd:annotation>
+			<xsd:documentation>Acronym for standards body. Will be used for query matching -
+				required.</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+
+	<xsd:simpleType name="std_designatorvalue_t">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="150"/>
+			<xsd:minLength value="2"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:complexType name="std_designator_t">
+		<xsd:sequence>
+			<xsd:element ref="std_designator" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="std_alt_script" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="std_variant_form" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:element name="std_designator" type="std_designatorvalue_t"/>
+	<xsd:element name="std_alt_script" type="std_designatorvalue_t"/>
+	<xsd:element name="std_variant_form" type="std_designatorvalue_t"/>
+
+<!-- ================SCN policy  cs-3495 ============================= -->
+	
+	<xsd:element name="scn_policies">
+		<xsd:annotation>
+			<xsd:documentation>A wrapper for Scholarly Sharing Network (SCN) policy information</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="scn_policy_set" minOccurs="0" maxOccurs="unbounded"/>
+ 			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	
+	
+	<xsd:element name="scn_policy_set">
+		<xsd:annotation>
+			<xsd:documentation>A group of related SCN  policies</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="scn_policy_ref" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+			<xsd:attribute name="start_date" type="xsd:date" use="optional"/>
+		</xsd:complexType>
+	</xsd:element>
+	
+	<xsd:element name="scn_policy_ref">
+		<xsd:annotation>
+			<xsd:documentation>An individual SCN policy</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:simpleContent>
+				<xsd:extension base="resource_t"/> 				
+			</xsd:simpleContent>
+		</xsd:complexType>
+	</xsd:element>
+ <!-- ================= -->       
+	
+</xsd:schema>

--- a/mycore-pi/src/main/resources/xsd/crossref/4.4.1/crossref4.4.1.xsd
+++ b/mycore-pi/src/main/resources/xsd/crossref/4.4.1/crossref4.4.1.xsd
@@ -1,0 +1,2102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:fr="http://www.crossref.org/fundref.xsd"
+            xmlns:ct="http://www.crossref.org/clinicaltrials.xsd"
+            xmlns:ai="http://www.crossref.org/AccessIndicators.xsd"
+            xmlns:rel="http://www.crossref.org/relations.xsd"
+            xmlns:mml="http://www.w3.org/1998/Math/MathML"
+            xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1" xmlns="http://www.crossref.org/schema/4.4.1"
+            targetNamespace="http://www.crossref.org/schema/4.4.1">
+
+  <!--Conforms to w3c http://www.w3.org/2001/XMLSchema-->
+  <!-- =============================================================
+
+                          Introduction
+
+     CrossRef W3C Deposit Schema Version 4.4.1
+
+     Developed for CrossRef (www.crossref.org) by
+
+     Inera Incorporated
+     Newton, MA 02460
+     http://www.inera.com
+     email: info@inera.com
+
+  For more information on the use of this schema see https://support.crossref.org/hc/en-us/sections/202832803
+
+     ============================================================= -->
+  <!-- =============================================================
+
+                          File Organization
+
+     This schema is organized into the following sections:
+     0. Include module common to multiple CrossRef schemas
+     1. Shared attributes
+     2. Schema-specific data types
+     3. Header Elements
+     4. Journal elements
+     5. Conference elements
+     6. Book elements
+     7. Elements common to books and conferences
+     8. Elements common to journals, books and conferences
+     9. Expanded Content Types (reports, dissertations, standards,database, peer review, posted content)
+    10. Elements common to reports, dissertations, standards, posted content, peer review
+     ============================================================= -->
+  <!-- =============================================================
+
+                          Change History
+
+    Changes record version, author initials, date, and comments
+   
+   4.4.1 (PDF) 8/7/18 add 'accept-with-reservation' as peer review recommendation type
+   4.4.1 (PDF) 7/12/18 add 'recommendation' as peer review type
+   4.4.1 (PDF) 12/18/17 updates to documentation
+   4.4.1 (CSK) 10/13/17 added peer review content type and related elements
+   4.4.1 (CSK) 6/9/17  added early-content as a top level content type (draft)
+   4.4.0 (PDF) 4/24/17 added 'pmid' as id_type for identifier element
+   4.3.7 (CSK) August 2015  Added linked clinical trials
+   4.3.6  (CSK)  12/2/14  reworked standard designator
+   4.3.5  10/31/14 added rel:program to support deposit of relationships
+   4.3.5 (PDF) updated standard_designator and child elements, moved mml:math to xrefFaces to fix problem with depositing mathML and other markup, restricted CrossMark update types to an enumerated list, removed cm_update_label
+   4.3.5 (PDF) added <relationships> and child elements to support deposit of relationships between DOIs.
+   4.3.5 (PDF) 9/8/14 changed standard_designator to designators, etc.
+   4.3.4 (PDF) 3/24/2014 moved standard_designator, standards_body, and child elements to common file, added standard_designator to citation
+   4.3.3, 4.3.4 (PDF) made doi_data required for standard_metadata
+   4.3.4 12/10/2013 
+   4.3.2 (PDF) 11/27/2013 updated custom_metadata to require either assertion, fr:program or ai:program be present 
+   4.3.2, 4.3.3 (PDF) 11/1/13 changed some elements from local to global (standard_designator, as_published, superseded by, adopted_from, standards_body, standards_body_name, standards_body_acronym)
+   4.3.2, 4.3.3 (PDF) 10/14/13 change adopted_by element to adopted_from (child of standard_designator)  
+   4.3.2, 4.3.3 (PDF) 10/2/2013 reorganized ai and fr programs 
+   4.3.1, 4.3.2, 4.3.3 (PDF) 9/10/2013 added fr:program to content_item, conference_paper, dissertation, report-paper, standard, book_metadata, book_series_metadata, book_set_metadata
+   4.3.2 (PDF) 5/1/2013 changed openAI.xsd to AccessIndicators.xsd
+   4.3.2 (PDF) 4/10/2013 added reference_distribution_opt and metadata_distribution_opt attribute to journal, journal_article, book_metadata, book_set_metadata, book_series_metadata, content_item, proceedings_series_metadata, proceedings_metadata
+   4.3.2 (PDF) 4/10/2013 added openAI.xsd namespace and import (for Open Access Indicators program)
+   4.3.2 (PDF) 4/9/2013  added "text-mining" value to the property attribute of the <collection> element, optional mime-type attribute to the <resource> element 
+   4.3.0 (PDF) 7/24/2012 added namespace and import for fundref.xsd
+   4.3.0 (PDF)  12/9/11 Added CrossMark element to content_item (for book chapters), dissertations, report-paper, and standards, moved CrossMark elements to common4.3.0.xsd to accommodate CrossMark-only deposits	
+   4.3.0 (PDF)  12/2/11 changed allowed value of crossmark_policy to doi_t
+   4.3.0 (PDF)	10/28/11 Added href attribute to <assertions>
+   4.3.0 (PDF) 	9/20/11 Added <noisbn> to book_series_metadata, book_set_metadata, and proceedings_series_metadata
+   4.3.0 (PDF) 	6/29/11	CrossMark	
+   4.3.0 (CSK) 6/2/09   Made conference paper contributer min=zero
+
+   4.3.0 (CSK) 8/12/08  Modified book series to allow unassigned content
+
+   4.3.0 (CSK) 6/23/2008 Added std-designation to identifier type attribute
+                       7/30.2008 Added publication_status attribute to <standard_metadata>
+
+    4.3.0 (CSK)  2/20/08  Changed to use common 1.0.6 which includes production
+                          multiple resolution changes
+    4.2.0 (BDR) 10/25/07
+    Changed structure of book metadata deposits so that
+     a) book series are handled seperately from books that are not series
+     b) book sets are properly supported
+    This is accomplished by changing the top book structure to be a choice
+     of book_metadata, book_series_metadata, or book_set_metadata
+    book_metadata is backwards compatible provided you are depositing books
+     that are not part of a series or a set
+    A minimum of 1 ISBN is required for each book volume. Previously ISBN was
+     optional
+
+    In conjunction with the book changes above, volume and issn were removed
+     from proceedings_metadata, report-paper_metadata, and standards_metatdata
+     because they are now in series_metadata.
+
+    4.1.0 (CSK/BDR) 4/13/06  Added elements for database deposits;
+
+    4.0.1 (CSK/BDR) 2/6/06,  3/23/06
+    Added citation_list to all deposit types, expanded from journal
+        articles only
+    Changed abbrev_title so that it is optional. full_title is still required
+    Changed full_title to allow up to 10 names for a journal
+    Added citation_list to conference_paper, book_metadata, content_item,
+        dissertation, report-paper_metadata, standard_metadata
+          (BDR) 4/6/06
+    Added approval_date to report-paper_metadata as optional element
+    Added report-number has an attribute to identifier to indicate report
+        numbers that use non-standard identification schemes
+
+    4.0.0 (BDR) 6/7/05
+
+    Extended schema to support expanded content types for dissertations,
+    reports, working papers, and standards
+
+    3.0.3 (CSK) 7/20/04
+
+    Added the <component> element to the common include file and to the <journal_article>,
+    <conference_paper> and <content_item> elements to allow the deposit of component
+    DOIs on their own or as parts of the three higher level entities. Also added
+    <sa_component> which identifies a parent DOI that may already exist (e.g. created
+    in an earlier deposit or via some other registration process).
+
+    3.0.2 (CSK) 7/16/04
+
+    Extensively modified collection element to fit multiple resolution pilot/demo. Added <doi> to the
+    possible elements in <item>
+
+    Moved elments resource,item,collection,property_t and property from the
+    main schema file to include file (common1.0.2.xsd) to faciliate creating a schema
+    for the deposit of only multiple resolution data.
+
+    3.0.1 (CSK)  4/12/04
+
+    Increased version number to reflect changes made in the common file.
+
+    3.0.0 (BDR) 11/05/03 (CSK) 12/19/03
+
+    Added citation_list element to support deposits of reference lists in journal
+    articles for forward linking
+
+    Separated common elements for reuse in other CrossRef schemas into common.xsd
+
+    2.0.7 (HS) Made DOI and contributors elements under book_metadata optional (to accommodate Elsevier)
+
+    2.0.6.1 (CSK) set min values to zero for <conference_date> and <conference_location> under
+                  the <event_metadata> record
+
+    2.0.5.2 (CSK) 9/02/03 changed the datatype for DOI and RESOURCE back to String from anyURI
+
+    2.0.5.1 (CSK) 3/19/03 increased number of allowed contributors to "unbounded"
+
+    2.0.5 (CSK) 10/04/02 minor change, fully backward compatible
+
+    Modifed xrefMonth maxInclusive value to "34" to allow extended definitions
+
+    2.0.5 (BDR) 05/02/02
+
+    Brought into full conformance with Xerces 2.0
+
+    2.0.4 (BDR) 02/25/02
+
+    Changed default name space declaration and brought into full
+    conformance with XML Spy 4.3
+
+    2.0.3 (BDR) 01/18/02
+
+    Changed item_data to resource and property where resource is the
+    container for a URI related to a DOI and property elements
+    qualify the resource or collection to which    they're applied.
+
+    Changed data type of DOI from string to xsd:anyURI
+
+    Changed the relationship of item and collection.
+
+    2.0.2 (BDR) 01/15/02
+
+    Tightened validation of ISBN and ISSN instances
+
+    Changed item_number maxLength from 15 to 32, added an
+    attribute for item_number_type, and changed publisher_item
+    to allow up to three item_number elements.
+
+    Added face markup to title, original_language_title, and subtitle
+    elements. This addition allows basic face markup in titles for
+    those disciplines (e.g. in genetics, mathematics) where lack of
+    face markup can result in ambiguous interpretation.
+
+    Increased DOI maxLength from 255 to 2048 characters
+
+    Changed the doi_data model from url to collection, item and item_data
+    to allow future expansion for multiple resolution. WARNING: the
+    collection model is infinitely recursive and may only be used in
+    accordance with the documentation provide by CrossRef!
+
+    2.0.1 (BDR) 10/25/01
+
+    Added contributors as an optional element to journal_issue to allow
+    for cases when a special issue of a journal has editors who may be
+    listed when the entire issue is cited
+
+    2.0.0 (BDR) 10/09/01
+
+    First major release of version 2.0.0, based loosely on
+    version 0.3 by Howard Ratner.
+
+     ============================================================= -->
+  <!-- =============================================================
+
+          0. Include module common to multiple CrossRef schemas
+
+     ============================================================= -->
+  <xsd:include schemaLocation="common4.4.1.xsd"/>
+  <!-- =============================================================
+
+                          1. Shared attributes
+
+     ============================================================= -->
+  <!--               Moved to common.xsd for version 3.0.0           -->
+  <!-- =============================================================
+
+                     2. Schema-specific data types
+
+     ================================================================= -->
+  <!--               Moved to common.xsd for version 3.0.0           -->
+  <!-- =============================================================
+
+                          3. Header elements
+
+     ================================================================= -->
+  <!--      Most elements moved to common.xsd for version 3.0.0      -->
+  <xsd:import namespace="http://www.ncbi.nlm.nih.gov/JATS1"
+              schemaLocation="JATS-journalpublishing1.xsd"/>
+  <xsd:import namespace="http://www.w3.org/1998/Math/MathML"
+              schemaLocation="http://www.w3.org/Math/XMLSchema/mathml3/mathml3.xsd"/>
+  <xsd:import namespace="http://www.crossref.org/fundref.xsd" schemaLocation="fundref.xsd"/>
+  <xsd:import namespace="http://www.crossref.org/clinicaltrials.xsd"
+              schemaLocation="clinicaltrials.xsd"/>
+  <xsd:import namespace="http://www.crossref.org/AccessIndicators.xsd"
+              schemaLocation="AccessIndicators.xsd"/>
+  <xsd:import namespace="http://www.crossref.org/relations.xsd" schemaLocation="relations.xsd"/>
+
+  <xsd:element name="doi_batch">
+    <xsd:annotation>
+      <xsd:documentation>Top level element for a metadata submission to CrossRef. This element indicates the start and
+        end of the XML file. The version number is fixed to the version of the schema. Be sure to set the name space
+        attributes as shown above in order for the Xerces parser to process the instance correctly. For the purposes of
+        parsing, you may also set xsi:schemaLocation to http://www.crossref.org/schema/4.x.x http://www.crossref.org
+        /schema/4.x.x/crossref.xsd.
+        A copy of the schema is located on the CrossRef server at this URL and will remain constant for a given version
+        of the schema. This location permits you to have a constant location for the schema for parsing without relying
+        on a hardwired local directory on your development platform.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="head"/>
+        <xsd:element ref="body"/>
+      </xsd:sequence>
+      <xsd:attribute name="version" type="xsd:string" fixed="4.4.1"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="head">
+    <xsd:annotation>
+      <xsd:documentation>The container for information related to the DOI batch submission. This element uniquely
+        identifies the batch deposit to CrossRef and contains information that will be used as a reference in error
+        messages sent by the MDDB.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="doi_batch_id"/>
+        <xsd:element ref="timestamp"/>
+        <xsd:element ref="depositor"/>
+        <xsd:element ref="registrant"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="body">
+    <xsd:annotation>
+      <xsd:documentation>The container for the main body of a DOI record submission. The body contains a set of records
+        within a support content type. It is not possible to mix content types within a single registration file. It is
+        possible to include records for multiple journals, books, conferences, or stand alone components in a single
+        submission.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:choice>
+        <xsd:element ref="journal" maxOccurs="unbounded"/>
+        <xsd:element ref="book" maxOccurs="unbounded"/>
+        <xsd:element ref="conference" maxOccurs="unbounded"/>
+        <xsd:element ref="sa_component" maxOccurs="unbounded"/>
+        <xsd:element ref="dissertation" maxOccurs="unbounded"/>
+        <xsd:element ref="report-paper" maxOccurs="unbounded"/>
+        <xsd:element ref="standard" maxOccurs="unbounded"/>
+        <xsd:element ref="database" maxOccurs="unbounded"/>
+        <xsd:element ref="peer_review" maxOccurs="unbounded"/>
+        <xsd:element ref="posted_content" maxOccurs="unbounded"/>
+      </xsd:choice>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- =============================================================
+
+                          4. Journal elements
+
+     ============================================================= -->
+  <xsd:element name="journal">
+    <xsd:annotation>
+      <xsd:documentation>The container for all information about a single journal and the articles being registered
+        within the journal. journal is the core container for information about a single journal and articles submitted
+        for registration from thatjournal. Within a journal instance, you may register articles from a single issue,
+        detailed in journal_issue. If you want to register items from more than one issue, you must use multiple journal
+        instances, which can be done within a single batch submission. If you have articles that have not been assigned
+        to an issue, you may register them within a single journal instance. In this case, do not include a
+        journal_issue. You may chose to submit only top level journal_metadata and journal_issue metadata for any
+        journal or issue, allowing you to register DOIs for an entire journal, or any issue or volume within a journal.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="journal_metadata"/>
+        <xsd:element ref="journal_issue" minOccurs="0"/>
+        <xsd:element ref="journal_article" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="journal_metadata">
+    <xsd:annotation>
+      <xsd:documentation>The container for metadata that defines a journal.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="full_title" maxOccurs="10"/>
+        <xsd:element ref="abbrev_title" minOccurs="0" maxOccurs="10"/>
+        <xsd:element ref="issn" minOccurs="0" maxOccurs="6"/>
+        <xsd:element ref="coden" minOccurs="0"/>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="doi_data" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="language.atts"/>
+      <xsd:attributeGroup ref="metadata_distribution_opts.att"/>
+      <xsd:attributeGroup ref="reference_distribution_opts.att"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="full_title">
+    <xsd:annotation>
+      <xsd:documentation>The full title by which a journal is commonly known or cited. full_title and abbrev_title must
+        both be submitted even if they are identical. Note: In version 4.1.0 and later, this element is allowed up to 10
+        times to allow for a) journal name changes over time, b) translated journal names (e.g. the Japanese name and
+        the English equivalent), and c) common author mis-spellings of a given journal name.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="255"/>
+        <xsd:minLength value="1"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+
+  <xsd:element name="abbrev_title">
+    <xsd:annotation>
+      <xsd:documentation>This element contains the common abbreviation or abbreviations used when citing this journal.
+        It is preferred, but not required, that periods be included after abbreviated words within the title. full_title
+        and abbrev_title must both be submitted, and they can be identical. If you do not know the abbreviated title for
+        a specific journal, please supply the full title in the abbrev_title element. Note: In version 4.1.0 and later,
+        this element is no longer required in journal_metadata because some journals do not have abbreviated journal
+        names.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="150"/>
+        <xsd:minLength value="1"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <xsd:element name="journal_issue">
+    <xsd:annotation>
+      <xsd:documentation>The container for metadata that defines a single issue of a journal. Special issue numbering
+        information for a journal should be placed in special_numbering. You may register a DOI for an entire issue by
+        including doi_data in journal_issue. The URI should resolve to the table of contents for the issue. contributors
+        is included in journal_issue to allow inclusion of editors of special issues. This element allows linking from a
+        reference such as: R.Glaser, L.Bond (Eds.), Testing: concepts and research, American Psychologist 36 (10-12)
+        (1981) (special issue). You should not include contributors for the regular editors of regular issues.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="contributors" minOccurs="0"/>
+        <xsd:element ref="titles" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="publication_date" maxOccurs="10"/>
+        <xsd:element ref="journal_volume" minOccurs="0"/>
+        <xsd:element ref="issue" minOccurs="0"/>
+        <xsd:element ref="special_numbering" minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>Issue level numbering for supplements or special issues. Text defining the type of
+              special issue (e.g. "suppl") should be included in this element along with the number.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="doi_data" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="journal_volume">
+    <xsd:annotation>
+      <xsd:documentation>The container for the journal volume and DOI assigned to an entire journal volume. You may
+        register a DOI for an entire volume by including doi_data in journal_volume.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="volume"/>
+        <xsd:element ref="publisher_item" minOccurs="0"/>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="doi_data" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="special_numbering">
+    <xsd:annotation>
+      <xsd:documentation>Issue level numbering for supplements or special issues. Text defining the type of special
+        issue (e.g. "suppl") should be included in this element along with the number.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="15"/>
+        <xsd:minLength value="1"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <xsd:element name="journal_article">
+    <xsd:annotation>
+      <xsd:documentation>The container for all information about a single journal article. A journal article is required
+        to have title and doi_data. All other information is optional. When registering items that do not have titles,
+        use the appropriate heading from the journal section or table of contents (e.g. "Errata") in title.
+        journal_article allows for multiple titles per entity. In some cases it may be helpful to submit multiple
+        titles. For example, if an erratum carries title of the original article a nd the heading "Errata", both should
+        be submitted by using two titles elements.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="titles" maxOccurs="20"/>
+        <xsd:element ref="contributors" minOccurs="0"/>
+        <xsd:element ref="jats:abstract" minOccurs="0" maxOccurs="10">
+          <xsd:annotation>
+            <xsd:documentation>The abstract element allows depositors to include abstracts extracted from NLM or JATS
+              XML in CrossRef deposits. The jats: namespace prefix must be included.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="publication_date" maxOccurs="10"/>
+        <xsd:element ref="pages" minOccurs="0"/>
+        <xsd:element ref="publisher_item" minOccurs="0"/>
+        <xsd:choice>
+          <xsd:element ref="crossmark" minOccurs="0"/>
+          <xsd:sequence>
+            <xsd:element ref="fr:program" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="ai:program" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="ct:program" minOccurs="0" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:choice>
+        <xsd:element ref="rel:program" minOccurs="0"/>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="scn_policies" minOccurs="0" maxOccurs="1"/>
+        <!-- cs-3495 -->
+        <xsd:element ref="doi_data"/>
+        <xsd:element ref="citation_list" minOccurs="0"/>
+        <xsd:element ref="component_list" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="publication_type.atts"/>
+      <xsd:attributeGroup ref="language.atts"/>
+      <xsd:attributeGroup ref="metadata_distribution_opts.att"/>
+      <xsd:attributeGroup ref="reference_distribution_opts.att"/>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- =============================================================
+
+                          5. Conference elements
+
+     ============================================================= -->
+  <xsd:element name="conference">
+    <xsd:annotation>
+      <xsd:documentation>conference is the core container for information about a single
+        conference and its proceedings. If a conference proceedings spans multiple volumes,
+        each volume must be contained in a unique conference element.
+
+        You may choose to submit only top level contributors, event_metadata and proceedings_metadata for any
+        conference, or you may choose to submit these elements along with metadata for each conference_paper.
+
+        The CrossRef system currently uses the proceedings_title and conference_acronym in the query matching process.
+        This system can cause problems when the proceedings have a simple non-changing title (e.g Proceedings of SPIE)
+        and the conference event name, conference_name, is used to differentiate conference topics (e.g. Optoelectronic
+        Integrated Circuits II). To avoid this problem, CrossRef recommends that you make sure the conference_acronym
+        accurately reflects the event name (e.g OpIC II in this example).
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="contributors" minOccurs="0"/>
+        <xsd:element ref="event_metadata"/>
+        <xsd:choice>
+          <xsd:element ref="proceedings_series_metadata"/>
+          <xsd:element ref="proceedings_metadata"/>
+        </xsd:choice>
+        <xsd:element ref="conference_paper" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="event_metadata">
+    <xsd:annotation>
+      <xsd:documentation>
+        event_metadata captures information about a conference event like sponsor, theme, and location.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="conference_name"/>
+        <xsd:element ref="conference_theme" minOccurs="0"/>
+        <xsd:element ref="conference_acronym" minOccurs="0"/>
+        <xsd:element ref="conference_sponsor" minOccurs="0" maxOccurs="10"/>
+        <xsd:element ref="conference_number" minOccurs="0"/>
+        <xsd:element ref="conference_location" minOccurs="0"/>
+        <xsd:element ref="conference_date" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="conference_name">
+    <xsd:annotation>
+      <xsd:documentation>The official name of the conference. conference_name does not include "Proceedings of". For
+        example, "The 23rd Annual Meeting of the American Society for Information Science" is a correct conference name.
+        It is quite common for a conference name to include the conference number or subject. When any of these metadata
+        items appear in the conference name, they should be included in this element, and also in the respective
+        sub-element, conference_number or proceedings_subject.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="512"/>
+        <xsd:minLength value="3"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <xsd:element name="conference_theme">
+    <xsd:annotation>
+      <xsd:documentation>The theme is the slogan or special emphasis of a conference in a particular year.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="255"/>
+        <xsd:minLength value="1"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <xsd:element name="conference_acronym">
+    <xsd:annotation>
+      <xsd:documentation>The popularly known as or jargon name (e.g. SIGGRAPH for "Special Interest Group on Computer
+        Graphics"). Authors commonly cite the conference acronym rather than the full conference or proceedings name, so
+        it is best to include this element when it is available. The conference acronym often includes the year of the
+        conference (e.g. SGML '97) or, less often, the conference number. It is preferred, but not required, that
+        submission of metadata exclude number or year information from the conference acronym. It is better to include
+        such information in conference_number, or conference_date, respectively.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="127"/>
+        <xsd:minLength value="1"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <xsd:element name="conference_sponsor">
+    <xsd:annotation>
+      <xsd:documentation>The sponsoring organization(s) of a conference. Multiple sponsors may be given if a conference
+        is hosted by more than one organization.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="255"/>
+        <xsd:minLength value="1"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <xsd:element name="conference_number">
+    <xsd:annotation>
+      <xsd:documentation>The number of a conference. conference_number should include only the number of the conference
+        without any extra text. For example, "The 24th Annual
+        Conference on..." should be tagged as &lt;conference_number>24&lt;/conference_number>. Roman numerals are
+        acceptable.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="15"/>
+        <xsd:minLength value="1"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <xsd:element name="conference_location">
+    <xsd:annotation>
+      <xsd:documentation>The city and country of the conference. If the conference is in the United States, the
+        appropriate state should also be provided, and the country may be omitted. If the conference is in Canada, the
+        province should be provided, and the country may be omitted. The specific venue or address within a city (e.g.
+        conference center, hotel, etc.) should not be provided.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="255"/>
+        <xsd:minLength value="2"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <xsd:simpleType name="conference_date_t">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="100"/>
+      <xsd:minLength value="0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:element name="conference_date">
+    <xsd:annotation>
+      <xsd:documentation>The start and end dates of a conference event. conference_date may be used in three ways:
+        1. If publishers that do not have parsed date values, provide just text with the conference dates. The date text
+        should be taken from the proceedings title page.
+        2. If publishers have parsed date values, provide them in the attributes.
+        3. If both parsed date values and the date text are available, both should be provided. This is the preferred
+        tagging for conference_date. For example:
+
+        <conference_date start_month="01" start_year="1997" start_day="15" end_year="1997" end_month="01" end_day="17">
+          Jan. 15-17, 1997
+        </conference_date>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:simpleContent>
+        <xsd:extension base="conference_date_t">
+          <xsd:attribute name="start_day" type="xrefDay" use="optional"/>
+          <xsd:attribute name="start_month" type="xrefMonth" use="optional"/>
+          <xsd:attribute name="start_year" type="xrefYear" use="optional"/>
+          <xsd:attribute name="end_day" type="xrefDay" use="optional"/>
+          <xsd:attribute name="end_month" type="xrefMonth" use="optional"/>
+          <xsd:attribute name="end_year" type="xrefYear" use="optional"/>
+        </xsd:extension>
+      </xsd:simpleContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="proceedings_metadata">
+    <xsd:annotation>
+      <xsd:documentation>proceedings_metadata captures information about conference proceedings.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="proceedings_title"/>
+        <xsd:element ref="proceedings_subject" minOccurs="0"/>
+        <xsd:element ref="publisher" maxOccurs="5"/>
+        <xsd:element ref="publication_date" maxOccurs="10"/>
+        <xsd:choice>
+          <xsd:element ref="isbn" maxOccurs="6"/>
+          <xsd:element ref="noisbn"/>
+        </xsd:choice>
+        <xsd:element ref="publisher_item" minOccurs="0"/>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="doi_data" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="language.atts"/>
+      <xsd:attributeGroup ref="metadata_distribution_opts.att"/>
+      <xsd:attributeGroup ref="reference_distribution_opts.att"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="proceedings_series_metadata">
+    <xsd:annotation>
+      <xsd:documentation>A container for all information that applies to a specific conference proceeding that is part
+        of a series. A conference proceedings published as a series can sometimes look just like a journal in that there
+        is no volume information (no volume title, no ISBN). In these cases the conference proceeding may be deposited
+        as a journal (which more accurately should have been called a 'series_publication'). To allow for the use of a
+        consistent XML heirarchy we will allow a proceedings_series_metadata root element to also describe such a
+        publication.
+
+        Note: this structure is organized to allow backward compatibility with previous schema versions by maintaining
+        the prior sequence of elements.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="series_metadata"/>
+        <xsd:choice>
+          <xsd:sequence>
+            <xsd:choice>
+              <xsd:sequence>
+                <xsd:element ref="proceedings_title"/>
+                <xsd:element ref="volume" minOccurs="0"/>
+              </xsd:sequence>
+              <xsd:element ref="volume"/>
+            </xsd:choice>
+            <xsd:element ref="proceedings_subject" minOccurs="0"/>
+            <xsd:element ref="publisher" maxOccurs="5"/>
+            <xsd:element ref="publication_date" maxOccurs="10"/>
+            <xsd:choice>
+              <xsd:element ref="isbn" maxOccurs="6"/>
+              <xsd:element ref="noisbn"/>
+            </xsd:choice>
+          </xsd:sequence>
+          <xsd:sequence>
+            <xsd:element ref="proceedings_subject" minOccurs="0"/>
+            <xsd:element ref="publisher" maxOccurs="5"/>
+            <xsd:element ref="publication_date" maxOccurs="10"/>
+          </xsd:sequence>
+        </xsd:choice>
+        <xsd:element ref="publisher_item" minOccurs="0"/>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="doi_data" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="metadata_distribution_opts.att"/>
+      <xsd:attributeGroup ref="reference_distribution_opts.att"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="proceedings_title">
+    <xsd:annotation>
+      <xsd:documentation>proceedings_title is the undifferentiated
+        title of a conference proceedings. It should generally be the title as it appears on
+        the cover of the printed proceedings. In some cases, proceedings_title may differ
+        from conference_name only in that the text "Proceedings of" often appears at the
+        start of the proceedings_title, and it this text should never be included in
+        conference_name. In other cases, the proceedings_title and conference_name may be
+        quite different.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="511"/>
+        <xsd:minLength value="1"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <xsd:element name="proceedings_subject">
+    <xsd:annotation>
+      <xsd:documentation>The subject of the printed conference proceedings, e.g. "Computer
+        Graphics" is the subject matter of SIGGRAPH. This element is useful because an
+        author may cite a conference paper by the conference subject. For example,
+        "Proceedings of the 1999 ACM Conference on Computer Graphics"
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="255"/>
+        <xsd:minLength value="1"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <xsd:element name="conference_paper">
+    <xsd:annotation>
+      <xsd:documentation>The container for all information about a single conference paper.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="contributors" minOccurs="0"/>
+        <xsd:element ref="titles"/>
+        <xsd:element ref="jats:abstract" minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>The abstract element allows depositors to include
+              abstracts extracted from NLM or JATS XML in CrossRef deposits. The jats:
+              namespace prefix must be included.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="publication_date" minOccurs="0" maxOccurs="10"/>
+        <xsd:element ref="pages" minOccurs="0"/>
+        <xsd:element ref="publisher_item" minOccurs="0"/>
+        <xsd:choice>
+          <xsd:element ref="crossmark" minOccurs="0"/>
+          <xsd:sequence>
+            <xsd:element ref="fr:program" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="ai:program" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="ct:program" minOccurs="0" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:choice>
+        <xsd:element ref="rel:program" minOccurs="0"/>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="scn_policies" minOccurs="0" maxOccurs="1"/>    <!-- cs-3495 -->
+        <xsd:element ref="doi_data"/>
+        <xsd:element ref="citation_list" minOccurs="0"/>
+        <xsd:element ref="component_list" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="publication_type.atts"/>
+      <xsd:attributeGroup ref="language.atts"/>
+      <xsd:attributeGroup ref="metadata_distribution_opts.att"/>
+      <xsd:attributeGroup ref="reference_distribution_opts.att"/>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- =============================================================
+
+                          6. Book elements
+
+     ============================================================= -->
+  <xsd:element name="book">
+    <xsd:annotation>
+      <xsd:documentation>The container for all information about a single book. book is the
+        core container for information about a specific book. Books may be in the form of
+        edited books (i.e. a contributed volume with one or more editors), monographs
+        (single-authored works), or reference works (e.g. encyclopedias). If a book contains
+        multiple volumes, each volume must be contained in a unique book element. You may
+        chose to submit only top level contributors and book_metadata for any book, or you
+        may chose to submit these elements along with metadata for each content_item. A
+        content item is typically any entity that is listed on the table of contents such as
+        a chapter, section, etc. It is not necessary to submit metadata for all items listed
+        on the table of contents. You may chose to drop items of lesser significance such as
+        front and back matter. Book-level metadata is captured within book_metadata,
+        book_series_metadata, or book_set_metadata. If a books is a single-volume work, use
+        book_metadata. If the book is a volume from a multi-volume work that is also a
+        serial publication (and therefore has an ISSN), use book_series_metadata. If the
+        book is a volume of non-serial publication, then it is considered a set and you
+        should use book_set_metadata book_type should be set to "monograph" when the same
+        author or authors wrote the majority of the content. It should be set to
+        "edited_book" when a book primarily consists of contributed chapters, each chapter
+        written by different authors. It should be set to "reference" for major reference
+        works such as encyclopedias. Use "other" when the author of the content does not fit
+        any of the other categories.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:choice>
+          <xsd:element ref="book_metadata"/>
+          <xsd:element ref="book_series_metadata"/>
+          <xsd:element ref="book_set_metadata"/>
+        </xsd:choice>
+        <xsd:element ref="content_item" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="book_type" use="required">
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:NMTOKEN">
+            <xsd:enumeration value="edited_book"/>
+            <xsd:enumeration value="monograph"/>
+            <xsd:enumeration value="reference"/>
+            <xsd:enumeration value="other"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="book_metadata">
+    <xsd:annotation>
+      <xsd:documentation>A container for all information that applies to a monograph. It does
+        not include metadata about individual chapters. The language of the book should be
+        specified in the book_metadata language attribute. If a book contains items in
+        multiple languages this attribute should be set for the predominant language of the
+        book. Individual items may have their language specified in content_item. If all
+        content items are the same language, it is only necessary to specify the language of
+        the book in this element. The contributors are the author(s) or editor(s) of the
+        entire work. When using book_metadata, specify the title of the book within
+        book_metadata. edition_number, when given, should include only a number and not
+        additional text such as "edition" or "ed". publisher_item, when given, specifies
+        this information for the entire book or volume. This element also appears in
+        content_item. doi_data is required for each book or volume that you submit. It is
+        not possible to submit DOI information for individual chapters without assigning a
+        DOI to the entire work. Note: citation_list should only be used in book_metadata
+        instead of content_item when the reference list is a separate section of the book,
+        and content_items are not included in the deposit (e.g. you are depositing a book
+        with a bibliography, but not the chapters of the book) In very limited circumstances
+        a book may be deposited without an ISBN, in which case the noisbn element must be
+        supplied to explicitly declare that an ISBN is not accidentily omitted. Great care
+        should be taken when choossing to use noisbn since it may adversely effect matching.
+        This provision is primarily being made to allow for the deposit of DOIs for
+        historical volumes that are difficult to obtain ISBNs.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="contributors" minOccurs="0"/>
+        <xsd:element ref="titles"/>
+        <xsd:element ref="jats:abstract" minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>The abstract element allows depositors to include
+              abstracts extracted from NLM or JATS XML in CrossRef deposits. The jats:
+              namespace prefix must be included.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="edition_number" minOccurs="0"/>
+        <xsd:element ref="publication_date" maxOccurs="10"/>
+        <xsd:choice>
+          <xsd:element ref="isbn" maxOccurs="6"/>
+          <xsd:element ref="noisbn"/>
+        </xsd:choice>
+        <xsd:element ref="publisher"/>
+        <xsd:element ref="publisher_item" minOccurs="0"/>
+        <xsd:choice>
+          <xsd:element ref="crossmark" minOccurs="0"/>
+          <xsd:sequence>
+            <xsd:element ref="fr:program" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="ai:program" minOccurs="0" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:choice>
+        <xsd:element ref="rel:program" minOccurs="0"/>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="doi_data" minOccurs="0"/>
+        <xsd:element ref="citation_list" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="language.atts"/>
+      <xsd:attributeGroup ref="metadata_distribution_opts.att"/>
+      <xsd:attributeGroup ref="reference_distribution_opts.att"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="book_series_metadata">
+    <xsd:annotation>
+      <xsd:documentation>A container for all information that applies to an individual volume
+        of a book series. It does not include metadata about individual chapters. The
+        language of the book should be specified in the book_series_metadata language
+        attribute. If a book contains items in multiple languages this attribute should be
+        set for the predominant language of the book. Individual items may have their
+        language specified in content_item. If all content items are the same language, it
+        is only necessary to specify the language of the book in this element. The
+        contributors are the author(s) or editor(s) of the entire work. If a multi- volume
+        work has separate editors for each volume, those editors should be specified in this
+        element, and the series editors are listed in the series_metadata contributors.
+        Series titles should be specified within series_metadata. Volume titles (when
+        present) are captured in book_series_metadata. If the volumes of a series only have
+        volume numbers and not individual titles, you may specify the volume number within
+        volume_metadata, and no title is required. volume and edition_number, when given,
+        should include only a number and not additional text such as "volume" or "edition".
+        For example, you should submit "3", not "third edition". If a work spans multiple
+        volumes with a unique ISBN for each volume and the whole series, you should specify
+        the series ISBN in isbn in series_metadata and the volume ISBN in isbn in
+        book_series_metadata. WARNING: Care must be taken when submitting books with series.
+        If a series title is submitted and no book title is supplied but an ISBN is supplied
+        at the book_series_metadata level and not with the series title, the CrossRef system
+        will index a series title with no ISBN and an ISBN with no title. Please take care
+        to associate the ISBN at the correct level of the XML hierarchy. publisher_item,
+        when given, specifies this information for the entire book or volume. This element
+        also appears in content_item. doi_data is required for each book or volume that you
+        submit. It is not possible to submit DOI information for individual chapters without
+        assigning a DOI to the entire work. Note: citation_list should only be used in
+        book_series_metadata instead of content_item when the reference list is a separate
+        section of the book, and content_items are not included in the deposit (e.g. you are
+        depositing a book with a bibliography, but not the chapters of the book) Normally
+        book content that is published as a series is required to have a series title with
+        an ISSN and a book title and/or a book volume number along with a book ISBN. An
+        exception is when book chapters are published on line first prior to being assigned
+        to a specific book in which case only the series title (and ISSN) is known at time
+        of DOI registration. Element unassigned_content is used as a placeholder to force
+        recognition of this condition and thus prevent accidental omission of book level
+        title information.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="series_metadata"/>
+        <xsd:choice>
+          <xsd:sequence>
+            <xsd:element ref="contributors" minOccurs="0"/>
+            <xsd:choice>
+              <xsd:sequence>
+                <xsd:element ref="titles"/>
+                <xsd:element ref="jats:abstract" minOccurs="0">
+                  <xsd:annotation>
+                    <xsd:documentation>The abstract element allows depositors to
+                      include abstracts extracted from NLM or JATS XML in
+                      CrossRef deposits. The jats: namespace prefix must be
+                      included.
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:element>
+                <xsd:element ref="volume" minOccurs="0"/>
+              </xsd:sequence>
+              <xsd:element ref="volume"/>
+            </xsd:choice>
+            <xsd:element ref="edition_number" minOccurs="0"/>
+            <xsd:element ref="publication_date" maxOccurs="10"/>
+            <xsd:choice>
+              <xsd:element ref="isbn" maxOccurs="6"/>
+              <xsd:element ref="noisbn"/>
+            </xsd:choice>
+          </xsd:sequence>
+          <xsd:element ref="publication_date" maxOccurs="10"/>
+        </xsd:choice>
+        <xsd:element ref="publisher"/>
+        <xsd:element ref="publisher_item" minOccurs="0"/>
+        <xsd:choice>
+          <xsd:element ref="crossmark" minOccurs="0"/>
+          <xsd:sequence>
+            <xsd:element ref="fr:program" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="ai:program" minOccurs="0" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:choice>
+        <xsd:element ref="rel:program" minOccurs="0"/>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="doi_data" minOccurs="0"/>
+        <xsd:element ref="citation_list" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="language.atts"/>
+      <xsd:attributeGroup ref="metadata_distribution_opts.att"/>
+      <xsd:attributeGroup ref="reference_distribution_opts.att"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="book_set_metadata">
+    <xsd:annotation>
+      <xsd:documentation>A container for all information that applies to an individual volume
+        of a book set. It does not include metadata about individual chapters. A set is a
+        finite series, and does not have an ISSN The language of the book should be
+        specified in the book_set_metadata language attribute. If a book contains items in
+        multiple languages this attribute should be set for the predominant language of the
+        book. Individual items may have their language specified in content_item. If all
+        content items are the same language, it is only necessary to specify the language of
+        the book in this element. The contributors are the author(s) or editor(s) of the
+        entire work. If a multi- volume work has separate editors for each volume, those
+        editors should be specified in this element, and the series editors are listed in
+        the series_metadata contributors. When using book_set_metadata, specify the title of
+        the entire set and the isbn of the set. Specify the title of the volume in
+        volume_metadata. If the volumes of a set only have volume numbers and not individual
+        titles, you may specify the volume number within volume_metadata, and no title is
+        required. volume and edition_number, when given, should include only a number and
+        not additional text such as "volume" or "edition". For example, you should submit
+        "3", not "third edition". If a work spans multiple volumes with a unique ISBN for
+        each volume and the whole series, you should specify the series ISBN in isbn in
+        series_metadata and the volume ISBN in isbn in book_series_metadata. publisher_item,
+        when given, specifies this information for the entire book or volume. This element
+        also appears in content_item. doi_data is required for each book or volume that you
+        submit. It is not possible to submit DOI information for individual chapters without
+        assigning a DOI to the entire work. Note: citation_list should only be used in
+        book_series_metadata instead of content_item when the reference list is a separate
+        section of the book, and content_items are not included in the deposit (e.g. you are
+        depositing a book with a bibliography, but not the chapters of the
+        book)
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="set_metadata"/>
+        <xsd:element ref="contributors" minOccurs="0"/>
+        <xsd:choice>
+          <xsd:sequence>
+            <xsd:element ref="titles"/>
+            <xsd:element ref="jats:abstract" minOccurs="0">
+              <xsd:annotation>
+                <xsd:documentation>The abstract element allows depositors to include
+                  abstracts extracted from NLM or JATS XML in CrossRef deposits.
+                  The jats: namespace prefix must be included.
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element ref="volume" minOccurs="0"/>
+          </xsd:sequence>
+          <xsd:element ref="volume"/>
+        </xsd:choice>
+        <xsd:element ref="edition_number" minOccurs="0"/>
+        <xsd:element ref="publication_date" maxOccurs="10"/>
+        <xsd:choice>
+          <xsd:element ref="isbn" maxOccurs="6"/>
+          <xsd:element ref="noisbn"/>
+        </xsd:choice>
+        <xsd:element ref="publisher"/>
+        <xsd:element ref="publisher_item" minOccurs="0"/>
+        <xsd:choice>
+          <xsd:element ref="crossmark" minOccurs="0"/>
+          <xsd:sequence>
+            <xsd:element ref="fr:program" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="ai:program" minOccurs="0" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:choice>
+        <xsd:element ref="rel:program" minOccurs="0"/>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="doi_data" minOccurs="0"/>
+        <xsd:element ref="citation_list" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="language.atts"/>
+      <xsd:attributeGroup ref="metadata_distribution_opts.att"/>
+      <xsd:attributeGroup ref="reference_distribution_opts.att"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="content_item">
+    <xsd:annotation>
+      <xsd:documentation>An entity in a book, such as a chapter, for which a DOI is being
+        registered. A content item is typically an entity listed on the table of contents.
+        There need not be a one-to-one correlation between content listings and content
+        items (e.g. you may choose not to register front and back matter items listed in the
+        table of contents). The language of a content_item only need be set if it differs
+        from the language of book_metadata. The component_type indicates the type of content
+        item you are registering. Please see the example of a book submission in this
+        documentation for a better understanding of how this attribute may be used in nested
+        tables of contents. level_sequence_number indicates the level of nesting for content
+        items. For example, you may use it to indicate when one content item, such as a
+        chapter, is actually inside another content item, such as a section. Please see the
+        example of a book submission in this documentation for a better understanding of how
+        this attribute may be used in nested tables of contents. Note: Because the CrossRef
+        schema uses a flat model to indicate hierarchically nested content items, there is
+        an implicit assumption that content items will be listed in the CrossRef submission
+        in the same order in which they appear in the table of contents. Please follow this
+        protocol when submitting DOI data for books. This order is not required for journal
+        and conference data. contributors for a content_item need not be listed if all items
+        in a book have the same contributors listed in book_metadata. In other words,
+        contributors must be listed for edited books, but they should not be listed for each
+        content_item in a monograph. The exception case is when a content item such as a
+        Preface or Forward for a monograph has a different author from that of the
+        monograph. In this case, the contributors should be given. The title of each content
+        item must be submitted. If, however, you are submitted data for a monograph that
+        simply has "Chapter 1", "Chapter 2", etc., you should put this information in
+        component_number, not titles.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="contributors" minOccurs="0"/>
+        <xsd:element ref="titles" minOccurs="0"/>
+        <xsd:element ref="jats:abstract" minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>The abstract element allows depositors to include
+              abstracts extracted from NLM or JATS XML in CrossRef deposits. The jats:
+              namespace prefix must be included.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="component_number" minOccurs="0"/>
+        <xsd:element ref="publication_date" minOccurs="0" maxOccurs="10"/>
+        <xsd:element ref="pages" minOccurs="0"/>
+        <xsd:element ref="publisher_item" minOccurs="0"/>
+        <xsd:choice>
+          <xsd:element ref="crossmark" minOccurs="0"/>
+          <xsd:sequence>
+            <xsd:element ref="fr:program" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="ai:program" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="ct:program" minOccurs="0" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:choice>
+        <xsd:element ref="rel:program" minOccurs="0"/>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="scn_policies" minOccurs="0" maxOccurs="1"/>    <!-- cs-3495 -->
+        <xsd:element ref="doi_data"/>
+        <xsd:element ref="citation_list" minOccurs="0"/>
+        <xsd:element ref="component_list" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attribute name="component_type" use="required">
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:NMTOKEN">
+            <xsd:enumeration value="chapter"/>
+            <xsd:enumeration value="section"/>
+            <xsd:enumeration value="part"/>
+            <xsd:enumeration value="track"/>
+            <xsd:enumeration value="reference_entry"/>
+            <xsd:enumeration value="other"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:attribute>
+      <xsd:attribute name="level_sequence_number" default="1">
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:positiveInteger">
+            <xsd:maxInclusive value="9"/>
+            <xsd:minInclusive value="1"/>
+            <xsd:totalDigits value="1"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:attribute>
+      <xsd:attributeGroup ref="publication_type.atts"/>
+      <xsd:attributeGroup ref="language.atts"/>
+      <xsd:attributeGroup ref="metadata_distribution_opts.att"/>
+      <xsd:attributeGroup ref="reference_distribution_opts.att"/>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- =============================================================
+
+              7. Elements common to books and conferences
+
+     ============================================================= -->
+  <xsd:element name="series_metadata">
+    <xsd:annotation>
+      <xsd:documentation>The container for metadata about a series publication. When a book,
+        conference proceeding, or report consists of multiple volumes, series_metadata is
+        used to describe information about the entire series. If a work spans multiple
+        volumes, you should use titles in series_metadata. If a work spans multiple volumes
+        with a unique title for each volume and the whole series, you should specify the
+        series title in titles in series_metadata and the volume title in titles in
+        book_series_metadata. If a unique ISBN has been assigned to the entire series (as
+        opposed to the individual volumes), it should given in series_metadata. You may
+        assign and register a DOI that encompasses an entire series by adding doi_data in
+        series_metadata. This element is optional for a series.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="contributors" minOccurs="0"/>
+        <xsd:element ref="titles"/>
+        <xsd:element ref="jats:abstract" minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>The abstract element allows depositors to include
+              abstracts extracted from NLM or JATS XML in CrossRef deposits. The jats:
+              namespace prefix must be included.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="issn" maxOccurs="6"/>
+        <xsd:element ref="coden" minOccurs="0"/>
+        <xsd:element ref="series_number" minOccurs="0"/>
+        <xsd:element ref="publisher_item" minOccurs="0"/>
+        <xsd:choice>
+          <xsd:element ref="crossmark" minOccurs="0"/>
+          <xsd:sequence>
+            <xsd:element ref="fr:program" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="ai:program" minOccurs="0" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:choice>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="doi_data" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="set_metadata">
+    <xsd:annotation>
+      <xsd:documentation>When a book consists of multiple volumes that are not part of a
+        serial publication (series), set_metadata is used to describe information about the
+        entire set.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="titles"/>
+        <xsd:choice>
+          <xsd:element ref="isbn" maxOccurs="6"/>
+          <xsd:element ref="noisbn"/>
+        </xsd:choice>
+        <xsd:element ref="contributors" minOccurs="0"/>
+        <xsd:element ref="part_number" minOccurs="0"/>
+        <xsd:element ref="publisher_item" minOccurs="0"/>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="doi_data" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="series_number">
+    <xsd:annotation>
+      <xsd:documentation>The series number within a specific published conference discipline.
+        The series number is different from the volume number. A volume number is the number
+        of a book in a physically printed set and typically appears in sequence. The series
+        number is not tied to the physical manifestation of the printed volume and need not
+        be strictly in sequence. It is most commonly used in "Lectures" published by
+        Springer-Verlag. This element is available in series_metadata, however it should
+        only be used for conference proceedings, not for books.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="15"/>
+        <xsd:minLength value="1"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <xsd:element name="part_number">
+    <xsd:annotation>
+      <xsd:documentation>The part number of a given volume. Deposited within
+        book_set_metadata. In some cases, a book set will have multiple parts, and then one
+        or more volumes within each part. The part number of a given volume should be
+        deposited in this element.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="15"/>
+        <xsd:minLength value="1"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <xsd:element name="publisher">
+    <xsd:annotation>
+      <xsd:documentation>A container for information about the publisher of a book or
+        conference proceedings.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="publisher_name"/>
+        <xsd:element ref="publisher_place" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="publisher_place">
+    <xsd:annotation>
+      <xsd:documentation>The city where the publisher of this work is located. publisher_place
+        gives the primary city location of the publisher. When the location is a major city
+        (e.g. New York, Amsterdam), no qualifying country, U.S. state, or Canadian province
+        need be given. If the city is not a major city, the appropriate country, U.S. state,
+        or Canadian province should be added.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="255"/>
+        <xsd:minLength value="2"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <xsd:element name="publisher_name">
+    <xsd:annotation>
+      <xsd:documentation>The name of the publisher of a book or conference proceedings.
+        publisher_name is the imprint of the publication (what the author will likely cite),
+        not the organization registering the DOI, if for any reason they are different. When
+        registering a translation, the translation publisher, not the original publisher,
+        should be given.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="255"/>
+        <xsd:minLength value="1"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <!-- =============================================================
+
+       8. Elements common to journals, books and conferences
+
+     ============================================================= -->
+  <xsd:element name="publisher_item">
+    <xsd:annotation>
+      <xsd:documentation>A container for item identification numbers set by a publisher.
+        item_number within publisher_item may also be used to provide an article number when
+        a first_page is not available or applicable. In certain cases it may be deemed
+        in-appropriate to 'misuse' the first_page element to provide a value that has
+        meaning in an on-line only publication and does not convey an form of page number.
+        In these circumstances the attribute &lt;item_number
+        item_number_type="article-number"&gt; will instruct the CrossRef system to treat the
+        value of item_number in the same manner as first_page. This value then becomes a
+        critical part of the query process. If both &lt;item_number
+        item_number_type="article-number"&gt; and first_page are present, first_page will
+        take precedence.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="item_number" minOccurs="0" maxOccurs="3"/>
+        <xsd:element ref="identifier" minOccurs="0" maxOccurs="10"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:simpleType name="item_number_t">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="32"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:element name="item_number">
+    <xsd:annotation>
+      <xsd:documentation>A publisher identifier that can be used to uniquely identify the
+        entity being registered. This identifier is a publisher-assigned number that
+        uniquely identifies the entity being registered. This element should be used for
+        identifiers based on publisher internal standards. Use identifier for a publisher
+        identifier that is based on a public standard such as PII or SICI. If the
+        item_number and identifier are identical, there is no need to submit both. In this
+        case, the preferred element to use is identifier. Data may be alpha, numeric or a
+        combination. item_number has an optional attribute, item_number_type. It is assigned
+        by the publisher to provide context for the data in item_number. If item_number
+        contains only a publisher's tracking number, this attribute need not be supplied. If
+        the item_number contains other data, this attribute can be used to define the
+        content. For example, if a journal is published online (i.e. it has no page
+        numbers), and each article on the table of contents is assigned a sequential number,
+        this article number can be placed in item_number, and the item_number_type attribute
+        can be set to "article_number". Although CrossRef has not provided a set of
+        enumerated types for this attribute, please check with CrossRef before using this
+        attribute to determine if a standard attribute has already been defined for your
+        specific needs. If a dissertation DAI has been assigned, it should be deposited in
+        the identifier element with the id_type attribute set to "dai". If an institution
+        has its own numbering system, it should be deposited in item_number, and the
+        item_number_type should be set to "institution" If the report number of an item
+        follows Z39.23, the number should be deposited in the identifier element with the
+        id_type attribute set to "Z39.23". If a report number uses its own numbering system,
+        it should be deposited in the identifier element, and the id_type should be set to
+        "report-number" The designation for a standard should be placed inside the
+        identifier element with the id_type attribute set to "ISO-std-ref" or
+        "std-designation" (more generic label)
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:simpleContent>
+        <xsd:extension base="item_number_t">
+          <xsd:attribute name="item_number_type" type="xsd:string" use="optional"/>
+        </xsd:extension>
+      </xsd:simpleContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:simpleType name="identifier_t">
+    <xsd:restriction base="xsd:string">
+      <xsd:maxLength value="255"/>
+      <xsd:minLength value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:element name="identifier">
+    <xsd:annotation>
+      <xsd:documentation>A public standard identifier that can be used to uniquely identify
+        the entity being registered. This identifier is a publisher-assigned number that
+        uniquely identifies the entity being registered. This element should be used for
+        identifiers based on public standards. Use item_number for a publisher identifier
+        that is based on a publisher's internal systems rather than on a public standard.
+        The supported standards are: PII - Publisher Item Identifier SICI - Serial Item and
+        Contribution Identifier DOI - Digital Object Identifier
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:simpleContent>
+        <xsd:extension base="identifier_t">
+          <xsd:attribute name="id_type" use="required">
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:NMTOKEN">
+                <xsd:enumeration value="pii"/>
+                <xsd:enumeration value="sici"/>
+                <xsd:enumeration value="doi"/>
+                <xsd:enumeration value="dai"/>
+                <xsd:enumeration value="Z39.23"/>
+                <xsd:enumeration value="ISO-std-ref"/>
+                <xsd:enumeration value="std-designation"/>
+                <xsd:enumeration value="report-number"/>
+                <xsd:enumeration value="pmid"/>
+                <xsd:enumeration value="other"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:simpleContent>
+    </xsd:complexType>
+  </xsd:element>
+  <!-- =============================================================
+
+      9. Expanded Content Types (reports, dissertations, standards, and datasets)
+
+     ============================================================= -->
+  <xsd:element name="dissertation">
+    <xsd:annotation>
+      <xsd:documentation>dissertation is the top level element for deposit of metadata about
+        one or more dissertations. The dissertation element does not have publisher, or issn
+        elements. It is expected that the dissertation element will be used for deposit of
+        items that have not been published in books or journals. If a dissertation is
+        published as a book or within a serial, it should be deposited using the top-level
+        element for the appropriate publication type. If a DAI has been assigned, it should
+        be deposited in the identifier element with the id_type attribute set to "dai". If
+        an institution has its own numbering system, it should be deposited in item_number,
+        and the item_number_type should be set to "institution"
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="person_name"/>
+        <xsd:element ref="titles"/>
+        <xsd:element ref="approval_date" maxOccurs="10"/>
+        <xsd:element ref="institution" maxOccurs="6"/>
+        <xsd:element ref="degree" minOccurs="0" maxOccurs="10"/>
+        <xsd:element ref="isbn" minOccurs="0" maxOccurs="6"/>
+        <xsd:element ref="publisher_item" minOccurs="0"/>
+        <xsd:choice>
+          <xsd:element ref="crossmark" minOccurs="0"/>
+          <xsd:sequence>
+            <xsd:element ref="fr:program" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="ai:program" minOccurs="0" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:choice>
+        <xsd:element ref="rel:program" minOccurs="0"/>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="scn_policies" minOccurs="0" maxOccurs="1"/>    <!-- cs-3495 -->
+        <xsd:element ref="doi_data"/>
+        <xsd:element ref="citation_list" minOccurs="0"/>
+        <xsd:element ref="component_list" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="publication_type.atts"/>
+      <xsd:attributeGroup ref="language.atts"/>
+      <xsd:attributeGroup ref="metadata_distribution_opts.att"/>
+      <xsd:attributeGroup ref="reference_distribution_opts.att"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- =============================================================
+      Reports / Working papers     
+     ============================================================= -->
+
+  <xsd:element name="report-paper">
+    <xsd:annotation>
+      <xsd:documentation>report-paper is the top level element for deposit of metadata about
+        one or more reports or working papers. component_list is included in report-paper to
+        handle items that have components but do not have content_item elements (i.e. a
+        report that is not divided into multiple chapters). If an item has content_item
+        elements, then component_list inside of content_item must be used rather than the
+        element available in report-paper
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:choice>
+          <xsd:element ref="report-paper_metadata"/>
+          <xsd:element ref="report-paper_series_metadata"/>
+        </xsd:choice>
+        <xsd:element ref="content_item" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="component_list" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="publication_type.atts"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="report-paper_metadata">
+    <xsd:annotation>
+      <xsd:documentation>report-paper_metadata is used as a wrapper for the metadata related
+        to a Technical Report or Working Paper. report-paper_metadata is almost identical to
+        book_metadata. It differs only in that report-paper_metadata removes the volume
+        number and adds the elements institution and contract_number. Please see the
+        comments for book_metadata about the usage of most elements in report-
+        paper_metadata. Reports and Working Papers are often sponsored by either
+        universities or by a non-academic organization (corporate or government). Such
+        institutions are not typically considered "publishers" and so the item may be
+        deposited using the institution element. Multiple element instances are permitted so
+        the sponsoring institution and publishing institution can both be deposited as
+        authors may cite either. If the report number of an item follows Z39.23, the number
+        should be deposited in the identifier element with the id_type attribute set to
+        "Z39.23". If a report number uses its own numbering system, it should be deposited
+        in item_number.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="contributors" minOccurs="0"/>
+        <xsd:element ref="titles"/>
+        <xsd:element ref="edition_number" minOccurs="0"/>
+        <xsd:element ref="publication_date" maxOccurs="10"/>
+        <xsd:element ref="approval_date" minOccurs="0" maxOccurs="10"/>
+        <xsd:element ref="isbn" minOccurs="0" maxOccurs="6"/>
+        <xsd:element ref="publisher" minOccurs="0"/>
+        <xsd:element ref="institution" minOccurs="0" maxOccurs="5"/>
+        <xsd:element ref="publisher_item" minOccurs="0"/>
+        <xsd:element ref="contract_number" minOccurs="0"/>
+        <xsd:choice>
+          <xsd:element ref="crossmark" minOccurs="0"/>
+          <xsd:sequence>
+            <xsd:element ref="fr:program" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="ai:program" minOccurs="0" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:choice>
+        <xsd:element ref="rel:program" minOccurs="0"/>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="scn_policies" minOccurs="0" maxOccurs="1"/>    <!-- cs-3495 -->
+        <xsd:element ref="doi_data" minOccurs="0"/>
+        <xsd:element ref="citation_list" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="language.atts"/>
+      <xsd:attributeGroup ref="metadata_distribution_opts.att"/>
+      <xsd:attributeGroup ref="reference_distribution_opts.att"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="report-paper_series_metadata">
+    <xsd:annotation>
+      <xsd:documentation>report-paper_series_metadata is used as a wrapper for the metadata
+        related to a Technical Report or Working Paper that is part of a series.
+        report-paper_series_metadata is almost identical to book_series_metadata. It differs
+        only in that report-paper_metadata removes the volume number and adds the elements
+        institution and contract_number. Please see the comments for book_series_metadata
+        about the usage of most elements in report- paper_series_metadata. Reports and
+        Working Papers are often sponsored by either universities or by a non-academic
+        organization (corporate or government). Such institutions are not typically
+        considered "publishers" and so the item may be deposited using the institution
+        element. Multiple element instances are permitted so the sponsoring institution and
+        publishing institution can both be deposited as authors may cite either. If the
+        report number of an item follows Z39.23, the number should be deposited in the
+        identifier element with the id_type attribute set to "Z39.23". If a report number
+        uses its own numbering system, it should be deposited in
+        item_number.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="series_metadata"/>
+        <xsd:element ref="contributors" minOccurs="0"/>
+        <xsd:choice>
+          <xsd:sequence>
+            <xsd:element ref="titles"/>
+            <xsd:element ref="jats:abstract" minOccurs="0">
+              <xsd:annotation>
+                <xsd:documentation>The abstract element allows depositors to include
+                  abstracts extracted from NLM or JATS XML in CrossRef deposits.
+                  The jats: namespace prefix must be included.
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element ref="volume" minOccurs="0"/>
+          </xsd:sequence>
+          <xsd:element ref="volume"/>
+        </xsd:choice>
+        <xsd:element ref="edition_number" minOccurs="0"/>
+        <xsd:element ref="publication_date" maxOccurs="10"/>
+        <xsd:element ref="approval_date" minOccurs="0" maxOccurs="10"/>
+        <xsd:element ref="isbn" minOccurs="0" maxOccurs="6"/>
+        <xsd:element ref="publisher" minOccurs="0"/>
+        <xsd:element ref="institution" minOccurs="0" maxOccurs="5"/>
+        <xsd:element ref="publisher_item" minOccurs="0"/>
+        <xsd:element ref="contract_number" minOccurs="0"/>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="doi_data" minOccurs="0"/>
+        <xsd:element ref="citation_list" minOccurs="0"/>
+        <xsd:element ref="rel:program" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="language.atts"/>
+      <xsd:attributeGroup ref="metadata_distribution_opts.att"/>
+      <xsd:attributeGroup ref="reference_distribution_opts.att"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- =============================================================
+        Standards
+       ============================================================= -->
+
+
+  <xsd:element name="standard">
+    <xsd:annotation>
+      <xsd:documentation>standard is the top level element for deposit of metadata about
+        standards developed by Standards Development Organizations (SDOs) or Consortia.
+        CrossRef does not determine if a new DOI should be created for each revision or
+        reaffirmation of a standard. The decision will be left to the individual standards
+        organizations. As of schema version 4.3.3, CrossRef recommends that the full
+        standard designation be placed in the as_published element (within
+        standard_designator). For backwards compatibility, the full designation may also be
+        included in the identifier element with the id_type attribute set to "ISO-std-ref".
+        In addition, CrossRef requires that the publisher of the standard be included in
+        standards_body_name, and the acronym within standards_acronym. The as_published and
+        standards_acronym elements will be combined to identify a standard for query
+        matching. component_list is included in standard to handle items that have
+        components but do not have content_item elements (i.e. a standard that is not
+        divided into multiple chapters). If an item has content_item elements, then
+        component_list inside of content_item must be used rather than the parent standard
+        element.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:choice>
+          <xsd:element ref="standard_metadata"/>
+        </xsd:choice>
+        <xsd:element ref="content_item" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="component_list" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="publication_type.atts"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="standard_metadata">
+    <xsd:annotation>
+      <xsd:documentation>Standard_metadata is used as a wrapper for the metadata related to a
+        Standard that is not part of a series. standard_metadata is similar to
+        book_metadata. It differs in that standard_metadata adds the elements institution
+        and approval_date. contributors contains the author(s) of the standard. In most
+        cases, it is expected that the organization element will be used rather than
+        person_name element for standards. However in some cases, standards are cited by
+        their individual authors. In such cases, individual authors should be deposited with
+        person_name, and the SDO or consortia name should be deposited with the organization
+        element in contributors and also the standards_body_name element in standards_body
+        Note that when the organization element is used in contributors, it should have the
+        name of the committee (when appropriate) that developed the standard, not the name
+        of the Standards Development Organization (SDO) or consortia. The SDO or consortia
+        name should be placed in the publisher or standards_body element (as appropriate)
+        Standards more often have version numbers than edition numbers. However the
+        edition_number element can be used for deposit of the version number of a standard
+        approval_date should be used for the date that a standard has been accepted or
+        re-affirmed if different from the date of publication. Both may be provided even if
+        identical Within publisher_item, the designation should be placed inside the
+        item_number element, and the id_type should be set to "designation" to indicate a
+        standard designation. Standards are typically sponsored or hosted by SDOs or
+        Consortia. In some cases standards are published by a traditional publisher rather
+        than by the owning organization. Such cases may be deposited with one or more
+        publishers.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="contributors" minOccurs="0"/>
+        <xsd:element ref="titles"/>
+        <xsd:element ref="jats:abstract" minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>The abstract element allows depositors to include
+              abstracts extracted from NLM or JATS XML in CrossRef deposits. The jats:
+              namespace prefix must be included.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="designators" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="edition_number" minOccurs="0"/>
+        <xsd:element ref="approval_date" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="isbn" minOccurs="0" maxOccurs="6"/>
+        <xsd:element ref="publisher" minOccurs="0"/>
+        <xsd:element ref="standards_body"/>
+        <xsd:element ref="publisher_item" minOccurs="0"/>
+        <xsd:choice>
+          <xsd:element ref="crossmark" minOccurs="0"/>
+          <xsd:sequence>
+            <xsd:element ref="fr:program" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="ai:program" minOccurs="0" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:choice>
+        <xsd:element ref="rel:program" minOccurs="0"/>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="doi_data" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="citation_list" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attribute name="publication_status" use="optional">
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:NMTOKEN">
+            <xsd:enumeration value="released"/>
+            <xsd:enumeration value="withdrawn"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:attribute>
+      <xsd:attributeGroup ref="language.atts"/>
+      <xsd:attributeGroup ref="metadata_distribution_opts.att"/>
+      <xsd:attributeGroup ref="reference_distribution_opts.att"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- =============================================================
+        Database / datasets
+       ============================================================= -->
+
+  <xsd:element name="database">
+    <xsd:annotation>
+      <xsd:documentation>database is the top level element for deposit of metadata about one
+        or more datasets or records in a database. Database structures allow for the
+        assignment of DOIs to entire databases at the aggregate level and at two lower
+        levels. The top level may be a physical/functional database or a logical abstration
+        acting as a collection much the same as a journal is a collection of articles. The
+        need to assign specific fields of metadata at each level depends on the nature of
+        the top most level (e.g. publication date may be appropriate at the top level for a
+        physical object but only at lower levels for an abstract top level object) The first
+        sub-level is the dataset which may be a basic record of the top level object or a
+        collection in its own right. In either case dataset must represent a physical
+        construct. A third level is provided in the component_list. NOTE: component_list in
+        &lt;database&gt; (rather than in dataset may be used as a second level when no third
+        level is required and the second level objects derive most of their qualities from
+        the parent. NOTE: This model is not intended to show relationships between different
+        dataset entries in the form of a relational database. However in the future it is
+        possible that multiple resolution may be used to express such
+        relationships
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="database_metadata"/>
+        <xsd:choice>
+          <xsd:element ref="dataset" minOccurs="0" maxOccurs="unbounded"/>
+          <xsd:element ref="component_list" minOccurs="0"/>
+        </xsd:choice>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="database_metadata">
+    <xsd:annotation>
+      <xsd:documentation>database_metadata contains metadata about the database. contributors
+        contains the author(s) of the database. In most cases, it is expected that the
+        organization element will be used rather than person_name element for the primary
+        database authoring information. contributors should not be confused with publisher
+        and institution. In many cases, databases are more likely to have one or both of the
+        latter elements rather than contributors at the top level (dataset elements are more
+        likely to have contributors). In most cases, the institution element may be the best
+        choice to deposit the database host organization because it includes the
+        institution_acronym element along with the name. The titles element is used to
+        capture the name of the database. The description element can be used to capture a
+        fuller description of the nature of the database than might be inferred from the
+        title. database_date should be used to capture the date that a database was first
+        created. Whenever updated records are deposited with CrossRef, the update_date
+        should be set to the date of the most recent CrossRef deposit. publisher_item may be
+        used to record an identifying number for the database other than the
+        DOI.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="contributors" minOccurs="0"/>
+        <xsd:element ref="titles"/>
+        <xsd:element ref="description" minOccurs="0"/>
+        <xsd:element ref="database_date" minOccurs="0" maxOccurs="10"/>
+        <xsd:element ref="publisher" minOccurs="0"/>
+        <xsd:element ref="institution" minOccurs="0" maxOccurs="10"/>
+        <xsd:element ref="publisher_item" minOccurs="0"/>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="doi_data" minOccurs="0"/>
+        <xsd:element ref="rel:program" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attributeGroup ref="language.atts"/>
+      <xsd:attributeGroup ref="metadata_distribution_opts.att"/>
+      <xsd:attributeGroup ref="reference_distribution_opts.att"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="dataset">
+    <xsd:annotation>
+      <xsd:documentation>dataset is used to capture information about one or more database
+        records or collections. The dataset_type attribute should be set to either "record"
+        or "collection" to indicate the type of deposit. The default value of this attribute
+        is "record". dataset entries are not intended to contain the entire database record
+        or collection. They are only intended to contain the metadata for each database
+        record or collection. The metadata can include: contributors: the author(s) of a
+        database record or collection titles: the title of a database record or collection
+        database_date: the creation date, publication date (if different from the creation
+        date) and the date of last update of the record publisher_item: the record number of
+        the dataset item. In this context, publisher_item can be used for the record number
+        of each item in the database. description: a brief summary description of the
+        contents of the database format: the format type of the dataset item if it includes
+        files rather than just text. Note the format element here should not be used to
+        describe the format of items deposited as part of the component_list doi_data: the
+        doi of the item. citation_list: a list of items (e.g. journal articles) cited by the
+        dataset item. For example, dataset entry from a taxonomy might cite the article in
+        which a species was first identified. component_list: a list of components included
+        in the dataset item such as supporting figures
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="contributors" minOccurs="0"/>
+        <xsd:element ref="titles" minOccurs="0"/>
+        <xsd:element ref="database_date" minOccurs="0" maxOccurs="10"/>
+        <xsd:element ref="publisher_item" minOccurs="0"/>
+        <xsd:element ref="description" minOccurs="0"/>
+        <xsd:element ref="format" minOccurs="0"/>
+        <xsd:choice>
+          <xsd:element ref="crossmark" minOccurs="0"/>
+          <xsd:sequence>
+            <xsd:element ref="fr:program" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="ai:program" minOccurs="0" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:choice>
+        <xsd:element ref="rel:program" minOccurs="0"/>
+        <xsd:element ref="archive_locations" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="doi_data"/>
+        <xsd:element ref="citation_list" minOccurs="0"/>
+        <xsd:element ref="component_list" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attribute name="dataset_type" default="record">
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:NMTOKEN">
+            <xsd:enumeration value="record"/>
+            <xsd:enumeration value="collection"/>
+            <xsd:enumeration value="crossmark_policy"/>
+            <xsd:enumeration value="other"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- =============================================================
+        Peer review
+       ============================================================= -->
+
+  <xsd:element name="peer_review">
+    <xsd:annotation>
+      <xsd:documentation>The peer_review content type is intended for assigning DOIs to the reports and other artifacts
+        associated with the review of published content.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="contributors" minOccurs="0"/>
+        <xsd:element ref="titles" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="review_date" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="institution" minOccurs="0" maxOccurs="5"/>
+        <xsd:element ref="competing_interest_statement" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="running_number" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="ai:program" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="rel:program" minOccurs="1"/>
+        <xsd:element ref="scn_policies" minOccurs="0" maxOccurs="1"/>    <!-- cs-3495 -->
+        <xsd:element ref="doi_data" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+      <xsd:attribute name="stage" use="optional">
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:NMTOKEN">
+            <xsd:enumeration value="pre-publication"/>
+            <xsd:enumeration value="post-publication"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:attribute>
+      <xsd:attribute name="type" use="optional">
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:NMTOKEN">
+            <xsd:enumeration value="referee-report"/>
+            <xsd:enumeration value="editor-report"/>
+            <xsd:enumeration value="author-comment"/>
+            <xsd:enumeration value="community-comment"/>
+            <xsd:enumeration value="aggregate"/>
+            <xsd:enumeration value="recommendation"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:attribute>
+      <xsd:attribute name="recommendation" use="optional">
+        <xsd:annotation>
+          <xsd:documentation>Recommendation provided by reviewer</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:NMTOKEN">
+            <xsd:enumeration value="major-revision"/>
+            <xsd:enumeration value="minor-revision"/>
+            <xsd:enumeration value="reject"/>
+            <xsd:enumeration value="reject-with-resubmit"/>
+            <xsd:enumeration value="accept"/>
+            <xsd:enumeration value="accept-with-reservation"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:attribute>
+      <xsd:attribute name="revision-round" use="optional" type="xsd:integer">
+        <xsd:annotation>
+          <xsd:documentation>Revision round number, first submission is defined as revision round 0</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attributeGroup ref="language.atts"/>
+      <xsd:attributeGroup ref="metadata_distribution_opts.att"/>
+    </xsd:complexType>
+
+  </xsd:element>
+
+  <!-- =============================================================
+        Posted Content (pre-publication)
+       ============================================================= -->
+
+  <xsd:element name="posted_content">
+    <xsd:annotation>
+      <xsd:documentation>Posted-content is for the assignment of DOIs to content that may
+        subsequently be formally published, such as preprints. Non-DOI identifiers associated with the content
+        may be recorded in the item_number element. We encourage the inclussion of an
+        abstract. The relation program (rel:program) should be used to link this content
+        item to other DOIs including the DOI of the published version of record. Posted content
+        should not be used to assign DOIs to accepted manuscripts. A DOI may be assigned to
+        an accepted manuscript using the content type appropriate for early registration.
+        DOIs assigned to accepted manuscripts should be reused (e.g. reassigned to the
+        published article). Posted-content DOIs must be continuously supported by
+        maintaining their metadata and the URL at which the content is available.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="group_title" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="contributors" minOccurs="0"/>
+        <xsd:element ref="titles"/>
+        <xsd:element ref="posted_date" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="acceptance_date" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="institution" minOccurs="0" maxOccurs="5"/>
+        <xsd:element ref="item_number" minOccurs="0" maxOccurs="3"/>
+        <xsd:element ref="jats:abstract" minOccurs="0"/>
+        <xsd:element maxOccurs="1" ref="fr:program" minOccurs="0"/>
+        <xsd:element ref="ai:program" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="rel:program" minOccurs="0"/>
+        <xsd:element ref="scn_policies" minOccurs="0" maxOccurs="1"/>    <!-- cs-3495 -->
+        <xsd:element ref="doi_data" minOccurs="1"/>
+        <xsd:element ref="citation_list" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attribute name="type" default="preprint">
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:NMTOKEN">
+            <xsd:enumeration value="preprint"/>
+            <xsd:enumeration value="working_paper"/>
+            <xsd:enumeration value="letter"/>
+            <xsd:enumeration value="dissertation"/>
+            <xsd:enumeration value="report"/>
+            <xsd:enumeration value="review"/>
+            <xsd:enumeration value="other"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:attribute>
+      <xsd:attributeGroup ref="language.atts"/>
+      <xsd:attributeGroup ref="metadata_distribution_opts.att"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="group_title">
+    <xsd:annotation>
+      <xsd:documentation>Prepublication content items may be organized into groupings within a
+        given publisher. This element provides for naming the group. It is expected that
+        publishers will have a small number of groups each of which reflect a topic or
+        subject area.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="1024"/>
+        <xsd:minLength value="1"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <!-- =============================================================================
+
+        10. Elements common to reports, dissertations, standards, posted content, peer review
+
+     ============================================================================= -->
+  <xsd:element name="institution">
+    <xsd:annotation>
+      <xsd:documentation>Wrapper element for information about an organization that sponsored
+        or hosted an item but is not the publisher of the item. The institution element
+        should be used to deposit metadata about an organization that sponsored or hosted
+        the research or development of the published material but was not actually the
+        publisher of the information. The institution is distinctly different from the
+        publisher because it may not be a publishing organization. It is typically an
+        organization such as a university, corporation, government agency, NGO or consortia.
+        If the content was published by an organization other than the sponsor, the use of
+        both the publisher and institution elements is encouraged because authors may cite
+        either one in a reference, and the availability of both may allow for more precise
+        matching in queries.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="institution_name"/>
+        <xsd:element ref="institution_acronym" minOccurs="0" maxOccurs="6"/>
+        <xsd:element ref="institution_place" minOccurs="0" maxOccurs="6"/>
+        <xsd:element ref="institution_department" minOccurs="0" maxOccurs="6"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="institution_name">
+    <xsd:annotation>
+      <xsd:documentation>The full name of an institution. Examples are: World Health
+        Organization; University of California, Davis. Corresponding institution_acronym
+        content for these organizations would be WHO and UCD,
+        respectively.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="1024"/>
+        <xsd:minLength value="1"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <xsd:element name="institution_acronym">
+    <xsd:annotation>
+      <xsd:documentation>The acronym of the institution. Note that authors often cite with
+        acronyms and this information can be important in matching a query Examples: WHO,
+        UCDavis, UCD Note: as shown above, an institution may be know by multiple acronyms,
+        in which case all common acronyms should be deposited.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="255"/>
+        <xsd:minLength value="1"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <xsd:element name="institution_place">
+    <xsd:annotation>
+      <xsd:documentation>institution_place gives
+        the primary city location of the institution. When the location is a major city
+        (e.g. New York, Amsterdam), no qualifying country or U.S. state need be given. If
+        the city is not a major city, the appropriate country and/or state or province
+        should be added.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="255"/>
+        <xsd:minLength value="2"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <xsd:element name="institution_department">
+    <xsd:annotation>
+      <xsd:documentation>institution_department is a department within an institution. A common use is the department
+        under which a
+        dissertation was completed. Note that the institution_department is repeatable. If
+        multiple departments are to be deposited, each one should be given in a unique
+        institution_department element. Example: Department of Psychology
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="255"/>
+        <xsd:minLength value="2"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+
+
+  <xsd:element name="degree">
+    <xsd:annotation>
+      <xsd:documentation>The degree(s) awarded for a dissertation.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="255"/>
+        <xsd:minLength value="2"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+  <xsd:element name="contract_number">
+    <xsd:annotation>
+      <xsd:documentation>The contract number under which a report or paper was
+        written.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleType>
+      <xsd:restriction base="xsd:string">
+        <xsd:maxLength value="255"/>
+        <xsd:minLength value="2"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:element>
+</xsd:schema>

--- a/mycore-pi/src/main/resources/xsd/crossref/4.4.1/fundref.xsd
+++ b/mycore-pi/src/main/resources/xsd/crossref/4.4.1/fundref.xsd
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://www.crossref.org/fundref.xsd"
+    xmlns="http://www.crossref.org/fundref.xsd">
+    
+    <!--=========Change History===========
+    5/2/13 (PDF) changed funding_identifier to award_number
+    -->
+    
+    
+    <xsd:element name="program">
+        <xsd:annotation>
+            <xsd:documentation>
+                FundRef documentation and examples: http://help.crossref.org/#fundref
+                
+                As part of CrossMark metadata, a deposit may contain what is called FundRef info. This details the funding behind a published article. The schema is a sequence of nested &lt;assertion&gt; tags. 
+                
+                If a DOI is not participating in CrossMark, FundRef data may be deposited as part of the &lt;journal_article&gt; metadata.
+                    
+                    Note: Some rules will be enforced by the deposit logic (e.g. not the schema). 
+                    
+                    FundRef data includes one or more award numbers (award_number), each of which may have one or more funders (funder_name). Each funder may have one or more optional identifiers (funder_identifier).
+                    
+                    A FundRef deposit begins with a &lt;fr:program&gt; tag within the &lt;crossmark&gt; structure (where fr is the namespace for the FundRef program).
+                        
+                        The &lt;program&gt; element is an implicit funder_group and will typically contain:
+                            
+                            A) one or more funder_name assertions and an award_number assertion.
+                            
+                            or
+                            
+                            B) one or more funder_group assertions where each funder_group should contain one or more funder_name assertions and at least one award_number assertion.
+                            
+                            Multiple 'award_number's may be included in a single program or fundgroup. Deposits without an award_number will be accepted, but award_number should be provided whenever possible. Items with several award numbers associated with a single funding organization should be grouped together by enclosing the "funder_name", "funder_identifier", and award_number(s) within a "fundgroup" assertion.    
+</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element ref="assertion" minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+            <xsd:attribute name="name" type="xsd:string" fixed="fundref"/>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="assertion">
+        <xsd:annotation>
+            <xsd:documentation>FundRef attributes included in assertion are:
+
+fundgroup: used to group funding info for items with multiple funding sources. Required for items with multiple award_number assertions, optional for items with a single award_number
+
+funder_identifier: funding agency identifier, must be nested within the funder_name assertion
+
+funder_name: name of the funding agency (required)
+
+award_number: grant number or other fund identifier</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType mixed="true">
+            <xsd:sequence>
+                <xsd:element ref="assertion" minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+            <xsd:attribute name="provider" default="publisher">
+                <xsd:simpleType>
+                <xsd:restriction base="xsd:NMTOKEN">
+                    <xsd:enumeration value="publisher"/>
+                    <xsd:enumeration value="crossref"/>
+                </xsd:restriction>
+                </xsd:simpleType>
+            </xsd:attribute>
+            <xsd:attribute name="name" use="required">
+                <xsd:simpleType>
+                    <xsd:restriction base="xsd:NMTOKEN">
+                        <xsd:enumeration value="fundgroup"/>
+                        <!-- fundgroup: used to group funding info for items with multiple funding sources. 
+                            Required for items with multiple award_number assertions, optional for items with a single award_number -->
+                        <xsd:enumeration value="funder_identifier"/>
+                        <!--funder_identifier: funding agency identifier, must be nested within the funder_name assertion-->
+                        <xsd:enumeration value="funder_name"/>
+                        <!--funder_name: name of the funding agency-->
+                        <xsd:enumeration value="award_number"/>
+                        <!---award_number: grant number or other fund identifier-->
+                    </xsd:restriction>
+                </xsd:simpleType>
+            </xsd:attribute>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/mycore-pi/src/main/resources/xsd/crossref/4.4.1/mathml3-common.xsd
+++ b/mycore-pi/src/main/resources/xsd/crossref/4.4.1/mathml3-common.xsd
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:m="http://www.w3.org/1998/Math/MathML"
+           elementFormDefault="qualified"
+           targetNamespace="http://www.w3.org/1998/Math/MathML">
+   <xs:element name="math">
+      <xs:complexType>
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:MathExpression"/>
+         <xs:attributeGroup ref="m:math.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="CommonDeprecatedAtt">
+      <xs:attribute name="other"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="CommonAtt">
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="xref"/>
+      <xs:attribute name="class" type="xs:NMTOKENS"/>
+      <xs:attribute name="style" type="xs:string"/>
+      <xs:attribute name="href" type="xs:anyURI"/>
+      <xs:attributeGroup ref="m:CommonDeprecatedAtt"/>
+      <xs:anyAttribute namespace="##other" processContents="skip"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="math.deprecatedattributes">
+      <xs:attribute name="mode" type="xs:string"/>
+      <xs:attribute name="macros" type="xs:string"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="name">
+      <xs:attribute name="name" use="required" type="xs:NCName"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="cd">
+      <xs:attribute name="cd" use="required" type="xs:NCName"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="src">
+      <xs:attribute name="src" type="xs:anyURI"/>
+   </xs:attributeGroup>
+   <xs:element name="annotation">
+      <xs:complexType mixed="true">
+         <xs:attributeGroup ref="m:annotation.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:complexType name="annotation-xml.model"><!--content model altered for libxml (annotation-xml)--><xs:sequence>
+         <xs:any processContents="lax"/>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:group name="anyElement">
+      <xs:choice>
+         <xs:any namespace="##other" processContents="skip"/>
+         <xs:any namespace="##local" processContents="skip"/>
+      </xs:choice>
+   </xs:group>
+   <xs:element name="annotation-xml">
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="m:annotation-xml.model">
+               <xs:attributeGroup ref="m:annotation.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="annotation.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attribute name="cd" type="xs:NCName"/>
+      <xs:attribute name="name" type="xs:NCName"/>
+      <xs:attributeGroup ref="m:DefEncAtt"/>
+      <xs:attributeGroup ref="m:src"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="DefEncAtt">
+      <xs:attribute name="encoding" type="xs:string"/>
+      <xs:attribute name="definitionURL" type="xs:anyURI"/>
+   </xs:attributeGroup>
+   <xs:group name="semantics">
+      <xs:sequence>
+         <xs:element name="semantics">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:group ref="m:MathExpression"/>
+                  <xs:choice minOccurs="0" maxOccurs="unbounded">
+                     <xs:element ref="m:annotation"/>
+                     <xs:element ref="m:annotation-xml"/>
+                  </xs:choice>
+               </xs:sequence>
+               <xs:attributeGroup ref="m:semantics.attributes"/>
+            </xs:complexType>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+   <xs:attributeGroup name="semantics.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:DefEncAtt"/>
+      <xs:attribute name="cd" type="xs:NCName"/>
+      <xs:attribute name="name" type="xs:NCName"/>
+   </xs:attributeGroup>
+   <xs:simpleType name="length">
+      <xs:restriction base="xs:string">
+         <xs:pattern value="\s*((-?[0-9]*([0-9]\.?|\.[0-9])[0-9]*(e[mx]|in|cm|mm|p[xtc]|%)?)|(negative)?((very){0,2}thi(n|ck)|medium)mathspace)\s*"/>
+      </xs:restriction>
+   </xs:simpleType>
+</xs:schema>

--- a/mycore-pi/src/main/resources/xsd/crossref/4.4.1/mathml3-content.xsd
+++ b/mycore-pi/src/main/resources/xsd/crossref/4.4.1/mathml3-content.xsd
@@ -1,0 +1,684 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:m="http://www.w3.org/1998/Math/MathML"
+           elementFormDefault="qualified"
+           targetNamespace="http://www.w3.org/1998/Math/MathML">
+   <xs:include schemaLocation="mathml3-strict-content.xsd"/>
+   <xs:complexType name="cn.content" mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element ref="m:mglyph"/>
+         <xs:element ref="m:sep"/>
+         <xs:element ref="m:PresentationExpression"/>
+      </xs:choice>
+   </xs:complexType>
+   <xs:attributeGroup name="cn.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:DefEncAtt"/>
+      <xs:attribute name="type"/>
+      <xs:attribute name="base"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="ci.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:DefEncAtt"/>
+      <xs:attribute name="type"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="ci.type">
+      <xs:attribute name="type" use="required"/>
+   </xs:attributeGroup>
+   <xs:complexType name="ci.content" mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element ref="m:mglyph"/>
+         <xs:element ref="m:PresentationExpression"/>
+      </xs:choice>
+   </xs:complexType>
+   <xs:attributeGroup name="csymbol.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:DefEncAtt"/>
+      <xs:attribute name="type"/>
+      <xs:attribute name="cd" type="xs:NCName"/>
+   </xs:attributeGroup>
+   <xs:complexType name="csymbol.content" mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+         <xs:element ref="m:mglyph"/>
+         <xs:element ref="m:PresentationExpression"/>
+      </xs:choice>
+   </xs:complexType>
+   <xs:element name="bvar">
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice>
+               <xs:element ref="m:ci"/>
+               <xs:group ref="m:semantics-ci"/>
+            </xs:choice>
+            <xs:element ref="m:degree"/>
+         </xs:choice>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="cbytes.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:DefEncAtt"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="cs.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:DefEncAtt"/>
+   </xs:attributeGroup>
+   <!--Ambiguous content model altered (apply.content)-->
+<xs:complexType name="apply.content">
+      <xs:sequence>
+         <xs:group ref="m:ContExp"/>
+         <xs:group ref="m:BvarQ"/>
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:Qualifier"/>
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:ContExp"/>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="bind.content">
+      <xs:complexContent>
+         <xs:extension base="m:apply.content"/>
+      </xs:complexContent>
+   </xs:complexType>
+   <xs:attributeGroup name="base">
+      <xs:attribute name="base" use="required"/>
+   </xs:attributeGroup>
+   <xs:element name="sep">
+      <xs:complexType/>
+   </xs:element>
+   <xs:element name="PresentationExpression" abstract="true"/>
+   <xs:group name="DomainQ">
+      <xs:sequence>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="m:domainofapplication"/>
+            <xs:element ref="m:condition"/>
+            <!--Ambiguous content model altered (interval)--><xs:sequence>
+               <xs:element ref="m:lowlimit"/>
+               <xs:element minOccurs="0" ref="m:uplimit"/>
+            </xs:sequence>
+         </xs:choice>
+      </xs:sequence>
+   </xs:group>
+   <xs:element name="domainofapplication">
+      <xs:complexType>
+         <xs:group ref="m:ContExp"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="condition">
+      <xs:complexType>
+         <xs:group ref="m:ContExp"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="uplimit">
+      <xs:complexType>
+         <xs:group ref="m:ContExp"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="lowlimit">
+      <xs:complexType>
+         <xs:group ref="m:ContExp"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:group name="Qualifier">
+      <xs:choice>
+         <xs:group ref="m:DomainQ"/>
+         <xs:element ref="m:degree"/>
+         <xs:element ref="m:momentabout"/>
+         <xs:element ref="m:logbase"/>
+      </xs:choice>
+   </xs:group>
+   <xs:element name="degree">
+      <xs:complexType>
+         <xs:group ref="m:ContExp"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="momentabout">
+      <xs:complexType>
+         <xs:group ref="m:ContExp"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="logbase">
+      <xs:complexType>
+         <xs:group ref="m:ContExp"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="type">
+      <xs:attribute name="type" use="required"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="order">
+      <xs:attribute name="order" use="required">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="numeric"/>
+               <xs:enumeration value="lexicographic"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="closure">
+      <xs:attribute name="closure" use="required"/>
+   </xs:attributeGroup>
+   <xs:element name="piecewise">
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="m:piece"/>
+            <xs:element ref="m:otherwise"/>
+         </xs:choice>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="piece">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group ref="m:ContExp"/>
+            <xs:group ref="m:ContExp"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="otherwise">
+      <xs:complexType>
+         <xs:group ref="m:ContExp"/>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="DeprecatedContExp" abstract="true"/>
+   <xs:element name="reln" substitutionGroup="m:DeprecatedContExp">
+      <xs:complexType>
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:ContExp"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="fn" substitutionGroup="m:DeprecatedContExp">
+      <xs:complexType>
+         <xs:group ref="m:ContExp"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="declare" substitutionGroup="m:DeprecatedContExp">
+      <xs:complexType>
+         <xs:group maxOccurs="unbounded" ref="m:ContExp"/>
+         <xs:attribute name="type" type="xs:string"/>
+         <xs:attribute name="scope" type="xs:string"/>
+         <xs:attribute name="nargs" type="xs:nonNegativeInteger"/>
+         <xs:attribute name="occurrence">
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:enumeration value="prefix"/>
+                  <xs:enumeration value="infix"/>
+                  <xs:enumeration value="function-model"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="interval.class" abstract="true">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group ref="m:ContExp"/>
+            <xs:group ref="m:ContExp"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+         <xs:attribute name="closure"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="interval" substitutionGroup="m:interval.class"/>
+   <xs:element name="unary-functional.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="inverse" substitutionGroup="m:unary-functional.class"/>
+   <xs:element name="ident" substitutionGroup="m:unary-functional.class"/>
+   <xs:element name="domain" substitutionGroup="m:unary-functional.class"/>
+   <xs:element name="codomain" substitutionGroup="m:unary-functional.class"/>
+   <xs:element name="image" substitutionGroup="m:unary-functional.class"/>
+   <xs:element name="ln" substitutionGroup="m:unary-functional.class"/>
+   <xs:element name="log" substitutionGroup="m:unary-functional.class"/>
+   <xs:element name="moment" substitutionGroup="m:unary-functional.class"/>
+   <xs:element name="lambda.class" abstract="true">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group ref="m:BvarQ"/>
+            <xs:group ref="m:DomainQ"/>
+            <xs:group ref="m:ContExp"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="lambda" substitutionGroup="m:lambda.class"/>
+   <xs:element name="nary-functional.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="compose" substitutionGroup="m:nary-functional.class"/>
+   <xs:group name="binary-arith.class">
+      <xs:choice>
+         <xs:element ref="m:quotient"/>
+         <xs:element ref="m:divide"/>
+         <xs:element ref="m:minus"/>
+         <xs:element ref="m:power"/>
+         <xs:element ref="m:rem"/>
+         <xs:element ref="m:root"/>
+      </xs:choice>
+   </xs:group>
+   <xs:element name="quotient">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="divide">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="minus">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="power">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="rem">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="root">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:group name="unary-arith.class">
+      <xs:choice>
+         <xs:element ref="m:factorial"/>
+         <!--Ambiguous content model altered (minus)--><!--Ambiguous content model altered (root)--><xs:element ref="m:abs"/>
+         <xs:element ref="m:conjugate"/>
+         <xs:element ref="m:arg"/>
+         <xs:element ref="m:real"/>
+         <xs:element ref="m:imaginary"/>
+         <xs:element ref="m:floor"/>
+         <xs:element ref="m:ceiling"/>
+         <xs:element ref="m:exp"/>
+      </xs:choice>
+   </xs:group>
+   <xs:element name="factorial">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="abs">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="conjugate">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="arg">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="real">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="imaginary">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="floor">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="ceiling">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="exp">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="nary-minmax.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="max" substitutionGroup="m:nary-minmax.class"/>
+   <xs:element name="min" substitutionGroup="m:nary-minmax.class"/>
+   <xs:element name="nary-arith.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="plus" substitutionGroup="m:nary-arith.class"/>
+   <xs:element name="times" substitutionGroup="m:nary-arith.class"/>
+   <xs:element name="gcd" substitutionGroup="m:nary-arith.class"/>
+   <xs:element name="lcm" substitutionGroup="m:nary-arith.class"/>
+   <xs:element name="nary-logical.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="and" substitutionGroup="m:nary-logical.class"/>
+   <xs:element name="or" substitutionGroup="m:nary-logical.class"/>
+   <xs:element name="xor" substitutionGroup="m:nary-logical.class"/>
+   <xs:element name="unary-logical.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="not" substitutionGroup="m:unary-logical.class"/>
+   <xs:element name="binary-logical.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="implies" substitutionGroup="m:binary-logical.class"/>
+   <xs:element name="equivalent" substitutionGroup="m:binary-logical.class"/>
+   <xs:element name="quantifier.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="forall" substitutionGroup="m:quantifier.class"/>
+   <xs:element name="exists" substitutionGroup="m:quantifier.class"/>
+   <xs:element name="nary-reln.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="eq" substitutionGroup="m:nary-reln.class"/>
+   <xs:element name="gt" substitutionGroup="m:nary-reln.class"/>
+   <xs:element name="lt" substitutionGroup="m:nary-reln.class"/>
+   <xs:element name="geq" substitutionGroup="m:nary-reln.class"/>
+   <xs:element name="leq" substitutionGroup="m:nary-reln.class"/>
+   <xs:element name="binary-reln.class" abstract="true"/>
+   <xs:element name="neq" substitutionGroup="m:binary-reln.class">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="approx" substitutionGroup="m:binary-reln.class">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="factorof" substitutionGroup="m:binary-reln.class">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="tendsto" substitutionGroup="m:binary-reln.class">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+         <xs:attribute name="type"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="int.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="int" substitutionGroup="m:int.class"/>
+   <xs:element name="Differential-Operator.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="diff" substitutionGroup="m:Differential-Operator.class"/>
+   <xs:element name="partialdiff.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="partialdiff" substitutionGroup="m:partialdiff.class"/>
+   <xs:element name="unary-veccalc.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="divergence" substitutionGroup="m:unary-veccalc.class"/>
+   <xs:element name="grad" substitutionGroup="m:unary-veccalc.class"/>
+   <xs:element name="curl" substitutionGroup="m:unary-veccalc.class"/>
+   <xs:element name="laplacian" substitutionGroup="m:unary-veccalc.class"/>
+   <xs:element name="nary-setlist-constructor.class" abstract="true"/>
+   <xs:element name="set" substitutionGroup="m:nary-setlist-constructor.class">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:BvarQ"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:DomainQ"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:ContExp"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+         <xs:attribute name="type"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="list" substitutionGroup="m:nary-setlist-constructor.class">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:BvarQ"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:DomainQ"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:ContExp"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+         <xs:attribute name="order">
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:enumeration value="numeric"/>
+                  <xs:enumeration value="lexicographic"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="nary-set.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="union" substitutionGroup="m:nary-set.class"/>
+   <xs:element name="intersect" substitutionGroup="m:nary-set.class"/>
+   <xs:element name="cartesianproduct" substitutionGroup="m:nary-set.class"/>
+   <xs:element name="binary-set.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="in" substitutionGroup="m:binary-set.class"/>
+   <xs:element name="notin" substitutionGroup="m:binary-set.class"/>
+   <xs:element name="notsubset" substitutionGroup="m:binary-set.class"/>
+   <xs:element name="notprsubset" substitutionGroup="m:binary-set.class"/>
+   <xs:element name="setdiff" substitutionGroup="m:binary-set.class"/>
+   <xs:element name="nary-set-reln.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="subset" substitutionGroup="m:nary-set-reln.class"/>
+   <xs:element name="prsubset" substitutionGroup="m:nary-set-reln.class"/>
+   <xs:element name="unary-set.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="card" substitutionGroup="m:unary-set.class"/>
+   <xs:element name="sum.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="sum" substitutionGroup="m:sum.class"/>
+   <xs:element name="product.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="product" substitutionGroup="m:product.class"/>
+   <xs:element name="limit.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="limit" substitutionGroup="m:limit.class"/>
+   <xs:element name="unary-elementary.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="sin" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="cos" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="tan" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="sec" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="csc" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="cot" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="sinh" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="cosh" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="tanh" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="sech" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="csch" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="coth" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="arcsin" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="arccos" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="arctan" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="arccosh" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="arccot" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="arccoth" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="arccsc" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="arccsch" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="arcsec" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="arcsech" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="arcsinh" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="arctanh" substitutionGroup="m:unary-elementary.class"/>
+   <xs:element name="nary-stats.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="mean" substitutionGroup="m:nary-stats.class"/>
+   <xs:element name="sdev" substitutionGroup="m:nary-stats.class"/>
+   <xs:element name="variance" substitutionGroup="m:nary-stats.class"/>
+   <xs:element name="median" substitutionGroup="m:nary-stats.class"/>
+   <xs:element name="mode" substitutionGroup="m:nary-stats.class"/>
+   <xs:element name="nary-constructor.class" abstract="true">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group ref="m:BvarQ"/>
+            <xs:group ref="m:DomainQ"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:ContExp"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="vector" substitutionGroup="m:nary-constructor.class"/>
+   <xs:element name="matrix" substitutionGroup="m:nary-constructor.class"/>
+   <xs:element name="matrixrow" substitutionGroup="m:nary-constructor.class"/>
+   <xs:element name="unary-linalg.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="determinant" substitutionGroup="m:unary-linalg.class"/>
+   <xs:element name="transpose" substitutionGroup="m:unary-linalg.class"/>
+   <xs:element name="nary-linalg.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="selector" substitutionGroup="m:nary-linalg.class"/>
+   <xs:element name="binary-linalg.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="vectorproduct" substitutionGroup="m:binary-linalg.class"/>
+   <xs:element name="scalarproduct" substitutionGroup="m:binary-linalg.class"/>
+   <xs:element name="outerproduct" substitutionGroup="m:binary-linalg.class"/>
+   <xs:element name="constant-set.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="integers" substitutionGroup="m:constant-set.class"/>
+   <xs:element name="reals" substitutionGroup="m:constant-set.class"/>
+   <xs:element name="rationals" substitutionGroup="m:constant-set.class"/>
+   <xs:element name="naturalnumbers" substitutionGroup="m:constant-set.class"/>
+   <xs:element name="complexes" substitutionGroup="m:constant-set.class"/>
+   <xs:element name="primes" substitutionGroup="m:constant-set.class"/>
+   <xs:element name="emptyset" substitutionGroup="m:constant-set.class"/>
+   <xs:element name="constant-arith.class" abstract="true">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:DefEncAtt"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="exponentiale" substitutionGroup="m:constant-arith.class"/>
+   <xs:element name="imaginaryi" substitutionGroup="m:constant-arith.class"/>
+   <xs:element name="notanumber" substitutionGroup="m:constant-arith.class"/>
+   <xs:element name="true" substitutionGroup="m:constant-arith.class"/>
+   <xs:element name="false" substitutionGroup="m:constant-arith.class"/>
+   <xs:element name="pi" substitutionGroup="m:constant-arith.class"/>
+   <xs:element name="eulergamma" substitutionGroup="m:constant-arith.class"/>
+   <xs:element name="infinity" substitutionGroup="m:constant-arith.class"/>
+</xs:schema>

--- a/mycore-pi/src/main/resources/xsd/crossref/4.4.1/mathml3-presentation.xsd
+++ b/mycore-pi/src/main/resources/xsd/crossref/4.4.1/mathml3-presentation.xsd
@@ -1,0 +1,2151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:m="http://www.w3.org/1998/Math/MathML"
+           elementFormDefault="qualified"
+           targetNamespace="http://www.w3.org/1998/Math/MathML">
+   <xs:complexType name="ImpliedMrow">
+      <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:MathExpression"/>
+   </xs:complexType>
+   <xs:element name="TableRowExpression" abstract="true"/>
+   <xs:element name="TableCellExpression" abstract="true">
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="m:ImpliedMrow">
+               <xs:attributeGroup ref="m:mtd.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:group name="MstackExpression">
+      <xs:choice>
+         <xs:group ref="m:MathExpression"/>
+         <xs:element ref="m:mscarries"/>
+         <xs:element ref="m:msline"/>
+         <xs:element ref="m:msrow"/>
+         <xs:element ref="m:msgroup"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="MsrowExpression">
+      <xs:choice>
+         <xs:group ref="m:MathExpression"/>
+         <xs:element ref="m:none"/>
+      </xs:choice>
+   </xs:group>
+   <xs:group name="MultiScriptExpression">
+      <xs:sequence>
+         <xs:choice>
+            <xs:group ref="m:MathExpression"/>
+            <xs:element ref="m:none"/>
+         </xs:choice>
+         <xs:choice>
+            <xs:group ref="m:MathExpression"/>
+            <xs:element ref="m:none"/>
+         </xs:choice>
+      </xs:sequence>
+   </xs:group>
+   <xs:simpleType name="mpadded-length">
+      <xs:restriction base="xs:string">
+         <xs:pattern value="\s*([\+\-]?[0-9]*([0-9]\.?|\.[0-9])[0-9]*\s*((%?\s*(height|depth|width)?)|e[mx]|in|cm|mm|p[xtc]|((negative)?((very){0,2}thi(n|ck)|medium)mathspace))?)\s*"/>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="linestyle">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="none"/>
+         <xs:enumeration value="solid"/>
+         <xs:enumeration value="dashed"/>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="verticalalign">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="top"/>
+         <xs:enumeration value="bottom"/>
+         <xs:enumeration value="center"/>
+         <xs:enumeration value="baseline"/>
+         <xs:enumeration value="axis"/>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="columnalignstyle">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="left"/>
+         <xs:enumeration value="center"/>
+         <xs:enumeration value="right"/>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="notationstyle">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="longdiv"/>
+         <xs:enumeration value="actuarial"/>
+         <xs:enumeration value="radical"/>
+         <xs:enumeration value="box"/>
+         <xs:enumeration value="roundedbox"/>
+         <xs:enumeration value="circle"/>
+         <xs:enumeration value="left"/>
+         <xs:enumeration value="right"/>
+         <xs:enumeration value="top"/>
+         <xs:enumeration value="bottom"/>
+         <xs:enumeration value="updiagonalstrike"/>
+         <xs:enumeration value="downdiagonalstrike"/>
+         <xs:enumeration value="verticalstrike"/>
+         <xs:enumeration value="horizontalstrike"/>
+         <xs:enumeration value="madruwb"/>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="unsigned-integer">
+      <xs:restriction base="xs:unsignedLong"/>
+   </xs:simpleType>
+   <xs:simpleType name="integer">
+      <xs:restriction base="xs:integer"/>
+   </xs:simpleType>
+   <xs:simpleType name="number">
+      <xs:restriction base="xs:decimal"/>
+   </xs:simpleType>
+   <xs:simpleType name="character">
+      <xs:restriction base="xs:string">
+         <xs:pattern value="\s*\S\s*"/>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="color">
+      <xs:restriction base="xs:string">
+         <xs:pattern value="\s*((#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?)|[aA][qQ][uU][aA]|[bB][lL][aA][cC][kK]|[bB][lL][uU][eE]|[fF][uU][cC][hH][sS][iI][aA]|[gG][rR][aA][yY]|[gG][rR][eE][eE][nN]|[lL][iI][mM][eE]|[mM][aA][rR][oO][oO][nN]|[nN][aA][vV][yY]|[oO][lL][iI][vV][eE]|[pP][uU][rR][pP][lL][eE]|[rR][eE][dD]|[sS][iI][lL][vV][eE][rR]|[tT][eE][aA][lL]|[wW][hH][iI][tT][eE]|[yY][eE][lL][lL][oO][wW])\s*"/>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="group-alignment">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="left"/>
+         <xs:enumeration value="center"/>
+         <xs:enumeration value="right"/>
+         <xs:enumeration value="decimalpoint"/>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="group-alignment-list">
+      <xs:restriction>
+         <xs:simpleType>
+            <xs:list itemType="m:group-alignment"/>
+         </xs:simpleType>
+         <xs:minLength value="1"/>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="group-alignment-list-list">
+      <xs:restriction base="xs:string">
+         <xs:pattern value="(\s*\{\s*(left|center|right|decimalpoint)(\s+(left|center|right|decimalpoint))*\})*\s*"/>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="positive-integer">
+      <xs:restriction base="xs:positiveInteger"/>
+   </xs:simpleType>
+   <xs:element name="TokenExpression" abstract="true"
+               substitutionGroup="m:PresentationExpression"/>
+   <xs:group name="token.content">
+      <xs:sequence>
+         <xs:choice minOccurs="0">
+            <xs:element ref="m:mglyph"/>
+            <xs:element ref="m:malignmark"/>
+         </xs:choice>
+      </xs:sequence>
+   </xs:group>
+   <xs:element name="mi" substitutionGroup="m:TokenExpression">
+      <xs:complexType mixed="true">
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:token.content"/>
+         <xs:attributeGroup ref="m:mi.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mi.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attributeGroup ref="m:TokenAtt"/>
+   </xs:attributeGroup>
+   <xs:element name="mn" substitutionGroup="m:TokenExpression">
+      <xs:complexType mixed="true">
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:token.content"/>
+         <xs:attributeGroup ref="m:mn.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mn.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attributeGroup ref="m:TokenAtt"/>
+   </xs:attributeGroup>
+   <xs:element name="mo" substitutionGroup="m:TokenExpression">
+      <xs:complexType mixed="true">
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:token.content"/>
+         <xs:attributeGroup ref="m:mo.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mo.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attributeGroup ref="m:TokenAtt"/>
+      <xs:attribute name="form">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="prefix"/>
+               <xs:enumeration value="infix"/>
+               <xs:enumeration value="postfix"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fence">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="separator">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="lspace" type="m:length"/>
+      <xs:attribute name="rspace" type="m:length"/>
+      <xs:attribute name="stretchy">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="symmetric">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="maxsize">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="infinity"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="minsize" type="m:length"/>
+      <xs:attribute name="largeop">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="movablelimits">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="accent">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="linebreak">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="auto"/>
+               <xs:enumeration value="newline"/>
+               <xs:enumeration value="nobreak"/>
+               <xs:enumeration value="goodbreak"/>
+               <xs:enumeration value="badbreak"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="lineleading" type="m:length"/>
+      <xs:attribute name="linebreakstyle">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="before"/>
+               <xs:enumeration value="after"/>
+               <xs:enumeration value="duplicate"/>
+               <xs:enumeration value="infixlinebreakstyle"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="linebreakmultchar"/>
+      <xs:attribute name="indentalign">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="auto"/>
+               <xs:enumeration value="id"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="indentshift" type="m:length"/>
+      <xs:attribute name="indenttarget"/>
+      <xs:attribute name="indentalignfirst">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="auto"/>
+               <xs:enumeration value="id"/>
+               <xs:enumeration value="indentalign"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="indentshiftfirst">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="indentshift"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="indentalignlast">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="auto"/>
+               <xs:enumeration value="id"/>
+               <xs:enumeration value="indentalign"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="indentshiftlast">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="indentshift"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="mtext" substitutionGroup="m:TokenExpression">
+      <xs:complexType mixed="true">
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:token.content"/>
+         <xs:attributeGroup ref="m:mtext.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mtext.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attributeGroup ref="m:TokenAtt"/>
+   </xs:attributeGroup>
+   <xs:element name="mspace" substitutionGroup="m:TokenExpression">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:mspace.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mspace.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attributeGroup ref="m:TokenAtt"/>
+      <xs:attribute name="width" type="m:length"/>
+      <xs:attribute name="height" type="m:length"/>
+      <xs:attribute name="depth" type="m:length"/>
+      <xs:attribute name="linebreak">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="auto"/>
+               <xs:enumeration value="newline"/>
+               <xs:enumeration value="nobreak"/>
+               <xs:enumeration value="goodbreak"/>
+               <xs:enumeration value="badbreak"/>
+               <xs:enumeration value="indentingnewline"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="indentalign">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="auto"/>
+               <xs:enumeration value="id"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="indentshift" type="m:length"/>
+      <xs:attribute name="indenttarget"/>
+      <xs:attribute name="indentalignfirst">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="auto"/>
+               <xs:enumeration value="id"/>
+               <xs:enumeration value="indentalign"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="indentshiftfirst">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="indentshift"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="indentalignlast">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="auto"/>
+               <xs:enumeration value="id"/>
+               <xs:enumeration value="indentalign"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="indentshiftlast">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="indentshift"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="ms" substitutionGroup="m:TokenExpression">
+      <xs:complexType mixed="true">
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:token.content"/>
+         <xs:attributeGroup ref="m:ms.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="ms.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attributeGroup ref="m:TokenAtt"/>
+      <xs:attribute name="lquote"/>
+      <xs:attribute name="rquote"/>
+   </xs:attributeGroup>
+   <xs:element name="mglyph">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:mglyph.attributes"/>
+         <xs:attributeGroup ref="m:mglyph.deprecatedattributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mglyph.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="src" type="xs:anyURI"/>
+      <xs:attribute name="width" type="m:length"/>
+      <xs:attribute name="height" type="m:length"/>
+      <xs:attribute name="valign" type="m:length"/>
+      <xs:attribute name="alt"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="mglyph.deprecatedattributes">
+      <xs:attribute name="index" type="m:integer"/>
+      <xs:attribute name="mathvariant">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="normal"/>
+               <xs:enumeration value="bold"/>
+               <xs:enumeration value="italic"/>
+               <xs:enumeration value="bold-italic"/>
+               <xs:enumeration value="double-struck"/>
+               <xs:enumeration value="bold-fraktur"/>
+               <xs:enumeration value="script"/>
+               <xs:enumeration value="bold-script"/>
+               <xs:enumeration value="fraktur"/>
+               <xs:enumeration value="sans-serif"/>
+               <xs:enumeration value="bold-sans-serif"/>
+               <xs:enumeration value="sans-serif-italic"/>
+               <xs:enumeration value="sans-serif-bold-italic"/>
+               <xs:enumeration value="monospace"/>
+               <xs:enumeration value="initial"/>
+               <xs:enumeration value="tailed"/>
+               <xs:enumeration value="looped"/>
+               <xs:enumeration value="stretched"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="mathsize">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="small"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="normal"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="big"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attributeGroup ref="m:DeprecatedTokenAtt"/>
+   </xs:attributeGroup>
+   <xs:element name="msline">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:msline.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="msline.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="position" type="m:integer"/>
+      <xs:attribute name="length" type="m:unsigned-integer"/>
+      <xs:attribute name="leftoverhang" type="m:length"/>
+      <xs:attribute name="rightoverhang" type="m:length"/>
+      <xs:attribute name="mslinethickness">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="thin"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="medium"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="thick"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="none">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:none.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="none.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+   </xs:attributeGroup>
+   <xs:element name="mprescripts">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:mprescripts.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mprescripts.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="CommonPresAtt">
+      <xs:attribute name="mathcolor" type="m:color"/>
+      <xs:attribute name="mathbackground">
+         <xs:simpleType>
+            <xs:union memberTypes="m:color">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="transparent"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="TokenAtt">
+      <xs:attribute name="mathvariant">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="normal"/>
+               <xs:enumeration value="bold"/>
+               <xs:enumeration value="italic"/>
+               <xs:enumeration value="bold-italic"/>
+               <xs:enumeration value="double-struck"/>
+               <xs:enumeration value="bold-fraktur"/>
+               <xs:enumeration value="script"/>
+               <xs:enumeration value="bold-script"/>
+               <xs:enumeration value="fraktur"/>
+               <xs:enumeration value="sans-serif"/>
+               <xs:enumeration value="bold-sans-serif"/>
+               <xs:enumeration value="sans-serif-italic"/>
+               <xs:enumeration value="sans-serif-bold-italic"/>
+               <xs:enumeration value="monospace"/>
+               <xs:enumeration value="initial"/>
+               <xs:enumeration value="tailed"/>
+               <xs:enumeration value="looped"/>
+               <xs:enumeration value="stretched"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="mathsize">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="small"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="normal"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="big"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="dir">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="ltr"/>
+               <xs:enumeration value="rtl"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attributeGroup ref="m:DeprecatedTokenAtt"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="DeprecatedTokenAtt">
+      <xs:attribute name="fontfamily"/>
+      <xs:attribute name="fontweight">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="normal"/>
+               <xs:enumeration value="bold"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fontstyle">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="normal"/>
+               <xs:enumeration value="italic"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fontsize" type="m:length"/>
+      <xs:attribute name="color" type="m:color"/>
+      <xs:attribute name="background">
+         <xs:simpleType>
+            <xs:union memberTypes="m:color">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="transparent"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="MalignExpression" abstract="true"
+               substitutionGroup="m:PresentationExpression"/>
+   <xs:element name="malignmark" substitutionGroup="m:MalignExpression">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:malignmark.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="malignmark.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="edge">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="right"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="maligngroup" substitutionGroup="m:MalignExpression">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:maligngroup.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="maligngroup.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="groupalign">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="decimalpoint"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="mrow" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:MathExpression"/>
+         <xs:attributeGroup ref="m:mrow.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mrow.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="dir">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="ltr"/>
+               <xs:enumeration value="rtl"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="mfrac" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group ref="m:MathExpression"/>
+            <xs:group ref="m:MathExpression"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:mfrac.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mfrac.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="linethickness">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="thin"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="medium"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="thick"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="numalign">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="denomalign">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="bevelled">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="msqrt" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="m:ImpliedMrow">
+               <xs:attributeGroup ref="m:msqrt.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="msqrt.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+   </xs:attributeGroup>
+   <xs:element name="mroot" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group ref="m:MathExpression"/>
+            <xs:group ref="m:MathExpression"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:mroot.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mroot.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+   </xs:attributeGroup>
+   <xs:element name="mstyle" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="m:ImpliedMrow">
+               <xs:attributeGroup ref="m:mstyle.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mstyle.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attributeGroup ref="m:mstyle.specificattributes"/>
+      <xs:attributeGroup ref="m:mstyle.generalattributes"/>
+      <xs:attributeGroup ref="m:mstyle.deprecatedattributes"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="mstyle.specificattributes">
+      <xs:attribute name="scriptlevel" type="m:integer"/>
+      <xs:attribute name="displaystyle">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="scriptsizemultiplier" type="m:number"/>
+      <xs:attribute name="scriptminsize" type="m:length"/>
+      <xs:attribute name="infixlinebreakstyle">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="before"/>
+               <xs:enumeration value="after"/>
+               <xs:enumeration value="duplicate"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="decimalpoint" type="m:character"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="mstyle.generalattributes">
+      <xs:attribute name="accent">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="accentunder">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="align">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="center"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alignmentscope">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:token">
+                           <xs:enumeration value="true"/>
+                           <xs:enumeration value="false"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="bevelled">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="charalign">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="charspacing">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="loose"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="medium"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="tight"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="close"/>
+      <xs:attribute name="columnalign">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list itemType="m:columnalignstyle"/>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="columnlines">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list itemType="m:linestyle"/>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="columnspacing">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list itemType="m:length"/>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="columnspan" type="m:positive-integer"/>
+      <xs:attribute name="columnwidth">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:union memberTypes="m:length">
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="auto"/>
+                              </xs:restriction>
+                           </xs:simpleType>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="fit"/>
+                              </xs:restriction>
+                           </xs:simpleType>
+                        </xs:union>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="crossout">
+         <xs:simpleType>
+            <xs:list>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="none"/>
+                     <xs:enumeration value="updiagonalstrike"/>
+                     <xs:enumeration value="downdiagonalstrike"/>
+                     <xs:enumeration value="verticalstrike"/>
+                     <xs:enumeration value="horizontalstrike"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:list>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="denomalign">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="depth" type="m:length"/>
+      <xs:attribute name="dir">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="ltr"/>
+               <xs:enumeration value="rtl"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="edge">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="right"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="equalcolumns">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="equalrows">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="fence">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="form">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="prefix"/>
+               <xs:enumeration value="infix"/>
+               <xs:enumeration value="postfix"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="frame" type="m:linestyle"/>
+      <xs:attribute name="framespacing">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:union memberTypes="m:length m:length"/>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:length value="2"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="groupalign" type="m:group-alignment-list-list"/>
+      <xs:attribute name="height" type="m:length"/>
+      <xs:attribute name="indentalign">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="auto"/>
+               <xs:enumeration value="id"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="indentalignfirst">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="auto"/>
+               <xs:enumeration value="id"/>
+               <xs:enumeration value="indentalign"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="indentalignlast">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="auto"/>
+               <xs:enumeration value="id"/>
+               <xs:enumeration value="indentalign"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="indentshift" type="m:length"/>
+      <xs:attribute name="indentshiftfirst">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="indentshift"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="indentshiftlast">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="indentshift"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="indenttarget"/>
+      <xs:attribute name="largeop">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="leftoverhang" type="m:length"/>
+      <xs:attribute name="length" type="m:unsigned-integer"/>
+      <xs:attribute name="linebreak">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="auto"/>
+               <xs:enumeration value="newline"/>
+               <xs:enumeration value="nobreak"/>
+               <xs:enumeration value="goodbreak"/>
+               <xs:enumeration value="badbreak"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="linebreakmultchar"/>
+      <xs:attribute name="linebreakstyle">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="before"/>
+               <xs:enumeration value="after"/>
+               <xs:enumeration value="duplicate"/>
+               <xs:enumeration value="infixlinebreakstyle"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="lineleading" type="m:length"/>
+      <xs:attribute name="linethickness">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="thin"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="medium"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="thick"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="location">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="w"/>
+               <xs:enumeration value="nw"/>
+               <xs:enumeration value="n"/>
+               <xs:enumeration value="ne"/>
+               <xs:enumeration value="e"/>
+               <xs:enumeration value="se"/>
+               <xs:enumeration value="s"/>
+               <xs:enumeration value="sw"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="longdivstyle">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="lefttop"/>
+               <xs:enumeration value="stackedrightright"/>
+               <xs:enumeration value="mediumstackedrightright"/>
+               <xs:enumeration value="shortstackedrightright"/>
+               <xs:enumeration value="righttop"/>
+               <xs:enumeration value="left/\right"/>
+               <xs:enumeration value="left)(right"/>
+               <xs:enumeration value=":right=right"/>
+               <xs:enumeration value="stackedleftleft"/>
+               <xs:enumeration value="stackedleftlinetop"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="lquote"/>
+      <xs:attribute name="lspace" type="m:length"/>
+      <xs:attribute name="mathsize">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="small"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="normal"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="big"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="mathvariant">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="normal"/>
+               <xs:enumeration value="bold"/>
+               <xs:enumeration value="italic"/>
+               <xs:enumeration value="bold-italic"/>
+               <xs:enumeration value="double-struck"/>
+               <xs:enumeration value="bold-fraktur"/>
+               <xs:enumeration value="script"/>
+               <xs:enumeration value="bold-script"/>
+               <xs:enumeration value="fraktur"/>
+               <xs:enumeration value="sans-serif"/>
+               <xs:enumeration value="bold-sans-serif"/>
+               <xs:enumeration value="sans-serif-italic"/>
+               <xs:enumeration value="sans-serif-bold-italic"/>
+               <xs:enumeration value="monospace"/>
+               <xs:enumeration value="initial"/>
+               <xs:enumeration value="tailed"/>
+               <xs:enumeration value="looped"/>
+               <xs:enumeration value="stretched"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="maxsize">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="infinity"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="minlabelspacing" type="m:length"/>
+      <xs:attribute name="minsize" type="m:length"/>
+      <xs:attribute name="movablelimits">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="mslinethickness">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="thin"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="medium"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="thick"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="notation"/>
+      <xs:attribute name="numalign">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="open"/>
+      <xs:attribute name="position" type="m:integer"/>
+      <xs:attribute name="rightoverhang" type="m:length"/>
+      <xs:attribute name="rowalign">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list itemType="m:verticalalign"/>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowlines">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list itemType="m:linestyle"/>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowspacing">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list itemType="m:length"/>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowspan" type="m:positive-integer"/>
+      <xs:attribute name="rquote"/>
+      <xs:attribute name="rspace" type="m:length"/>
+      <xs:attribute name="selection" type="m:positive-integer"/>
+      <xs:attribute name="separator">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="separators"/>
+      <xs:attribute name="shift" type="m:integer"/>
+      <xs:attribute name="side">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="leftoverlap"/>
+               <xs:enumeration value="rightoverlap"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="stackalign">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="decimalpoint"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="stretchy">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="subscriptshift" type="m:length"/>
+      <xs:attribute name="superscriptshift" type="m:length"/>
+      <xs:attribute name="symmetric">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="valign" type="m:length"/>
+      <xs:attribute name="width" type="m:length"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="mstyle.deprecatedattributes">
+      <xs:attributeGroup ref="m:DeprecatedTokenAtt"/>
+      <xs:attribute name="veryverythinmathspace" type="m:length"/>
+      <xs:attribute name="verythinmathspace" type="m:length"/>
+      <xs:attribute name="thinmathspace" type="m:length"/>
+      <xs:attribute name="mediummathspace" type="m:length"/>
+      <xs:attribute name="thickmathspace" type="m:length"/>
+      <xs:attribute name="verythickmathspace" type="m:length"/>
+      <xs:attribute name="veryverythickmathspace" type="m:length"/>
+   </xs:attributeGroup>
+   <xs:attributeGroup name="math.attributes">
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attributeGroup ref="m:mstyle.specificattributes"/>
+      <xs:attributeGroup ref="m:mstyle.generalattributes"/>
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attribute name="display">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="block"/>
+               <xs:enumeration value="inline"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="maxwidth" type="m:length"/>
+      <xs:attribute name="overflow">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="linebreak"/>
+               <xs:enumeration value="scroll"/>
+               <xs:enumeration value="elide"/>
+               <xs:enumeration value="truncate"/>
+               <xs:enumeration value="scale"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="altimg" type="xs:anyURI"/>
+      <xs:attribute name="altimg-width" type="m:length"/>
+      <xs:attribute name="altimg-height" type="m:length"/>
+      <xs:attribute name="altimg-valign">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="top"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="middle"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="bottom"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="alttext"/>
+      <xs:attribute name="cdgroup" type="xs:anyURI"/>
+      <xs:attributeGroup ref="m:math.deprecatedattributes"/>
+   </xs:attributeGroup>
+   <xs:element name="merror" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="m:ImpliedMrow">
+               <xs:attributeGroup ref="m:merror.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="merror.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+   </xs:attributeGroup>
+   <xs:element name="mpadded" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="m:ImpliedMrow">
+               <xs:attributeGroup ref="m:mpadded.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mpadded.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="height" type="m:mpadded-length"/>
+      <xs:attribute name="depth" type="m:mpadded-length"/>
+      <xs:attribute name="width" type="m:mpadded-length"/>
+      <xs:attribute name="lspace" type="m:mpadded-length"/>
+      <xs:attribute name="voffset" type="m:mpadded-length"/>
+   </xs:attributeGroup>
+   <xs:element name="mphantom" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="m:ImpliedMrow">
+               <xs:attributeGroup ref="m:mphantom.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mphantom.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+   </xs:attributeGroup>
+   <xs:element name="mfenced" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:MathExpression"/>
+         <xs:attributeGroup ref="m:mfenced.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mfenced.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="open"/>
+      <xs:attribute name="close"/>
+      <xs:attribute name="separators"/>
+   </xs:attributeGroup>
+   <xs:element name="menclose" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="m:ImpliedMrow">
+               <xs:attributeGroup ref="m:menclose.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="menclose.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="notation"/>
+   </xs:attributeGroup>
+   <xs:element name="msub" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group ref="m:MathExpression"/>
+            <xs:group ref="m:MathExpression"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:msub.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="msub.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="subscriptshift" type="m:length"/>
+   </xs:attributeGroup>
+   <xs:element name="msup" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group ref="m:MathExpression"/>
+            <xs:group ref="m:MathExpression"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:msup.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="msup.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="superscriptshift" type="m:length"/>
+   </xs:attributeGroup>
+   <xs:element name="msubsup" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group ref="m:MathExpression"/>
+            <xs:group ref="m:MathExpression"/>
+            <xs:group ref="m:MathExpression"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:msubsup.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="msubsup.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="subscriptshift" type="m:length"/>
+      <xs:attribute name="superscriptshift" type="m:length"/>
+   </xs:attributeGroup>
+   <xs:element name="munder" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group ref="m:MathExpression"/>
+            <xs:group ref="m:MathExpression"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:munder.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="munder.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="accentunder">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="align">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="center"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="mover" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group ref="m:MathExpression"/>
+            <xs:group ref="m:MathExpression"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:mover.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mover.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="accent">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="align">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="center"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="munderover" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group ref="m:MathExpression"/>
+            <xs:group ref="m:MathExpression"/>
+            <xs:group ref="m:MathExpression"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:munderover.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="munderover.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="accent">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="accentunder">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="align">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="center"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="mmultiscripts" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group ref="m:MathExpression"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:MultiScriptExpression"/>
+            <xs:sequence minOccurs="0">
+               <xs:element ref="m:mprescripts"/>
+               <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:MultiScriptExpression"/>
+            </xs:sequence>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:mmultiscripts.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mmultiscripts.attributes">
+      <xs:attributeGroup ref="m:msubsup.attributes"/>
+   </xs:attributeGroup>
+   <xs:element name="mtable" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="m:TableRowExpression"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:mtable.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mtable.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="align">
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="\s*(top|bottom|center|baseline|axis)(\s+-?[0-9]+)?\s*"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowalign">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list itemType="m:verticalalign"/>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="columnalign">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list itemType="m:columnalignstyle"/>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="groupalign" type="m:group-alignment-list-list"/>
+      <xs:attribute name="alignmentscope">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:restriction base="xs:token">
+                           <xs:enumeration value="true"/>
+                           <xs:enumeration value="false"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="columnwidth">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:union memberTypes="m:length">
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="auto"/>
+                              </xs:restriction>
+                           </xs:simpleType>
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:enumeration value="fit"/>
+                              </xs:restriction>
+                           </xs:simpleType>
+                        </xs:union>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="width">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="auto"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowspacing">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list itemType="m:length"/>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="columnspacing">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list itemType="m:length"/>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="rowlines">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list itemType="m:linestyle"/>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="columnlines">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list itemType="m:linestyle"/>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="frame" type="m:linestyle"/>
+      <xs:attribute name="framespacing">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list>
+                     <xs:simpleType>
+                        <xs:union memberTypes="m:length m:length"/>
+                     </xs:simpleType>
+                  </xs:list>
+               </xs:simpleType>
+               <xs:length value="2"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="equalrows">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="equalcolumns">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="displaystyle">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="true"/>
+               <xs:enumeration value="false"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="side">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="leftoverlap"/>
+               <xs:enumeration value="rightoverlap"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="minlabelspacing" type="m:length"/>
+   </xs:attributeGroup>
+   <xs:element name="mlabeledtr" substitutionGroup="m:TableRowExpression">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="m:TableCellExpression"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:mlabeledtr.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mlabeledtr.attributes">
+      <xs:attributeGroup ref="m:mtr.attributes"/>
+   </xs:attributeGroup>
+   <xs:element name="mtr" substitutionGroup="m:TableRowExpression">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="m:TableCellExpression"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:mtr.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mtr.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="rowalign">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="top"/>
+               <xs:enumeration value="bottom"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="baseline"/>
+               <xs:enumeration value="axis"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="columnalign">
+         <xs:simpleType>
+            <xs:restriction>
+               <xs:simpleType>
+                  <xs:list itemType="m:columnalignstyle"/>
+               </xs:simpleType>
+               <xs:minLength value="1"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="groupalign" type="m:group-alignment-list-list"/>
+   </xs:attributeGroup>
+   <xs:element name="mtd" substitutionGroup="m:TableCellExpression"/>
+   <xs:attributeGroup name="mtd.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="rowspan" type="m:positive-integer"/>
+      <xs:attribute name="columnspan" type="m:positive-integer"/>
+      <xs:attribute name="rowalign">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="top"/>
+               <xs:enumeration value="bottom"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="baseline"/>
+               <xs:enumeration value="axis"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="columnalign" type="m:columnalignstyle"/>
+      <xs:attribute name="groupalign" type="m:group-alignment-list"/>
+   </xs:attributeGroup>
+   <xs:element name="mstack" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:MstackExpression"/>
+         <xs:attributeGroup ref="m:mstack.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mstack.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="align">
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="\s*(top|bottom|center|baseline|axis)(\s+-?[0-9]+)?\s*"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="stackalign">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+               <xs:enumeration value="decimalpoint"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="charalign">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="left"/>
+               <xs:enumeration value="center"/>
+               <xs:enumeration value="right"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="charspacing">
+         <xs:simpleType>
+            <xs:union memberTypes="m:length">
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="loose"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="medium"/>
+                  </xs:restriction>
+               </xs:simpleType>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="tight"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:union>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="mlongdiv" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:group ref="m:MstackExpression"/>
+            <xs:group ref="m:MstackExpression"/>
+            <xs:group maxOccurs="unbounded" ref="m:MstackExpression"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:mlongdiv.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mlongdiv.attributes">
+      <xs:attributeGroup ref="m:msgroup.attributes"/>
+      <xs:attribute name="longdivstyle">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="lefttop"/>
+               <xs:enumeration value="stackedrightright"/>
+               <xs:enumeration value="mediumstackedrightright"/>
+               <xs:enumeration value="shortstackedrightright"/>
+               <xs:enumeration value="righttop"/>
+               <xs:enumeration value="left/\right"/>
+               <xs:enumeration value="left)(right"/>
+               <xs:enumeration value=":right=right"/>
+               <xs:enumeration value="stackedleftleft"/>
+               <xs:enumeration value="stackedleftlinetop"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="msgroup">
+      <xs:complexType>
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:MstackExpression"/>
+         <xs:attributeGroup ref="m:msgroup.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="msgroup.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="position" type="m:integer"/>
+      <xs:attribute name="shift" type="m:integer"/>
+   </xs:attributeGroup>
+   <xs:element name="msrow">
+      <xs:complexType>
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:MsrowExpression"/>
+         <xs:attributeGroup ref="m:msrow.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="msrow.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="position" type="m:integer"/>
+   </xs:attributeGroup>
+   <xs:element name="mscarries">
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="m:MsrowExpression"/>
+            <xs:element ref="m:mscarry"/>
+         </xs:choice>
+         <xs:attributeGroup ref="m:mscarries.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mscarries.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="position" type="m:integer"/>
+      <xs:attribute name="location">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="w"/>
+               <xs:enumeration value="nw"/>
+               <xs:enumeration value="n"/>
+               <xs:enumeration value="ne"/>
+               <xs:enumeration value="e"/>
+               <xs:enumeration value="se"/>
+               <xs:enumeration value="s"/>
+               <xs:enumeration value="sw"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="crossout">
+         <xs:simpleType>
+            <xs:list>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="none"/>
+                     <xs:enumeration value="updiagonalstrike"/>
+                     <xs:enumeration value="downdiagonalstrike"/>
+                     <xs:enumeration value="verticalstrike"/>
+                     <xs:enumeration value="horizontalstrike"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:list>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="scriptsizemultiplier" type="m:number"/>
+   </xs:attributeGroup>
+   <xs:element name="mscarry">
+      <xs:complexType>
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:MsrowExpression"/>
+         <xs:attributeGroup ref="m:mscarry.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="mscarry.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="location">
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="w"/>
+               <xs:enumeration value="nw"/>
+               <xs:enumeration value="n"/>
+               <xs:enumeration value="ne"/>
+               <xs:enumeration value="e"/>
+               <xs:enumeration value="se"/>
+               <xs:enumeration value="s"/>
+               <xs:enumeration value="sw"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="crossout">
+         <xs:simpleType>
+            <xs:list>
+               <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                     <xs:enumeration value="none"/>
+                     <xs:enumeration value="updiagonalstrike"/>
+                     <xs:enumeration value="downdiagonalstrike"/>
+                     <xs:enumeration value="verticalstrike"/>
+                     <xs:enumeration value="horizontalstrike"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:list>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:attributeGroup>
+   <xs:element name="maction" substitutionGroup="m:PresentationExpression">
+      <xs:complexType>
+         <xs:group maxOccurs="unbounded" ref="m:MathExpression"/>
+         <xs:attributeGroup ref="m:maction.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="maction.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+      <xs:attributeGroup ref="m:CommonPresAtt"/>
+      <xs:attribute name="actiontype" use="required"/>
+      <xs:attribute name="selection" type="m:positive-integer"/>
+   </xs:attributeGroup>
+</xs:schema>

--- a/mycore-pi/src/main/resources/xsd/crossref/4.4.1/mathml3-strict-content.xsd
+++ b/mycore-pi/src/main/resources/xsd/crossref/4.4.1/mathml3-strict-content.xsd
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:m="http://www.w3.org/1998/Math/MathML"
+           elementFormDefault="qualified"
+           targetNamespace="http://www.w3.org/1998/Math/MathML">
+   <xs:group name="ContExp">
+      <xs:choice>
+<!--Ambiguous content model altered (ContExp)-->
+         <xs:element ref="m:apply"/>
+         <xs:element ref="m:bind"/>
+         <xs:element ref="m:ci"/>
+         <xs:element ref="m:cn"/>
+         <xs:element ref="m:csymbol"/>
+         <xs:element ref="m:cbytes"/>
+         <xs:element ref="m:cerror"/>
+         <xs:element ref="m:cs"/>
+         <xs:element ref="m:share"/>
+         <xs:element ref="m:piecewise"/>
+         <xs:element ref="m:DeprecatedContExp"/>
+         <xs:element ref="m:interval.class"/>
+         <xs:element ref="m:unary-functional.class"/>
+         <xs:element ref="m:lambda.class"/>
+         <xs:element ref="m:nary-functional.class"/>
+         <xs:group ref="m:binary-arith.class"/>
+         <xs:group ref="m:unary-arith.class"/>
+         <xs:element ref="m:nary-minmax.class"/>
+         <xs:element ref="m:nary-arith.class"/>
+         <xs:element ref="m:nary-logical.class"/>
+         <xs:element ref="m:unary-logical.class"/>
+         <xs:element ref="m:binary-logical.class"/>
+         <xs:element ref="m:quantifier.class"/>
+         <xs:element ref="m:nary-reln.class"/>
+         <xs:element ref="m:binary-reln.class"/>
+         <xs:element ref="m:int.class"/>
+         <xs:element ref="m:Differential-Operator.class"/>
+         <xs:element ref="m:partialdiff.class"/>
+         <xs:element ref="m:unary-veccalc.class"/>
+         <xs:element ref="m:nary-setlist-constructor.class"/>
+         <xs:element ref="m:nary-set.class"/>
+         <xs:element ref="m:binary-set.class"/>
+         <xs:element ref="m:nary-set-reln.class"/>
+         <xs:element ref="m:unary-set.class"/>
+         <xs:element ref="m:sum.class"/>
+         <xs:element ref="m:product.class"/>
+         <xs:element ref="m:limit.class"/>
+         <xs:element ref="m:unary-elementary.class"/>
+         <xs:element ref="m:nary-stats.class"/>
+         <xs:element ref="m:nary-constructor.class"/>
+         <xs:element ref="m:unary-linalg.class"/>
+         <xs:element ref="m:nary-linalg.class"/>
+         <xs:element ref="m:binary-linalg.class"/>
+         <xs:element ref="m:constant-set.class"/>
+         <xs:element ref="m:constant-arith.class"/>
+      </xs:choice>
+   </xs:group>
+   <xs:element name="cn">
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="m:cn.content">
+               <xs:attributeGroup ref="m:cn.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:group name="semantics-ci">
+      <xs:sequence>
+         <xs:element name="semantics">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:choice>
+                     <xs:element ref="m:ci"/>
+                     <xs:group ref="m:semantics-ci"/>
+                  </xs:choice>
+                  <xs:choice minOccurs="0" maxOccurs="unbounded">
+                     <xs:element ref="m:annotation"/>
+                     <xs:element ref="m:annotation-xml"/>
+                  </xs:choice>
+               </xs:sequence>
+               <xs:attributeGroup ref="m:semantics.attributes"/>
+            </xs:complexType>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="semantics-contexp">
+      <xs:sequence>
+         <xs:element name="semantics">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:group ref="m:ContExp"/>
+                  <xs:choice minOccurs="0" maxOccurs="unbounded">
+                     <xs:element ref="m:annotation"/>
+                     <xs:element ref="m:annotation-xml"/>
+                  </xs:choice>
+               </xs:sequence>
+               <xs:attributeGroup ref="m:semantics.attributes"/>
+            </xs:complexType>
+         </xs:element>
+      </xs:sequence>
+   </xs:group>
+   <xs:element name="ci">
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="m:ci.content">
+               <xs:attributeGroup ref="m:ci.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="csymbol">
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="m:csymbol.content">
+               <xs:attributeGroup ref="m:csymbol.attributes"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:simpleType name="SymbolName">
+      <xs:restriction base="xs:NCName"/>
+   </xs:simpleType>
+   <xs:group name="BvarQ">
+      <xs:sequence>
+         <xs:element minOccurs="0" maxOccurs="unbounded" ref="m:bvar"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:element name="apply">
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="m:apply.content">
+               <xs:attributeGroup ref="m:CommonAtt"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="bind">
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="m:bind.content">
+               <xs:attributeGroup ref="m:CommonAtt"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="share">
+      <xs:complexType>
+         <xs:attributeGroup ref="m:CommonAtt"/>
+         <xs:attributeGroup ref="m:src"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="cerror">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element ref="m:csymbol"/>
+            <xs:group minOccurs="0" maxOccurs="unbounded" ref="m:ContExp"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="m:cerror.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="cerror.attributes">
+      <xs:attributeGroup ref="m:CommonAtt"/>
+   </xs:attributeGroup>
+   <xs:element name="cbytes">
+      <xs:complexType>
+         <xs:simpleContent>
+            <xs:extension base="m:base64">
+               <xs:attributeGroup ref="m:cbytes.attributes"/>
+            </xs:extension>
+         </xs:simpleContent>
+      </xs:complexType>
+   </xs:element>
+   <xs:simpleType name="base64">
+      <xs:restriction base="xs:base64Binary"/>
+   </xs:simpleType>
+   <xs:element name="cs">
+      <xs:complexType mixed="true">
+         <xs:attributeGroup ref="m:cs.attributes"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:group name="MathExpression">
+      <xs:choice>
+         <xs:group ref="m:ContExp"/>
+         <xs:element ref="m:PresentationExpression"/>
+         <xs:group ref="m:semantics"/>
+      </xs:choice>
+   </xs:group>
+</xs:schema>

--- a/mycore-pi/src/main/resources/xsd/crossref/4.4.1/mathml3.xsd
+++ b/mycore-pi/src/main/resources/xsd/crossref/4.4.1/mathml3.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:m="http://www.w3.org/1998/Math/MathML"
+           elementFormDefault="qualified"
+           targetNamespace="http://www.w3.org/1998/Math/MathML">
+   <xs:include schemaLocation="mathml3-content.xsd"/>
+   <xs:include schemaLocation="mathml3-presentation.xsd"/>
+   <xs:include schemaLocation="mathml3-common.xsd"/>
+</xs:schema>

--- a/mycore-pi/src/main/resources/xsd/crossref/4.4.1/relations.xsd
+++ b/mycore-pi/src/main/resources/xsd/crossref/4.4.1/relations.xsd
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://www.crossref.org/relations.xsd"
+    xmlns="http://www.crossref.org/relations.xsd">
+    <xsd:annotation>
+        <xsd:documentation> Version:   beta 0.3
+        
+        This schema provides for creating relationships between items represented by crossref DOIs and other items that may 
+        be defined by a DOI (crossref or other RA) or by some other identifier. New relation types will be added as they're needed.
+        Please contact support@crossref.org to request additions or changes.
+        
+        Certain relationship types are covered elsewhere in the main deposit schema due primarily to specific processing or 
+        the need to logically group those relations alongside other relevant metadata. For example cited-by relations are 
+        created by the deposit of a citation_list. Crossmark->Updates addresses relationships between DOIs where a primary 
+        item is updated, revised, hasErratum, withdrawn ... etc.  When constructing relations please be sure to use the 
+        the most appropriate metadata structure.
+        
+        Relationships between DOIs in crossref are established bidirectionally between those DOIs making it unnecessary to
+        deposit relationship metadata for both DOIs.
+        Example: 
+              DOI A metadata contains 'hasTranslation' with a target of DOI B will automatically
+              make this claim visible in metadata for B.
+              Seen from the perspective of B: A claims it hasTranslation of which B is the target of the claim.
+        
+        Change history: 
+        10/3/14  CSK   removed reg-agency attribute. This is not necessary, can be derived from the DOI
+        10/3/14  CSK   split into inter and intra relation elements
+        10/3/14  CSK   pulled in common crossref schema for description element and language attributes 
+        12/21/16 CSK   added comments to each relation type indicating the appropriate inverse relation type
+        3/6/17 PDF added accession as identifier-type
+        
+        ====== C O N V E N T I O N ==============================================================================================
+        Relationships between two objects have an implicit directionality that in natural language terms dictate which object is the actor
+        and which is acted-upon.  This directionality is semantically based on the relationship name. Crossref's model makes
+        no attempt to automatically 'understand' this semantic. 
+        
+        The identifier parent to the PROGRAM element is considered the claimant of the relationship (e.g. the entity that
+        establishes the relationship).
+        
+            yes:  10.1234/abcd references 10.5678/efgh    =>  10.1234/abcd claims that it references 10.5678/efgh
+            yes:  10.1234/abcd referencedBy 10.5678/efgh  =>  10.1234/abcd claims that it is referenced by 10.5678/efgh
+       
+        ==========================================================================================================================
+       
+        </xsd:documentation></xsd:annotation>
+    
+    <xsd:include schemaLocation="common4.3.5.xsd"/>    
+
+    <xsd:element name="program">
+        <xsd:annotation>
+            <xsd:documentation>Accommodates deposit of relationship claims between items.</xsd:documentation>
+        </xsd:annotation>
+
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element ref="related_item" minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+            <xsd:attribute name="name" type="xsd:string" fixed="relations"/>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <xsd:element name="related_item">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:annotation><xsd:documentation>
+                    Description of the relationship to the target item or of the target item itself
+                </xsd:documentation></xsd:annotation>
+                <xsd:element ref="description" minOccurs="0" maxOccurs="1"/>
+                <xsd:choice>
+                    <xsd:element ref="inter_work_relation" minOccurs="1" maxOccurs="1"/>
+                    <xsd:element ref="intra_work_relation" minOccurs="1" maxOccurs="1"/> 
+                </xsd:choice>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>            
+    
+    <xsd:element name="inter_work_relation">
+        <xsd:complexType mixed="true">
+            <xsd:attribute name="relationship-type" use="required">
+                <xsd:annotation>
+                    <xsd:documentation> Used to describe relations between items that are not the same work.
+                    </xsd:documentation>
+                </xsd:annotation>
+                <xsd:simpleType>
+                    <xsd:restriction base="xsd:string">
+                        <!--   Crossref  -->
+                        <xsd:enumeration value="isDerivedFrom"/>      <!-- hasDeverivtion -->
+                        <xsd:enumeration value="hasDerivation"/>      <!-- isDerivedFrom -->
+                        <xsd:enumeration value="isReviewOf"/>         <!-- hasReview -->
+                        <xsd:enumeration value="hasReview"/>          <!-- isReviewOf -->
+                        <xsd:enumeration value="isCommentOn"/>        <!-- hasComment -->
+                        <xsd:enumeration value="hasComment"/>         <!-- isCommentOn -->
+                        <xsd:enumeration value="isReplyTo"/>          <!-- hasReply -->
+                        <xsd:enumeration value="hasReply"/>           <!-- isReplyTo -->
+                        <xsd:enumeration value="basedOnData"/>        <!-- isDataBasisFor -->
+                        <xsd:enumeration value="isDataBasisFor"/>     <!-- basedOnData -->
+                        <xsd:enumeration value="hasRelatedMaterial"/> <!-- isRelatedMaterial -->
+                        <xsd:enumeration value="isRelatedMaterial"/>  <!-- hasRelatedMaterial -->
+                        
+                        <!--   Common with DataCite  -->
+                        <xsd:enumeration value="isCompiledBy"/>       <!-- compiles -->
+                        <xsd:enumeration value="compiles"/>           <!-- isCompiledBy -->
+                        <xsd:enumeration value="isDocumentedBy"/>     <!-- documents -->
+                        <xsd:enumeration value="documents"/>          <!-- isDocumentedBy -->
+                        <xsd:enumeration value="isSupplementTo"/>     <!-- isSupplememtedBy -->
+                        <xsd:enumeration value="isSupplementedBy"/>   <!-- isSupplementTo -->
+                        <xsd:enumeration value="isContinuedBy"/>      <!-- continues -->
+                        <xsd:enumeration value="continues"/>          <!-- isContinuedBy -->
+                         
+                        <!--   From Dublin core -->
+                        <xsd:enumeration value="isPartOf"/>           <!-- hasPart -->
+                        <xsd:enumeration value="hasPart"/>            <!-- isPartOf -->
+                        <xsd:enumeration value="references"/>         <!-- isReferencedBy -->
+                        <xsd:enumeration value="isReferencedBy"/>     <!-- references -->
+                        <xsd:enumeration value="isBasedOn"/>          <!-- isBasisFor -->
+                        <xsd:enumeration value="isBasisFor"/>         <!-- isBasedOn -->
+                        <xsd:enumeration value="requires"/>           <!-- isRequiredBy -->
+                        <xsd:enumeration value="isRequiredBy"/>       <!-- requires --> 
+                       
+                    </xsd:restriction>
+                </xsd:simpleType>
+            </xsd:attribute>
+            <xsd:attributeGroup ref="relations_type.atts"/>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <xsd:element name="intra_work_relation">
+        <xsd:complexType mixed="true">
+            <xsd:attribute name="relationship-type" use="required">
+                <xsd:annotation>
+                    <xsd:documentation>Used to define relations between items that are essentially the same work but may differ in 
+                                       format, language, revision ... etc. Assigning different identifers to exactly the same item
+                                       available in one place or as copies in multiple places can be problematic and should be avoided.
+                    </xsd:documentation>
+                </xsd:annotation>
+                <xsd:simpleType>
+                    <xsd:restriction base="xsd:string">
+                        <!--   Crossref  -->              
+                        <xsd:enumeration value="isTranslationOf"/>    <!-- hasTranslation --> 
+                        <xsd:enumeration value="hasTranslation"/>     <!-- isTranslationOf --> 
+                        <xsd:enumeration value="isPreprintOf"/>       <!-- hasPreprint --> 
+                        <xsd:enumeration value="hasPreprint"/>        <!-- isPreprintOf --> 
+                        <xsd:enumeration value="isManuscriptOf"/>     <!-- hasManuscript --> 
+                        <xsd:enumeration value="hasManuscript"/>      <!-- isManuscriptOf --> 
+                        <xsd:enumeration value="isExpressionOf"/>     <!-- hasExpression --> 
+                        <xsd:enumeration value="hasExpression"/>      <!-- isExpressionOf --> 
+                        <xsd:enumeration value="isManifestationOf"/>  <!-- hasManifestation --> 
+                        <xsd:enumeration value="hasManifestation"/>   <!-- isManifestationOf --> 
+                        <xsd:enumeration value="isReplacedBy"/>       <!-- replaces --> 
+                        <xsd:enumeration value="replaces"/>           <!-- isReplacedBy --> 
+                        <xsd:enumeration value="isSameAs"/>           <!-- isSameAs --> 
+                         
+                        <!--   Common with DataCite  -->
+                        <xsd:enumeration value="isIdenticalTo"/>      <!-- isIdenticalTo --> 
+                        <xsd:enumeration value="isVariantFormOf"/>    <!-- isOriginalFormOf --> 
+                        <xsd:enumeration value="isOriginalFormOf"/>   <!-- isVariantFormOf --> 
+                        
+                        <!--   From Dublin core -->
+                        <xsd:enumeration value="isVersionOf"/>        <!-- hasVersion --> 
+                        <xsd:enumeration value="hasVersion"/>         <!-- isVersionOf -->                   
+                        <xsd:enumeration value="isFormatOf"/>         <!-- hasFormat --> 
+                        <xsd:enumeration value="hasFormat"/>          <!-- isFormatOf --> 
+                          
+                    </xsd:restriction>
+                </xsd:simpleType>
+             </xsd:attribute>     
+             <xsd:attributeGroup ref="relations_type.atts"/>
+        </xsd:complexType>
+    </xsd:element>   
+    
+    <!-- =========================================================== -->
+        
+    <xsd:attributeGroup name="relations_type.atts">
+        <xsd:attribute name="identifier-type" use="required">
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="doi"/>
+                    <xsd:enumeration value="issn"/>
+                    <xsd:enumeration value="isbn"/>
+                    <xsd:enumeration value="uri"/>
+                    <xsd:enumeration value="pmid"/>
+                    <xsd:enumeration value="pmcid"/>
+                    <xsd:enumeration value="purl"/>
+                    <xsd:enumeration value="arxiv"/>
+                    <xsd:enumeration value="ark"/>
+                    <xsd:enumeration value="handle"/>
+                    <xsd:enumeration value="uuid"/>
+                    <xsd:enumeration value="ecli"/>
+                    <xsd:enumeration value="accession"/>   
+                    <xsd:enumeration value="other"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+        </xsd:attribute>
+        
+        <xsd:attribute name="namespace">
+            <xsd:annotation>
+                <xsd:documentation>An identifier systems may require a namespace that is needed in addition to the identifer value to provide uniqueness.</xsd:documentation>
+            </xsd:annotation>            
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:string">
+                    <xsd:maxLength value="1024"/>
+                    <xsd:minLength value="4"/>          
+                </xsd:restriction>
+            </xsd:simpleType>
+        </xsd:attribute>
+    </xsd:attributeGroup>
+</xsd:schema>

--- a/mycore-pi/src/main/resources/xsl/crossref-helper-4.4.1.xsl
+++ b/mycore-pi/src/main/resources/xsl/crossref-helper-4.4.1.xsl
@@ -1,0 +1,62 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:cr="http://www.crossref.org/schema/4.4.1"
+                version="3.0">
+
+  <xsl:template name="crossrefContainer">
+    <xsl:param name="content" />
+    <cr:doi_batch version="4.4.1">
+      <cr:head>
+        <!-- these will be filled by java code -->
+        <cr:doi_batch_id></cr:doi_batch_id>
+        <cr:timestamp></cr:timestamp>
+        <cr:depositor>
+          <cr:depositor_name></cr:depositor_name>
+          <cr:email_address></cr:email_address>
+        </cr:depositor>
+        <cr:registrant></cr:registrant>
+      </cr:head>
+      <cr:body>
+        <xsl:copy-of select="$content" />
+      </cr:body>
+    </cr:doi_batch>
+  </xsl:template>
+
+  <xsl:template name="doiData">
+    <xsl:param name="id" select="/mycoreobject/@ID"/>
+    <cr:doi_data_replace>
+      <!-- the javacode will replace the object id with the real DOI data (doi, timestamp, resource, collection)-->
+      <xsl:value-of select="$id"/>
+    </cr:doi_data_replace>
+  </xsl:template>
+
+  <!-- produces the archive_locations elements-->
+  <xsl:template name="archive_locations">
+    <xsl:param name="CLOCKSS" select="true()"/>
+    <xsl:param name="LOCKSS" select="true()"/>
+    <xsl:param name="Portico" select="true()"/>
+    <xsl:param name="KB" select="true()"/>
+    <xsl:param name="Internet_Archive" select="true()"/>
+    <xsl:param name="DWT" select="true()"/>
+
+    <cr:archive_locations>
+      <xsl:if test="$CLOCKSS">
+        <cr:archive name="CLOCKSS"/>
+      </xsl:if>
+      <xsl:if test="$LOCKSS">
+        <cr:archive name="LOCKSS"/>
+      </xsl:if>
+      <xsl:if test="$Portico">
+        <cr:archive name="Portico"/>
+      </xsl:if>
+      <xsl:if test="$KB">
+        <cr:archive name="KB"/>
+      </xsl:if>
+      <xsl:if test="$Internet_Archive">
+        <cr:archive name="Internet Archive"/>
+      </xsl:if>
+      <xsl:if test="$DWT">
+        <cr:archive name="DWT"/>
+      </xsl:if>
+    </cr:archive_locations>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/mycore-pi/src/test/java/org/mycore/pi/MCRMockIdentifierService.java
+++ b/mycore-pi/src/test/java/org/mycore/pi/MCRMockIdentifierService.java
@@ -63,4 +63,8 @@ public class MCRMockIdentifierService extends MCRPIService<MCRMockIdentifier> {
     public boolean isUpdatedCalled() {
         return updatedCalled;
     }
+
+    protected void reset() {
+        this.registerCalled = this.deleteCalled = this.updatedCalled = false;
+    }
 }

--- a/mycore-pi/src/test/java/org/mycore/pi/MCRPIManagerTest.java
+++ b/mycore-pi/src/test/java/org/mycore/pi/MCRPIManagerTest.java
@@ -74,6 +74,8 @@ public class MCRPIManagerTest extends MCRStoreTestCase {
                 .getInstance()
                 .getRegistrationService(MOCK_SERVICE);
 
+        ((MCRMockIdentifierService)registrationService).reset();
+
         MCRObject mcrObject = buildMockObject();
         mockMetadataManager.put(mcrObject.getId(), mcrObject);
         registrationService.register(mcrObject, null);
@@ -105,6 +107,7 @@ public class MCRPIManagerTest extends MCRStoreTestCase {
             .getRegistrationService(MOCK_SERVICE);
 
         MCRMockIdentifierService casted = (MCRMockIdentifierService) registrationService;
+        casted.reset();
 
         Assert.assertFalse("Delete should not have been called!", casted.isDeleteCalled());
         Assert.assertFalse("Register should not have been called!", casted.isRegisterCalled());


### PR DESCRIPTION
- Cache MCRServices (only one instance per ID; because slow schema
parsing)
- Move Methods from MCRDOIService to MCRDOIBaseService and extend from it
- MCRPIJob runs with MCRJanitor if no PI User is specified
- Added Stylesheets for mods2crossref and some util functions for
*2crossref
- Added MCRCrossrefService

[Link to jira](https://mycore.atlassian.net/browse/MCR-1961).
