### PR TITLE
MCR-2025 first shot of NIO implementation that uses IFS2

### DIFF
--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRXMLMetadataManager.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRXMLMetadataManager.java
@@ -334,7 +334,7 @@ public class MCRXMLMetadataManager {
                 }
             }
         }
-        MCRMetadataStore store = MCRStoreManager.getStore(projectType, MCRMetadataStore.class);
+        MCRMetadataStore store = MCRStoreManager.getStore(projectType);
         if (store == null) {
             throw new MCRPersistenceException(
                 new MessageFormat("Metadata store for project {0} and object type {1} is unconfigured.", Locale.ROOT)

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRFile.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRFile.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
@@ -30,6 +31,7 @@ import org.jdom2.Element;
 import org.mycore.common.content.MCRContent;
 import org.mycore.common.content.streams.MCRDevNull;
 import org.mycore.datamodel.ifs.MCRContentInputStream;
+import org.mycore.datamodel.niofs.MCRFileAttributes;
 
 /**
  * Represents a file stored in a file collection. This is a file that is
@@ -58,7 +60,7 @@ public class MCRFile extends MCRStoredNode {
      * @param fo
      *            the file in the local underlying filesystem storing this file
      */
-    protected MCRFile(MCRDirectory parent, Path fo, Element data) throws IOException {
+    protected MCRFile(MCRDirectory parent, Path fo, Element data) {
         super(parent, fo, data);
     }
 
@@ -83,8 +85,7 @@ public class MCRFile extends MCRStoredNode {
      */
     @Override
     protected MCRVirtualNode buildChildNode(Path fo) {
-        throw new UnsupportedOperationException("not yet implemented");
-        //return new MCRVirtualNode(this, path);
+        return null; //not implemented
     }
 
     /**
@@ -158,5 +159,11 @@ public class MCRFile extends MCRStoredNode {
                 e.setAttribute("md5", md5);
             }
         });
+    }
+
+    @Override
+    public MCRFileAttributes<String> getBasicFileAttributes() throws IOException {
+        BasicFileAttributes attrs = Files.readAttributes(path, BasicFileAttributes.class);
+        return MCRFileAttributes.fromAttributes(attrs, getMD5());
     }
 }

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRFileCollection.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRFileCollection.java
@@ -54,7 +54,7 @@ public class MCRFileCollection extends MCRDirectory {
      */
     private static final Logger LOGGER = LogManager.getLogger(MCRFileCollection.class);
 
-    private static final String dataFile = "mcrdata.xml";
+    public static final String DATA_FILE = "mcrdata.xml";
 
     /**
      * The store this file collection is stored in.
@@ -103,7 +103,7 @@ public class MCRFileCollection extends MCRDirectory {
     }
 
     private void readAdditionalData() throws IOException {
-        Path src = path.resolve(dataFile);
+        Path src = path.resolve(DATA_FILE);
         if (!Files.exists(src)) {
             LOGGER.warn("Metadata file is missing, repairing metadata...");
             writeData(e -> {
@@ -131,7 +131,7 @@ public class MCRFileCollection extends MCRDirectory {
     }
 
     protected void saveAdditionalData() throws IOException {
-        Path target = path.resolve(dataFile);
+        Path target = path.resolve(DATA_FILE);
         try {
             readData(e -> {
                 try {
@@ -159,7 +159,7 @@ public class MCRFileCollection extends MCRDirectory {
     @Override
     public Stream<MCRNode> getChildren() throws IOException {
         return super.getChildren()
-            .filter(f -> !dataFile.equals(f.getName()));
+            .filter(f -> !DATA_FILE.equals(f.getName()));
     }
 
     /**
@@ -211,7 +211,7 @@ public class MCRFileCollection extends MCRDirectory {
 
     @Override
     public MCRNode getChild(String name) {
-        if (dataFile.equals(name)) {
+        if (DATA_FILE.equals(name)) {
             return null;
         } else {
             return super.getChild(name);
@@ -225,7 +225,7 @@ public class MCRFileCollection extends MCRDirectory {
 
     private Stream<Path> getUsableChildSream() throws IOException {
         return Files.list(path)
-            .filter(p -> !dataFile.equals(p.getFileName().toString()));
+            .filter(p -> !DATA_FILE.equals(p.getFileName().toString()));
     }
 
     @Override

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRFileCollection.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRFileCollection.java
@@ -210,17 +210,27 @@ public class MCRFileCollection extends MCRDirectory {
     }
 
     @Override
-    public int getNumChildren() throws IOException {
-        return super.getNumChildren() - 1;
-    }
-
-    @Override
-    public MCRNode getChild(String name) throws IOException {
+    public MCRNode getChild(String name) {
         if (dataFile.equals(name)) {
             return null;
         } else {
             return super.getChild(name);
         }
+    }
+
+    @Override
+    public boolean hasChildren() throws IOException {
+        return getUsableChildSream().findAny().isPresent();
+    }
+
+    private Stream<Path> getUsableChildSream() throws IOException {
+        return Files.list(path)
+            .filter(p -> !dataFile.equals(p.getFileName().toString()));
+    }
+
+    @Override
+    public int getNumChildren() throws IOException {
+        return Math.toIntExact(getUsableChildSream().count());
     }
 
     @Override

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRMetadataStore.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRMetadataStore.java
@@ -21,12 +21,14 @@ package org.mycore.datamodel.ifs2;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jdom2.JDOMException;
 import org.mycore.common.MCRException;
 import org.mycore.common.config.MCRConfiguration;
+import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.content.MCRContent;
 
 /**
@@ -44,7 +46,7 @@ import org.mycore.common.content.MCRContent;
  */
 public class MCRMetadataStore extends MCRStore {
 
-    public static final Logger LOGGER = LogManager.getLogger(MCRMetadataStore.class);
+    public static final Logger LOGGER = LogManager.getLogger();
 
     /**
      * If true (which is default), store will enforce it gets
@@ -65,11 +67,11 @@ public class MCRMetadataStore extends MCRStore {
     @Override
     protected void init(String type) {
         super.init(type);
-        prefix = type + "_";
+        prefix = MCRConfiguration2.getString("MCR.IFS2.Store." + type + ".Prefix").orElse(type + "_");
         suffix = ".xml";
-        forceXML = MCRConfiguration.instance().getBoolean("MCR.IFS2.Store." + type + ".ForceXML", true);
+        forceXML = MCRConfiguration2.getBoolean("MCR.IFS2.Store." + type + ".ForceXML").orElse(true);
         if (forceXML) {
-            forceDocType = MCRConfiguration.instance().getString("MCR.IFS2.Store." + type + ".ForceDocType", null);
+            forceDocType = MCRConfiguration2.getString("MCR.IFS2.Store." + type + ".ForceDocType").orElse(null);
             LOGGER.debug("Set doctype for {} to {}", type, forceDocType);
         }
     }
@@ -83,7 +85,7 @@ public class MCRMetadataStore extends MCRStore {
     @Override
     protected void init(MCRStoreConfig config) {
         super.init(config);
-        prefix = config.getID() + "_";
+        prefix = Optional.ofNullable(config.getPrefix()).orElseGet(() -> config.getID() + "_");
         suffix = ".xml";
         forceXML = MCRConfiguration.instance().getBoolean("MCR.IFS2.Store." + config.getID() + ".ForceXML", true);
         if (forceXML) {

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRStore.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRStore.java
@@ -32,9 +32,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.StringTokenizer;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -192,6 +196,19 @@ public abstract class MCRStore {
             LOGGER.error("Error whil checking if base directory is empty: " + baseDirectory, e);
             return false;
         }
+    }
+
+    /**
+     * @return all Ids of this store
+     */
+    public IntStream getStoredIDs() {
+        int characteristics = Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.SORTED;
+        return StreamSupport
+            .stream(() -> Spliterators
+                .spliteratorUnknownSize(listIDs(ASCENDING), characteristics),
+                characteristics,
+                false)
+            .mapToInt(Integer::intValue);
     }
 
     /**
@@ -355,6 +372,13 @@ public abstract class MCRStore {
     }
 
     /**
+     * @return the absolute path of the local base directory
+     */
+    public Path getBaseDirectory() {
+        return baseDirectory.toAbsolutePath();
+    }
+
+    /**
      * Returns the absolute path of the local base directory
      * 
      * @return the base directory storing the data
@@ -452,6 +476,7 @@ public abstract class MCRStore {
             idLength += slotLength[i++];
         }
         idLength += Integer.parseInt(st.nextToken());
+        prefix = config.getPrefix();
 
         try {
             try {
@@ -567,9 +592,8 @@ public abstract class MCRStore {
 
     public interface MCRStoreConfig {
         String getBaseDir();
-
         String getID();
-
+        String getPrefix();
         String getSlotLayout();
     }
 }

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRStoreBrowserServlet.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRStoreBrowserServlet.java
@@ -88,7 +88,7 @@ class MCRStoreBrowserRequest {
             store = MCRXMLMetadataManager.instance().getStore(storeID);
         // TODO: the store can never be null, instead an MCRPersistenceException is thrown
         if (store == null) {
-            store = MCRStoreManager.getStore(storeID, MCRMetadataStore.class);
+            store = MCRStoreManager.getStore(storeID);
             if (store == null)
                 store = MCRStoreManager.createStore(storeID, MCRMetadataStore.class);
         }

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRStoreCenter.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRStoreCenter.java
@@ -20,6 +20,10 @@ package org.mycore.datamodel.ifs2;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.mycore.common.function.MCRFunctions;
 
 public class MCRStoreCenter {
     private Map<String, MCRStore> storeHeap;
@@ -41,23 +45,44 @@ public class MCRStoreCenter {
      * @throws MCRStoreAlreadyExistsException If with the same id already exists in the store center
      */
     public void addStore(String id, MCRStore store) throws MCRStoreAlreadyExistsException {
-        if (storeHeap.containsKey(id)) {
+        if (storeHeap.putIfAbsent(id, store) != null) {
             throw new MCRStoreAlreadyExistsException("Could not add store with ID " + id + ", store allready exists");
         }
-
-        storeHeap.put(id, store);
     }
 
     /**
      * Get the MyCoRe Store with the given ID from store center.
-     * 
+     *
      * @param id - The id of the to retrieved store
      * @param storeClass - The class type of the retrieved store
      * @return The retrieved store or null if not exists
+     * @deprecated use {@link #getStore(String)} instead
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public <T extends MCRStore> T getStore(String id, Class<T> storeClass) {
         return (T) storeHeap.get(id);
+    }
+
+    /**
+     * Get the MyCoRe Store with the given ID from store center.
+     *
+     * @param id - The id of the to retrieved store
+     * @return The retrieved store or null if not exists
+     */
+    public <T extends MCRStore> T getStore(String id) {
+        return (T) storeHeap.get(id);
+    }
+
+    /**
+     * @return a Stream of all {@link MCRStore}s that are an instance of <code>&lt;T&gt;</code>
+     */
+    public <T extends MCRStore> Stream<T> getCurrentStores(Class<T> sClass) {
+        return storeHeap.values()
+            .stream()
+            .filter(sClass::isInstance)
+            .map(s -> (T) s)
+            .filter(Objects::nonNull);
     }
 
     /**

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRStoreDefaultConfig.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRStoreDefaultConfig.java
@@ -19,6 +19,7 @@
 package org.mycore.datamodel.ifs2;
 
 import org.mycore.common.config.MCRConfiguration;
+import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.datamodel.ifs2.MCRStore.MCRStoreConfig;
 
 class MCRStoreDefaultConfig implements MCRStoreConfig {
@@ -34,6 +35,11 @@ class MCRStoreDefaultConfig implements MCRStoreConfig {
     @Override
     public String getBaseDir() {
         return MCRConfiguration.instance().getString(storeConfigPrefix + "BaseDir");
+    }
+
+    @Override
+    public String getPrefix() {
+        return MCRConfiguration2.getString(storeConfigPrefix + "Prefix").orElse(id + "_");
     }
 
     @Override

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRStoreManager.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRStoreManager.java
@@ -51,10 +51,14 @@ public class MCRStoreManager {
      * @param ID
      *            the ID of the store
      */
-    public static MCRStore getStore(String ID) {
-        return getStore(ID, MCRStore.class);
+    public static <T extends MCRStore> T getStore(String ID) {
+        return MCRStoreCenter.instance().getStore(ID);
     }
 
+    /**
+     * @deprecated use {@link #getStore(String)} instead
+     */
+    @Deprecated
     public static <T extends MCRStore> T getStore(String ID, Class<T> storeClass) {
         return MCRStoreCenter.instance().getStore(ID, storeClass);
     }

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRVirtualNode.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRVirtualNode.java
@@ -18,7 +18,6 @@
 
 package org.mycore.datamodel.ifs2;
 
-import java.io.IOException;
 import java.nio.file.Path;
 
 /**
@@ -45,7 +44,7 @@ public class MCRVirtualNode extends MCRNode {
      * Returns a virtual node that is a child of this virtual node.
      */
     @Override
-    protected MCRVirtualNode buildChildNode(Path fo) throws IOException {
+    protected MCRVirtualNode buildChildNode(Path fo) {
         return new MCRVirtualNode(this, fo);
     }
 }

--- a/mycore-base/src/main/java/org/mycore/datamodel/niofs/MCRFileAttributes.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/niofs/MCRFileAttributes.java
@@ -29,7 +29,19 @@ import java.util.regex.Pattern;
  */
 public class MCRFileAttributes<T> implements BasicFileAttributes {
     enum fileType {
-        file, directory, link, other
+        file, directory, link, other;
+        public static fileType fromAttribute(BasicFileAttributes attrs) {
+            if (attrs.isRegularFile()) {
+                return file;
+            }
+            if (attrs.isDirectory()) {
+                return directory;
+            }
+            if (attrs.isSymbolicLink()) {
+                return link;
+            }
+            return other;
+        }
     }
 
     private static final FileTime EPOCHE_TIME = FileTime.fromMillis(0);
@@ -77,6 +89,11 @@ public class MCRFileAttributes<T> implements BasicFileAttributes {
         final FileTime creationTime, final FileTime lastModified, final FileTime lastAccessTime) {
         return new MCRFileAttributes<>(fileType.file, size, filekey, md5sum, creationTime, lastModified,
             lastAccessTime);
+    }
+
+    public static <T> MCRFileAttributes<T> fromAttributes(BasicFileAttributes attrs, String md5) {
+        return new MCRFileAttributes<>(fileType.fromAttribute(attrs), attrs.size(), (T) attrs.fileKey(), md5,
+            attrs.creationTime(), attrs.lastModifiedTime(), attrs.lastAccessTime());
     }
 
     /* (non-Javadoc)

--- a/mycore-base/src/test/java/org/mycore/datamodel/ifs2/test/MCRStoreCenterTest.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/ifs2/test/MCRStoreCenterTest.java
@@ -31,7 +31,6 @@ import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.Locale;
-import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -56,13 +55,17 @@ public class MCRStoreCenterTest {
         FakeStoreConfig config = new FakeStoreConfig("heapOp");
         storeHeap.addStore(config.getID(), new FakeStore(config));
         String storeID = config.getID();
-        FakeStore fakeStore = storeHeap.getStore(storeID, FakeStore.class);
+        FakeStore fakeStore = storeHeap.getStore(storeID);
 
         assertNotNull("The store should be not null.", fakeStore);
         assertEquals("Fake Store", fakeStore.getMsg());
 
+        assertTrue("Could not find store with ID: " + storeID, storeHeap.getCurrentStores(FakeStore.class)
+            .filter(s -> storeID.equals(s.getID()))
+            .findAny().isPresent());
+
         assertTrue("Could not remove store with ID: " + storeID, storeHeap.removeStore(storeID));
-        assertNull("There should be no store with ID: " + storeID, storeHeap.getStore(storeID, FakeStore.class));
+        assertNull("There should be no store with ID: " + storeID, storeHeap.<FakeStore> getStore(storeID));
     }
 
     @Test(expected = MCRStoreAlreadyExistsException.class)
@@ -92,6 +95,11 @@ public class MCRStoreCenterTest {
         @Override
         public String getID() {
             return "fake";
+        }
+
+        @Override
+        public String getPrefix() {
+            return "fake_";
         }
 
         @Override

--- a/mycore-base/src/test/java/org/mycore/datamodel/ifs2/test/MCRStoreManagerTest.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/ifs2/test/MCRStoreManagerTest.java
@@ -67,6 +67,11 @@ public class MCRStoreManagerTest {
         }
 
         @Override
+        public String getPrefix() {
+            return getID() + "_";
+        }
+
+        @Override
         public String getBaseDir() {
             return baseDir.toUri().toString();
         }

--- a/mycore-ifs/src/main/java/org/mycore/datamodel/ifs2/MCRCStoreIFS2.java
+++ b/mycore-ifs/src/main/java/org/mycore/datamodel/ifs2/MCRCStoreIFS2.java
@@ -97,10 +97,10 @@ public class MCRCStoreIFS2 extends MCRContentStore {
             prefix = base + "_";
         }
 
-        MCRFileStore store = MCRStoreManager.getStore(sid, MCRFileStore.class);
+        MCRFileStore store = MCRStoreManager.getStore(sid);
         if (store == null) {
             synchronized (this) {
-                store = MCRStoreManager.getStore(sid, MCRFileStore.class);
+                store = MCRStoreManager.getStore(sid);
                 if (store == null) {
                     store = createStore(sid, storeBaseDir);
                 }
@@ -288,7 +288,7 @@ public class MCRCStoreIFS2 extends MCRContentStore {
             throw new IOException("No storage id");
         }
         MCRFile file = getFile(storageId);
-        return file.getLocalFile();
+        return file.getLocalPath().toFile();
     }
 
     private MCRFileCollection getSlot(MCRObjectID derivateID) throws IOException {

--- a/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRBasicFileAttributeViewImpl.java
+++ b/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRBasicFileAttributeViewImpl.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.datamodel.niofs.ifs2;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.FileTime;
+
+import org.mycore.datamodel.ifs2.MCRStoredNode;
+import org.mycore.datamodel.niofs.MCRFileAttributes;
+
+abstract class MCRBasicFileAttributeViewImpl implements BasicFileAttributeView {
+
+    public MCRBasicFileAttributeViewImpl() {
+        super();
+    }
+
+    static MCRFileAttributes<String> readAttributes(MCRStoredNode node) throws IOException {
+        return node.getBasicFileAttributes();
+    }
+
+    @Override
+    public String name() {
+        return "basic";
+    }
+
+    @Override
+    public MCRFileAttributes<String> readAttributes() throws IOException {
+        MCRStoredNode node = resolveNode();
+        return readAttributes(node);
+    }
+
+    @Override
+    public void setTimes(FileTime lastModifiedTime, FileTime lastAccessTime, FileTime createTime) throws IOException {
+        MCRStoredNode node = resolveNode();
+        BasicFileAttributeView localView = Files
+            .getFileAttributeView(node.getLocalPath(), BasicFileAttributeView.class);
+        localView.setTimes(lastModifiedTime, lastAccessTime, createTime);
+    }
+
+    protected abstract MCRStoredNode resolveNode() throws IOException;
+
+}

--- a/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRDirectoryStream.java
+++ b/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRDirectoryStream.java
@@ -1,0 +1,339 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.datamodel.niofs.ifs2;
+
+import java.io.IOException;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.ClosedDirectoryStreamException;
+import java.nio.file.DirectoryIteratorException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.SecureDirectoryStream;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.FileAttributeView;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.mycore.datamodel.ifs2.MCRDirectory;
+import org.mycore.datamodel.ifs2.MCRFile;
+import org.mycore.datamodel.ifs2.MCRNode;
+import org.mycore.datamodel.ifs2.MCRStoredNode;
+import org.mycore.datamodel.niofs.MCRFileAttributes;
+import org.mycore.datamodel.niofs.MCRMD5AttributeView;
+import org.mycore.datamodel.niofs.MCRPath;
+
+/**
+ * A {@link SecureDirectoryStream} on internal file system. This implementation uses IFS directly. Do use this class but
+ * stick to the interface.
+ *
+ * @author Thomas Scheffler (yagee)
+ */
+public class MCRDirectoryStream implements SecureDirectoryStream<Path> {
+    static Logger LOGGER = LogManager.getLogger();
+
+    private MCRDirectory dir;
+
+    private MCRPath path;
+
+    private Iterator<Path> iterator;
+
+    /**
+     * @throws IOException
+     *             if 'path' is not from {@link MCRIFSFileSystem}
+     */
+    public MCRDirectoryStream(MCRDirectory dir, MCRPath path) throws IOException {
+        this.dir = Objects.requireNonNull(dir, "'dir' may not be null");
+        this.path = Optional.of(path).orElseGet(() -> MCRFileSystemUtils.toPath(dir));
+        this.iterator = new MCRDirectoryIterator(this);
+    }
+
+    @Override
+    public Iterator<Path> iterator() {
+        checkClosed();
+        synchronized (this) {
+            if (iterator == null) {
+                throw new IllegalStateException("Iterator already obtained");
+            }
+            Iterator<Path> pathIterator = this.iterator;
+            iterator = null;
+            return pathIterator;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        dir = null;
+    }
+
+    void checkClosed() {
+        if (dir == null) {
+            throw new ClosedDirectoryStreamException();
+        }
+    }
+
+    MCRPath checkRelativePath(Path path) {
+        if (path.isAbsolute()) {
+            throw new IllegalArgumentException(path + " is absolute.");
+        }
+        return checkFileSystem(path);
+    }
+
+    private MCRPath checkFileSystem(Path path) {
+        if (!(path.getFileSystem() instanceof MCRIFSFileSystem)) {
+            throw new IllegalArgumentException(path + " is not from " + MCRIFSFileSystem.class.getSimpleName());
+        }
+        return MCRPath.toMCRPath(path);
+    }
+
+    @Override
+    public SecureDirectoryStream<Path> newDirectoryStream(Path path, LinkOption... options) throws IOException {
+        checkClosed();
+        MCRPath mcrPath = checkFileSystem(path);
+        if (mcrPath.isAbsolute()) {
+            return (SecureDirectoryStream<Path>) Files.newDirectoryStream(mcrPath);
+        }
+        MCRNode childByPath = dir.getNodeByPath(mcrPath.toString());
+        if (childByPath == null || childByPath instanceof MCRFile) {
+            throw new NoSuchFileException(dir.toString(), path.toString(), "Does not exist or is a file.");
+        }
+        return new MCRDirectoryStream((MCRDirectory) childByPath, MCRPath.toMCRPath(path.resolve(mcrPath)));
+    }
+
+    @Override
+    public SeekableByteChannel newByteChannel(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs)
+        throws IOException {
+        checkClosed();
+        MCRPath mcrPath = checkRelativePath(path);
+        if (mcrPath.isAbsolute()) {
+            return mcrPath.getFileSystem().provider().newByteChannel(mcrPath, options, attrs);
+        }
+        Set<? extends OpenOption> fileOpenOptions = options.stream()
+            .filter(option -> !(option == StandardOpenOption.CREATE || option == StandardOpenOption.CREATE_NEW))
+            .collect(Collectors.toSet());
+        boolean create = options.contains(StandardOpenOption.CREATE);
+        boolean createNew = options.contains(StandardOpenOption.CREATE_NEW);
+        if (create || createNew) {
+            for (OpenOption option : fileOpenOptions) {
+                //check before we create any file instance
+                MCRFileSystemProvider.checkOpenOption(option);
+            }
+        }
+        MCRFileSystemProvider provider = (MCRFileSystemProvider) mcrPath.getFileSystem().provider();
+        MCRFileSystemUtils.getMCRFile(dir, mcrPath, create, createNew);
+        return provider.newByteChannel(this.path.resolve(mcrPath), fileOpenOptions, attrs);
+    }
+
+    @Override
+    public void deleteFile(Path path) throws IOException {
+        deleteFileSystemNode(checkFileSystem(path));
+    }
+
+    @Override
+    public void deleteDirectory(Path path) throws IOException {
+        deleteFileSystemNode(checkFileSystem(path));
+    }
+
+    /**
+     * Deletes {@link MCRStoredNode} if it exists.
+     *
+     * @param path
+     *            relative or absolute
+     * @throws IOException
+     */
+    private void deleteFileSystemNode(MCRPath path) throws IOException {
+        checkClosed();
+        if (path.isAbsolute()) {
+            Files.delete(path);
+        }
+        MCRStoredNode childByPath = (MCRStoredNode) dir.getNodeByPath(path.toString());
+        if (childByPath == null) {
+            throw new NoSuchFileException(this.path.toString(), path.toString(), null);
+        }
+        childByPath.delete();
+    }
+
+    @Override
+    public void move(Path srcpath, SecureDirectoryStream<Path> targetdir, Path targetpath) throws IOException {
+        checkClosed();
+        checkFileSystem(srcpath);
+        checkFileSystem(targetpath);
+        throw new AtomicMoveNotSupportedException(srcpath.toString(), targetpath.toString(),
+            "Currently not implemented");
+    }
+
+    @Override
+    public <V extends FileAttributeView> V getFileAttributeView(Class<V> type) {
+        return getFileAttributeView(null, type, (LinkOption[]) null);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <V extends FileAttributeView> V getFileAttributeView(Path path, Class<V> type, LinkOption... options) {
+        if (path != null) {
+            MCRPath file = checkRelativePath(path);
+            if (file.getNameCount() != 1) {
+                throw new InvalidPathException(path.toString(), "'path' must have one name component.");
+            }
+        }
+        checkClosed();
+        if (type == null) {
+            throw new NullPointerException();
+        }
+        //must support BasicFileAttributeView
+        if (type == BasicFileAttributeView.class) {
+            return (V) new BasicFileAttributeViewImpl(this, path);
+        }
+        if (type == MCRMD5AttributeView.class) {
+            return (V) new MD5FileAttributeViewImpl(this, path);
+        }
+        return null;
+    }
+
+    private static class MCRDirectoryIterator implements Iterator<Path> {
+
+        Path nextPath;
+
+        boolean hasNextCalled;
+
+        private MCRDirectoryStream mcrDirectoryStream;
+
+        MCRStoredNode[] children;
+
+        private int pos;
+
+        public MCRDirectoryIterator(MCRDirectoryStream mcrDirectoryStream) throws IOException {
+            this.mcrDirectoryStream = mcrDirectoryStream;
+            children = mcrDirectoryStream.dir.getChildren().toArray(MCRStoredNode[]::new);
+            this.nextPath = null;
+            hasNextCalled = false;
+            pos = -1;
+        }
+
+        @Override
+        public boolean hasNext() {
+            LOGGER.debug(() -> "hasNext() called: " + pos);
+            if (mcrDirectoryStream.dir == null) {
+                return false; //stream closed
+            }
+            int nextPos = pos + 1;
+            if (nextPos >= children.length) {
+                return false;
+            }
+            //we are OK
+            nextPath = getPath(children, nextPos);
+            hasNextCalled = true;
+            return true;
+        }
+
+        private MCRPath getPath(MCRStoredNode[] children, int index) {
+            try {
+                MCRPath path = MCRPath.toMCRPath(mcrDirectoryStream.path.resolve(children[index].getName()));
+                LOGGER.debug(() -> "getting path at index " + index + ": " + path);
+                return path;
+            } catch (RuntimeException e) {
+                throw new DirectoryIteratorException(new IOException(e));
+            }
+        }
+
+        @Override
+        public Path next() {
+            LOGGER.debug(() -> "next() called: " + pos);
+            pos++;
+            if (hasNextCalled) {
+                hasNextCalled = false;
+                return nextPath;
+            }
+            mcrDirectoryStream.checkClosed();
+            if (pos >= children.length) {
+                throw new NoSuchElementException();
+            }
+            return getPath(children, pos);
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+    static class BasicFileAttributeViewImpl extends MCRBasicFileAttributeViewImpl {
+
+        private MCRDirectoryStream mcrDirectoryStream;
+
+        private Path fileName;
+
+        public BasicFileAttributeViewImpl(MCRDirectoryStream mcrDirectoryStream, Path path) {
+            this.mcrDirectoryStream = mcrDirectoryStream;
+            if (path.toString().length() <= 2 && (path.toString().equals(".") || path.toString().equals(".."))) {
+                throw new InvalidPathException(path.toString(), "'path' must be a valid file name.");
+            }
+            this.fileName = path;
+        }
+
+        @Override
+        protected MCRStoredNode resolveNode() throws IOException {
+            MCRDirectory parent = mcrDirectoryStream.dir;
+            mcrDirectoryStream.checkClosed();
+            MCRStoredNode child;
+            try {
+                child = (MCRStoredNode) parent.getChild(fileName.toString());
+            } catch (RuntimeException e) {
+                throw new IOException(e);
+            }
+            if (child == null) {
+                throw new NoSuchFileException(mcrDirectoryStream.path.toString(), fileName.toString(), null);
+            }
+            return child;
+        }
+    }
+
+    private static class MD5FileAttributeViewImpl extends BasicFileAttributeViewImpl implements
+        MCRMD5AttributeView<String> {
+
+        public MD5FileAttributeViewImpl(MCRDirectoryStream mcrDirectoryStream, Path path) {
+            super(mcrDirectoryStream, path);
+            // TODO Auto-generated constructor stub
+        }
+
+        @Override
+        public MCRFileAttributes<String> readAllAttributes() throws IOException {
+            return readAttributes();
+        }
+
+        @Override
+        public String name() {
+            return "md5";
+        }
+
+    }
+}

--- a/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRFileChannel.java
+++ b/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRFileChannel.java
@@ -1,0 +1,150 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.datamodel.niofs.ifs2;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+
+import org.mycore.common.content.streams.MCRMD5InputStream;
+import org.mycore.datamodel.ifs.MCRContentInputStream;
+import org.mycore.datamodel.ifs2.MCRFile;
+
+/**
+ * @author Thomas Scheffler (yagee)
+ */
+public class MCRFileChannel extends FileChannel {
+
+    private FileChannel baseChannel;
+
+    private MCRFile file;
+
+    private boolean write;
+
+    public MCRFileChannel(MCRFile file, FileChannel baseChannel, boolean write) {
+        this.file = file;
+        this.baseChannel = baseChannel;
+        this.write = write;
+    }
+
+    public void implCloseChannel() throws IOException {
+        baseChannel.close(); //MCR-1003 close before updating metadata, as we read attributes from this file later
+        updateMetadata();
+    }
+
+    private void updateMetadata() throws IOException {
+        if (!write) {
+            return;
+        }
+        MessageDigest md5Digest = MCRMD5InputStream.buildMD5Digest();
+        FileChannel md5Channel = (FileChannel) Files.newByteChannel(file.getLocalPath(), StandardOpenOption.READ);
+        try {
+            long position = 0, size = md5Channel.size();
+            while (position < size) {
+                long remainingSize = size - position;
+                final ByteBuffer byteBuffer = md5Channel.map(MapMode.READ_ONLY, position,
+                    Math.min(remainingSize, Integer.MAX_VALUE));
+                while (byteBuffer.hasRemaining()) {
+                    md5Digest.update(byteBuffer);
+                }
+                position += byteBuffer.limit();
+            }
+        } finally {
+            if (md5Channel != baseChannel) {
+                md5Channel.close();
+            }
+        }
+        String md5 = MCRContentInputStream.getMD5String(md5Digest.digest());
+        file.setMD5(md5);
+    }
+
+    //Delegate to baseChannel
+
+    public int read(ByteBuffer dst) throws IOException {
+        return baseChannel.read(dst);
+    }
+
+    public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
+        return baseChannel.read(dsts, offset, length);
+    }
+
+    public int write(ByteBuffer src) throws IOException {
+        return baseChannel.write(src);
+    }
+
+    public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return baseChannel.write(srcs, offset, length);
+    }
+
+    public long position() throws IOException {
+        return baseChannel.position();
+    }
+
+    public FileChannel position(long newPosition) throws IOException {
+        return baseChannel.position(newPosition);
+    }
+
+    public long size() throws IOException {
+        return baseChannel.size();
+    }
+
+    public FileChannel truncate(long size) throws IOException {
+        return baseChannel.truncate(size);
+    }
+
+    public void force(boolean metaData) throws IOException {
+        baseChannel.force(metaData);
+    }
+
+    public long transferTo(long position, long count, WritableByteChannel target) throws IOException {
+        return baseChannel.transferTo(position, count, target);
+    }
+
+    public long transferFrom(ReadableByteChannel src, long position, long count) throws IOException {
+        return baseChannel.transferFrom(src, position, count);
+    }
+
+    public int read(ByteBuffer dst, long position) throws IOException {
+        return baseChannel.read(dst, position);
+    }
+
+    public int write(ByteBuffer src, long position) throws IOException {
+        return baseChannel.write(src, position);
+    }
+
+    public MappedByteBuffer map(MapMode mode, long position, long size) throws IOException {
+        return baseChannel.map(mode, position, size);
+    }
+
+    public FileLock lock(long position, long size, boolean shared) throws IOException {
+        return baseChannel.lock(position, size, shared);
+    }
+
+    public FileLock tryLock(long position, long size, boolean shared) throws IOException {
+        return baseChannel.tryLock(position, size, shared);
+    }
+
+}

--- a/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRFileStore.java
+++ b/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRFileStore.java
@@ -1,0 +1,168 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.datamodel.niofs.ifs2;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.attribute.FileStoreAttributeView;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.logging.log4j.LogManager;
+import org.mycore.datamodel.ifs2.MCRFile;
+import org.mycore.datamodel.ifs2.MCRStore;
+import org.mycore.datamodel.ifs2.MCRStoreManager;
+import org.mycore.datamodel.ifs2.MCRStoredNode;
+import org.mycore.datamodel.niofs.MCRAbstractFileStore;
+import org.mycore.datamodel.niofs.MCRPath;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+public class MCRFileStore extends MCRAbstractFileStore {
+
+    private MCRStore contentStore;
+
+    private String baseId;
+
+    private FileStore baseFileStore;
+
+    private static LoadingCache<String, MCRFileStore> instanceHolder = CacheBuilder.newBuilder().weakKeys()
+        .build(new CacheLoader<String, MCRFileStore>() {
+
+            @Override
+            public MCRFileStore load(String contentStoreID) throws Exception {
+                MCRStore store = MCRStoreManager.getStore(contentStoreID);
+                return new MCRFileStore(store);
+            }
+        });
+
+    private MCRFileStore(MCRStore contentStore) throws IOException {
+        this.contentStore = contentStore;
+        Path baseDir = this.contentStore.getBaseDirectory();
+        this.baseFileStore = getFileStore(baseDir);
+        this.baseId = contentStore.getID().substring(MCRFileSystemUtils.STORE_ID_PREFIX.length());
+        if (baseFileStore == null) {
+            String reason = "Cannot access base directory or any parent directory of Content Store "
+                + contentStore.getID();
+            throw new NoSuchFileException(baseDir.toString(), null, reason);
+        }
+    }
+
+    private static FileStore getFileStore(Path baseDir) throws IOException {
+        if (baseDir == null) {
+            return null;
+        }
+        //fixes MCR-964
+        return Files.exists(baseDir) ? Files.getFileStore(baseDir) : getFileStore(baseDir.getParent());
+    }
+
+    static MCRFileStore getInstance(String storeId) throws IOException {
+        try {
+            return instanceHolder.get(storeId);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException) {
+                throw (IOException) cause;
+            }
+            throw new IOException("Error while geting instance of " + MCRFileStore.class.getSimpleName(), cause);
+        }
+    }
+
+    public static MCRFileStore getInstance(MCRStoredNode node) throws IOException {
+        return getInstance(node.getRoot().getStore().getID());
+    }
+
+    @Override
+    public String name() {
+        return contentStore.getID();
+    }
+
+    @Override
+    public String type() {
+        return contentStore.getClass().getCanonicalName();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return baseFileStore.isReadOnly();
+    }
+
+    @Override
+    public long getTotalSpace() throws IOException {
+        return baseFileStore.getTotalSpace();
+    }
+
+    @Override
+    public long getUsableSpace() throws IOException {
+        return baseFileStore.getUsableSpace();
+    }
+
+    @Override
+    public long getUnallocatedSpace() throws IOException {
+        return baseFileStore.getUnallocatedSpace();
+    }
+
+    @Override
+    public boolean supportsFileAttributeView(Class<? extends FileAttributeView> type) {
+        return this.baseFileStore.supportsFileAttributeView(type);
+    }
+
+    @Override
+    public boolean supportsFileAttributeView(String name) {
+        return this.baseFileStore.supportsFileAttributeView(name);
+    }
+
+    @Override
+    public <V extends FileStoreAttributeView> V getFileStoreAttributeView(Class<V> type) {
+        return this.baseFileStore.getFileStoreAttributeView(type);
+    }
+
+    @Override
+    public Object getAttribute(String attribute) throws IOException {
+        return this.baseFileStore.getAttribute(attribute);
+    }
+
+    @Override
+    public Path getBaseDirectory() throws IOException {
+        return this.contentStore.getBaseDirectory();
+    }
+
+    @Override
+    public Path getPhysicalPath(MCRPath path) {
+        MCRFileSystemUtils.checkPathAbsolute(path);
+        LogManager.getLogger().warn("Checking if {} is of baseId {}", path, baseId);
+        if (!path.getOwner().startsWith(baseId + "_")) {
+            LogManager.getLogger().warn("{} is not of baseId {}", path, baseId);
+            return null;
+        }
+        try {
+            MCRFile mcrFile = MCRFileSystemUtils.getMCRFile(path, false, false);
+            return mcrFile.getLocalPath();
+        } catch (IOException e) {
+            LogManager.getLogger(getClass()).info(e.getMessage());
+            return null;
+        }
+    }
+
+}

--- a/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRFileSystemProvider.java
+++ b/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRFileSystemProvider.java
@@ -1,0 +1,750 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.datamodel.niofs.ifs2;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.channels.FileChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.AccessMode;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.CopyOption;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.DirectoryStream.Filter;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.NotDirectoryException;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.mycore.datamodel.ifs2.MCRDirectory;
+import org.mycore.datamodel.ifs2.MCRFile;
+import org.mycore.datamodel.ifs2.MCRFileCollection;
+import org.mycore.datamodel.ifs2.MCRStoredNode;
+import org.mycore.datamodel.metadata.MCRObjectID;
+import org.mycore.datamodel.niofs.MCRAbstractFileSystem;
+import org.mycore.datamodel.niofs.MCRFileAttributes;
+import org.mycore.datamodel.niofs.MCRMD5AttributeView;
+import org.mycore.datamodel.niofs.MCRPath;
+
+import com.google.common.collect.Sets;
+
+/**
+ * @author Thomas Scheffler (yagee)
+ */
+public class MCRFileSystemProvider extends FileSystemProvider {
+
+    public static final String SCHEME = "ifs2";
+
+    public static final URI FS_URI = URI.create(SCHEME + ":///");
+
+    private static MCRAbstractFileSystem FILE_SYSTEM_INSTANCE;
+
+    private static final Logger LOGGER = LogManager.getLogger(MCRFileSystemProvider.class);
+
+    private static final Set<? extends CopyOption> SUPPORTED_COPY_OPTIONS = Collections.unmodifiableSet(EnumSet.of(
+        StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING));
+
+    private static final Set<? extends OpenOption> SUPPORTED_OPEN_OPTIONS = EnumSet.of(StandardOpenOption.APPEND,
+        StandardOpenOption.DSYNC, StandardOpenOption.READ, StandardOpenOption.SPARSE, StandardOpenOption.SYNC,
+        StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+
+    /**
+     *
+     */
+    public MCRFileSystemProvider() {
+        //TODO: One filesystem enough?
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#getScheme()
+     */
+    @Override
+    public String getScheme() {
+        return SCHEME;
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#newFileSystem(java.net.URI, java.util.Map)
+     */
+    @Override
+    public FileSystem newFileSystem(URI uri, Map<String, ?> env) throws IOException {
+        throw new FileSystemAlreadyExistsException();
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#getFileSystem(java.net.URI)
+     */
+    @Override
+    public MCRIFSFileSystem getFileSystem(URI uri) {
+        if (FILE_SYSTEM_INSTANCE == null) {
+            synchronized (this) {
+                if (FILE_SYSTEM_INSTANCE == null) {
+                    FILE_SYSTEM_INSTANCE = new MCRIFSFileSystem(this);
+                }
+            }
+        }
+        return getMCRIFSFileSystem();
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#getPath(java.net.URI)
+     */
+    @Override
+    public Path getPath(final URI uri) {
+        if (!FS_URI.getScheme().equals(Objects.requireNonNull(uri).getScheme())) {
+            throw new FileSystemNotFoundException("Unkown filesystem: " + uri);
+        }
+        String path = uri.getPath().substring(1);//URI path is absolute -> remove first slash
+        String owner = null;
+        for (int i = 0; i < path.length(); i++) {
+            if (path.charAt(i) == MCRAbstractFileSystem.SEPARATOR) {
+                break;
+            }
+            if (path.charAt(i) == ':') {
+                owner = path.substring(0, i);
+                path = path.substring(i + 1);
+                break;
+            }
+
+        }
+        return MCRAbstractFileSystem.getPath(owner, path, getFileSystemFromPathURI(FS_URI));
+    }
+
+    private MCRIFSFileSystem getFileSystemFromPathURI(final URI uri) {
+        return getMCRIFSFileSystem();
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#newByteChannel(java.nio.file.Path, java.util.Set, java.nio.file.attribute.FileAttribute[])
+     */
+    @Override
+    public SeekableByteChannel newByteChannel(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs)
+        throws IOException {
+        if (attrs.length > 0) {
+            throw new UnsupportedOperationException("Atomically setting of file attributes is not supported.");
+        }
+        MCRPath ifsPath = MCRFileSystemUtils.checkPathAbsolute(path);
+        Set<? extends OpenOption> fileOpenOptions = options.stream()
+            .filter(option -> !(option == StandardOpenOption.CREATE || option == StandardOpenOption.CREATE_NEW))
+            .collect(Collectors.toSet());
+        boolean create = options.contains(StandardOpenOption.CREATE);
+        boolean createNew = options.contains(StandardOpenOption.CREATE_NEW);
+        if (create || createNew) {
+            for (OpenOption option : fileOpenOptions) {
+                //check before we create any file instance
+                checkOpenOption(option);
+            }
+        }
+        MCRFile mcrFile = MCRFileSystemUtils.getMCRFile(ifsPath, create, createNew);
+        if (mcrFile == null) {
+            throw new NoSuchFileException(path.toString());
+        }
+        boolean write = options.contains(StandardOpenOption.WRITE) || options.contains(StandardOpenOption.APPEND);
+        FileChannel baseChannel = (FileChannel) Files.newByteChannel(mcrFile.getLocalPath(), fileOpenOptions);
+        return new MCRFileChannel(mcrFile, baseChannel, write);
+    }
+
+    static void checkOpenOption(OpenOption option) {
+        if (!SUPPORTED_OPEN_OPTIONS.contains(option)) {
+            throw new UnsupportedOperationException("Unsupported OpenOption: " + option.getClass().getSimpleName()
+                + "." + option);
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#newDirectoryStream(java.nio.file.Path, java.nio.file.DirectoryStream.Filter)
+     */
+    @Override
+    public DirectoryStream<Path> newDirectoryStream(Path dir, Filter<? super Path> filter) throws IOException {
+        MCRPath mcrPath = MCRFileSystemUtils.checkPathAbsolute(dir);
+        MCRStoredNode node = MCRFileSystemUtils.resolvePath(mcrPath);
+        if (node instanceof MCRDirectory) {
+            return new MCRDirectoryStream((MCRDirectory) node, mcrPath);
+        }
+        throw new NotDirectoryException(dir.toString());
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#createDirectory(java.nio.file.Path, java.nio.file.attribute.FileAttribute[])
+     */
+    @Override
+    public void createDirectory(Path dir, FileAttribute<?>... attrs) throws IOException {
+        if (attrs.length > 0) {
+            throw new UnsupportedOperationException("Setting 'attrs' atomically is unsupported.");
+        }
+        MCRPath mcrPath = MCRFileSystemUtils.checkPathAbsolute(dir);
+        MCRDirectory rootDirectory;
+        if (mcrPath.isAbsolute() && mcrPath.getNameCount() == 0) {
+            MCRObjectID derId = MCRObjectID.getInstance(mcrPath.getOwner());
+            org.mycore.datamodel.ifs2.MCRFileStore store = MCRFileSystemUtils.getStore(derId.getBase());
+            if (store.retrieve(derId.getNumberAsInteger()) != null) {
+                throw new FileAlreadyExistsException(mcrPath.toString());
+            }
+            store.create(derId.getNumberAsInteger());
+            return;
+        }
+        rootDirectory = MCRFileSystemUtils.getFileCollection(mcrPath.getOwner());
+        MCRPath parentPath = mcrPath.getParent();
+        MCRPath absolutePath = getAbsolutePathFromRootComponent(parentPath);
+        MCRStoredNode childByPath = (MCRStoredNode) rootDirectory.getNodeByPath(absolutePath.toString());
+        if (childByPath == null) {
+            throw new NoSuchFileException(parentPath.toString(), dir.getFileName().toString(),
+                "parent directory does not exist");
+        }
+        if (childByPath instanceof MCRFile) {
+            throw new NotDirectoryException(parentPath.toString());
+        }
+        MCRDirectory parentDir = (MCRDirectory) childByPath;
+        String dirName = mcrPath.getFileName().toString();
+        if (parentDir.getChild(dirName) != null) {
+            throw new FileAlreadyExistsException(mcrPath.toString());
+        }
+        parentDir.createDir(dirName);
+    }
+
+    static MCRPath getAbsolutePathFromRootComponent(MCRPath mcrPath) {
+        if (!mcrPath.isAbsolute()) {
+            throw new InvalidPathException(mcrPath.toString(), "'path' must be absolute.");
+        }
+        String path = mcrPath.toString().substring(mcrPath.getOwner().length() + 1);
+        return MCRAbstractFileSystem.getPath(null, path, mcrPath.getFileSystem());
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#delete(java.nio.file.Path)
+     */
+    @Override
+    public void delete(Path path) throws IOException {
+        MCRPath mcrPath = MCRFileSystemUtils.checkPathAbsolute(path);
+        MCRStoredNode child = MCRFileSystemUtils.resolvePath(mcrPath);
+        if (child instanceof MCRDirectory) {
+            if (child.hasChildren()) {
+                throw new DirectoryNotEmptyException(mcrPath.toString());
+            }
+        }
+        try {
+            child.delete();
+        } catch (RuntimeException e) {
+            throw new IOException("Could not delete: " + mcrPath, e);
+        }
+    }
+
+    private static MCRDirectory getParentDirectory(MCRPath mcrPath) throws IOException {
+        if (mcrPath.getNameCount() == 0) {
+            throw new IllegalArgumentException("Root component has no parent: " + mcrPath);
+        }
+        MCRDirectory rootDirectory = MCRFileSystemUtils.getFileCollection(mcrPath.getOwner());
+        if (mcrPath.getNameCount() == 1) {
+            return rootDirectory;
+        }
+        MCRPath parentPath = mcrPath.getParent();
+        MCRStoredNode parentNode = (MCRStoredNode) rootDirectory
+            .getNodeByPath(getAbsolutePathFromRootComponent(parentPath).toString());
+        if (parentNode == null) {
+            throw new NoSuchFileException(MCRFileSystemUtils.toPath(rootDirectory).toString(),
+                getAbsolutePathFromRootComponent(mcrPath).toString(), "Parent directory does not exists.");
+        }
+        if (parentNode instanceof MCRFile) {
+            throw new NotDirectoryException(MCRFileSystemUtils.toPath(parentNode).toString());
+        }
+        MCRDirectory parentDir = (MCRDirectory) parentNode;
+        parentDir.getChildren();//warm-up cache
+        return parentDir;
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#copy(java.nio.file.Path, java.nio.file.Path, java.nio.file.CopyOption[])
+     */
+    @Override
+    public void copy(Path source, Path target, CopyOption... options) throws IOException {
+        if (isSameFile(source, target)) {
+            return; //that was easy
+        }
+        checkCopyOptions(options);
+        HashSet<CopyOption> copyOptions = Sets.newHashSet(options);
+        boolean createNew = !copyOptions.contains(StandardCopyOption.REPLACE_EXISTING);
+        MCRPath src = MCRFileSystemUtils.checkPathAbsolute(source);
+        MCRPath tgt = MCRFileSystemUtils.checkPathAbsolute(target);
+        MCRStoredNode srcNode = MCRFileSystemUtils.resolvePath(src);
+        //checkParent of target;
+        if (tgt.getNameCount() == 0 && srcNode instanceof MCRDirectory) {
+            MCRDirectory tgtDir = MCRFileSystemUtils.getFileCollection(tgt.getOwner());
+            if (tgtDir != null) {
+                if (tgtDir.hasChildren() && copyOptions.contains(StandardCopyOption.REPLACE_EXISTING)) {
+                    throw new DirectoryNotEmptyException(tgt.toString());
+                }
+            } else {
+                MCRObjectID tgtDerId = MCRObjectID.getInstance(tgt.getOwner());
+                org.mycore.datamodel.ifs2.MCRFileStore store = MCRFileSystemUtils.getStore(tgtDerId.getBase());
+                MCRFileCollection tgtCollection = store.create(tgtDerId.getNumberAsInteger());
+                if (copyOptions.contains(StandardCopyOption.COPY_ATTRIBUTES)) {
+                    copyDirectoryAttributes((MCRDirectory) srcNode, tgtCollection);
+                }
+            }
+            return; //created new root component
+        }
+        MCRDirectory tgtParentDir = MCRFileSystemUtils.resolvePath(tgt.getParent());
+        if (srcNode instanceof MCRFile) {
+            MCRFile srcFile = (MCRFile) srcNode;
+            MCRFile targetFile = MCRFileSystemUtils.getMCRFile(tgt, true, createNew);
+            targetFile.setContent(srcFile.getContent());
+            if (copyOptions.contains(StandardCopyOption.COPY_ATTRIBUTES)) {
+                copyFileAttributes(srcFile, targetFile);
+            }
+        } else if (srcNode instanceof MCRDirectory) {
+            MCRStoredNode child = (MCRStoredNode) tgtParentDir.getChild(tgt.getFileName().toString());
+            if (child != null) {
+                if (!copyOptions.contains(StandardCopyOption.REPLACE_EXISTING)) {
+                    throw new FileAlreadyExistsException(tgtParentDir.toString(), tgt.getFileName().toString(), null);
+                }
+                if (child instanceof MCRFile) {
+                    throw new NotDirectoryException(tgt.toString());
+                }
+                MCRDirectory tgtDir = (MCRDirectory) child;
+                if (tgtDir.hasChildren() && copyOptions.contains(StandardCopyOption.REPLACE_EXISTING)) {
+                    throw new DirectoryNotEmptyException(tgt.toString());
+                }
+                if (copyOptions.contains(StandardCopyOption.COPY_ATTRIBUTES)) {
+                    copyDirectoryAttributes((MCRDirectory) srcNode, tgtDir);
+                }
+            } else {
+                //simply create directory
+                @SuppressWarnings("unused")
+                MCRDirectory tgtDir = tgtParentDir.createDir(tgt.getFileName().toString());
+                if (copyOptions.contains(StandardCopyOption.COPY_ATTRIBUTES)) {
+                    copyDirectoryAttributes((MCRDirectory) srcNode, tgtDir);
+                }
+            }
+        }
+    }
+
+    public static void copyFileAttributes(MCRFile source, MCRFile target)
+        throws IOException {
+        Path targetLocalFile = target.getLocalPath();
+        BasicFileAttributeView targetBasicFileAttributeView = Files.getFileAttributeView(targetLocalFile,
+            BasicFileAttributeView.class);
+        BasicFileAttributes srcAttr = Files.readAttributes(source.getLocalPath(), BasicFileAttributes.class);
+        target.setMD5(source.getMD5());
+        targetBasicFileAttributeView.setTimes(srcAttr.lastModifiedTime(), srcAttr.lastAccessTime(),
+            srcAttr.creationTime());
+    }
+
+    public static void copyDirectoryAttributes(MCRDirectory source, MCRDirectory target)
+        throws IOException {
+        Path tgtLocalPath = target.getLocalPath();
+        Path srcLocalPath = source.getLocalPath();
+        BasicFileAttributes srcAttrs = Files
+            .readAttributes(srcLocalPath, BasicFileAttributes.class);
+        Files.getFileAttributeView(tgtLocalPath, BasicFileAttributeView.class)
+            .setTimes(srcAttrs.lastModifiedTime(), srcAttrs.lastAccessTime(), srcAttrs.creationTime());
+    }
+
+    private void checkCopyOptions(CopyOption[] options) {
+        for (CopyOption option : options) {
+            if (!SUPPORTED_COPY_OPTIONS.contains(option)) {
+                throw new UnsupportedOperationException("Unsupported copy option: " + option);
+            }
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#move(java.nio.file.Path, java.nio.file.Path, java.nio.file.CopyOption[])
+     */
+    @Override
+    public void move(Path source, Path target, CopyOption... options) throws IOException {
+        HashSet<CopyOption> copyOptions = Sets.newHashSet(options);
+        if (copyOptions.contains(StandardCopyOption.ATOMIC_MOVE)) {
+            throw new AtomicMoveNotSupportedException(source.toString(), target.toString(),
+                "ATOMIC_MOVE not supported yet");
+        }
+        if (Files.isDirectory(source)) {
+            MCRPath src = MCRFileSystemUtils.checkPathAbsolute(source);
+            MCRDirectory srcRootDirectory = MCRFileSystemUtils.getFileCollection(src.getOwner());
+            if (srcRootDirectory.hasChildren()) {
+                throw new IOException("Directory is not empty");
+            }
+        }
+        copy(source, target, options);
+        delete(source);
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#isSameFile(java.nio.file.Path, java.nio.file.Path)
+     */
+    @Override
+    public boolean isSameFile(Path path, Path path2) throws IOException {
+        return MCRFileSystemUtils.checkPathAbsolute(path).equals(MCRFileSystemUtils.checkPathAbsolute(path2));
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#isHidden(java.nio.file.Path)
+     */
+    @Override
+    public boolean isHidden(Path path) throws IOException {
+        MCRFileSystemUtils.checkPathAbsolute(path);
+        return false;
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#getFileStore(java.nio.file.Path)
+     */
+    @Override
+    public FileStore getFileStore(Path path) throws IOException {
+        MCRPath mcrPath = MCRFileSystemUtils.checkPathAbsolute(path);
+        MCRStoredNode node = MCRFileSystemUtils.resolvePath(mcrPath);
+        return MCRFileStore.getInstance(node);
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#checkAccess(java.nio.file.Path, java.nio.file.AccessMode[])
+     */
+    @Override
+    public void checkAccess(Path path, AccessMode... modes) throws IOException {
+        MCRPath mcrPath = MCRFileSystemUtils.checkPathAbsolute(path);
+        MCRStoredNode node = MCRFileSystemUtils.resolvePath(mcrPath);
+        if (node == null) {
+            throw new NoSuchFileException(mcrPath.toString());
+        }
+        if (node instanceof MCRDirectory) {
+            checkDirectory((MCRDirectory) node, modes);
+        } else {
+            checkFile((MCRFile) node, modes);
+        }
+    }
+
+    private void checkDirectory(MCRDirectory rootDirectory, AccessMode... modes) throws AccessDeniedException {
+        for (AccessMode mode : modes) {
+            switch (mode) {
+                case READ:
+                case WRITE:
+                case EXECUTE:
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Unsupported AccessMode: " + mode);
+            }
+        }
+    }
+
+    private void checkFile(MCRFile file, AccessMode... modes) throws AccessDeniedException {
+        for (AccessMode mode : modes) {
+            switch (mode) {
+                case READ:
+                case WRITE:
+                    break;
+                case EXECUTE:
+                    throw new AccessDeniedException(MCRFileSystemUtils.toPath(file).toString(), null,
+                        "Unsupported AccessMode: " + mode);
+                default:
+                    throw new UnsupportedOperationException("Unsupported AccessMode: " + mode);
+            }
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#getFileAttributeView(java.nio.file.Path, java.lang.Class, java.nio.file.LinkOption[])
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public <V extends FileAttributeView> V getFileAttributeView(Path path, Class<V> type, LinkOption... options) {
+        MCRPath mcrPath = MCRFileSystemUtils.checkPathAbsolute(path);
+        if (type == null) {
+            throw new NullPointerException();
+        }
+        //must support BasicFileAttributeView
+        if (type == BasicFileAttributeView.class) {
+            return (V) new BasicFileAttributeViewImpl(mcrPath);
+        }
+        if (type == MCRMD5AttributeView.class) {
+            return (V) new MD5FileAttributeViewImpl(mcrPath);
+        }
+        return null;
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#readAttributes(java.nio.file.Path, java.lang.Class, java.nio.file.LinkOption[])
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public <A extends BasicFileAttributes> A readAttributes(Path path, Class<A> type, LinkOption... options)
+        throws IOException {
+        MCRPath mcrPath = MCRFileSystemUtils.checkPathAbsolute(path);
+        MCRStoredNode node = MCRFileSystemUtils.resolvePath(mcrPath);
+        //must support BasicFileAttributeView
+        if (type == BasicFileAttributes.class || type == MCRFileAttributes.class) {
+            return (A) MCRBasicFileAttributeViewImpl.readAttributes(node);
+        }
+        return null;
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#readAttributes(java.nio.file.Path, java.lang.String, java.nio.file.LinkOption[])
+     */
+    @Override
+    public Map<String, Object> readAttributes(Path path, String attributes, LinkOption... options) throws IOException {
+        MCRPath mcrPath = MCRFileSystemUtils.checkPathAbsolute(path);
+        String[] s = splitAttrName(attributes);
+        if (s[0].length() == 0) {
+            throw new IllegalArgumentException(attributes);
+        }
+        BasicFileAttributeViewImpl view = null;
+        switch (s[0]) {
+            case "basic":
+                view = new BasicFileAttributeViewImpl(mcrPath);
+                break;
+            case "md5":
+                view = new MD5FileAttributeViewImpl(mcrPath);
+                break;
+        }
+        if (view == null) {
+            throw new UnsupportedOperationException("View '" + s[0] + "' not available");
+        }
+        return view.getAttributeMap(s[1].split(","));
+    }
+
+    private static String[] splitAttrName(String attribute) {
+        String[] s = new String[2];
+        int pos = attribute.indexOf(':');
+        if (pos == -1) {
+            s[0] = "basic";
+            s[1] = attribute;
+        } else {
+            s[0] = attribute.substring(0, pos++);
+            s[1] = (pos == attribute.length()) ? "" : attribute.substring(pos);
+        }
+        return s;
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileSystemProvider#setAttribute(java.nio.file.Path, java.lang.String, java.lang.Object, java.nio.file.LinkOption[])
+     */
+    @Override
+    public void setAttribute(Path path, String attribute, Object value, LinkOption... options) throws IOException {
+        throw new UnsupportedOperationException("setAttributes is not implemented yet.");
+    }
+
+    public static MCRIFSFileSystem getMCRIFSFileSystem() {
+        return (MCRIFSFileSystem) (FILE_SYSTEM_INSTANCE == null ? MCRAbstractFileSystem.getInstance(SCHEME)
+            : FILE_SYSTEM_INSTANCE);
+    }
+
+    static class BasicFileAttributeViewImpl extends MCRBasicFileAttributeViewImpl {
+        private static final String SIZE_NAME = "size";
+
+        private static final String CREATION_TIME_NAME = "creationTime";
+
+        private static final String LAST_ACCESS_TIME_NAME = "lastAccessTime";
+
+        private static final String LAST_MODIFIED_TIME_NAME = "lastModifiedTime";
+
+        private static final String FILE_KEY_NAME = "fileKey";
+
+        private static final String IS_DIRECTORY_NAME = "isDirectory";
+
+        private static final String IS_REGULAR_FILE_NAME = "isRegularFile";
+
+        private static final String IS_SYMBOLIC_LINK_NAME = "isSymbolicLink";
+
+        private static final String IS_OTHER_NAME = "isOther";
+
+        private static HashSet<String> allowedAttr = Sets.newHashSet("*", SIZE_NAME, CREATION_TIME_NAME,
+            LAST_ACCESS_TIME_NAME, LAST_MODIFIED_TIME_NAME, FILE_KEY_NAME, IS_DIRECTORY_NAME, IS_REGULAR_FILE_NAME,
+            IS_SYMBOLIC_LINK_NAME, IS_OTHER_NAME);
+
+        protected MCRPath path;
+
+        public BasicFileAttributeViewImpl(Path path) {
+            this.path = MCRPath.toMCRPath(path);
+            if (!path.isAbsolute()) {
+                throw new InvalidPathException(path.toString(), "'path' must be absolute.");
+            }
+        }
+
+        @Override
+        protected MCRStoredNode resolveNode() throws IOException {
+            return MCRFileSystemUtils.resolvePath(this.path);
+        }
+
+        public Map<String, Object> getAttributeMap(String... attributes) throws IOException {
+            Set<String> allowed = getAllowedAttributes();
+            boolean copyAll = false;
+            for (String attr : attributes) {
+                if (!allowed.contains(attr)) {
+                    throw new IllegalArgumentException("'" + attr + "' not recognized");
+                }
+                if (attr.equals("*")) {
+                    copyAll = true;
+                }
+            }
+            Set<String> requested = copyAll ? allowed : Sets.newHashSet(attributes);
+            return buildMap(requested, readAttributes());
+        }
+
+        protected Map<String, Object> buildMap(Set<String> requested, MCRFileAttributes<String> attrs) {
+            HashMap<String, Object> map = new HashMap<>();
+            for (String attr : map.keySet()) {
+                switch (attr) {
+                    case SIZE_NAME:
+                        map.put(attr, attrs.size());
+                        break;
+                    case CREATION_TIME_NAME:
+                        map.put(attr, attrs.creationTime());
+                        break;
+                    case LAST_ACCESS_TIME_NAME:
+                        map.put(attr, attrs.lastAccessTime());
+                        break;
+                    case LAST_MODIFIED_TIME_NAME:
+                        map.put(attr, attrs.lastModifiedTime());
+                        break;
+                    case FILE_KEY_NAME:
+                        map.put(attr, attrs.fileKey());
+                        break;
+                    case IS_DIRECTORY_NAME:
+                        map.put(attr, attrs.isDirectory());
+                        break;
+                    case IS_REGULAR_FILE_NAME:
+                        map.put(attr, attrs.isRegularFile());
+                        break;
+                    case IS_SYMBOLIC_LINK_NAME:
+                        map.put(attr, attrs.isSymbolicLink());
+                        break;
+                    case IS_OTHER_NAME:
+                        map.put(attr, attrs.isOther());
+                        break;
+                    default:
+                        //ignored
+                        break;
+                }
+            }
+            return map;
+        }
+
+        public void setAttribute(String name, Object value) throws IOException {
+            Set<String> allowed = getAllowedAttributes();
+            if ("*".equals(name) || !allowed.contains(name)) {
+                throw new IllegalArgumentException("'" + name + "' not recognized");
+            }
+            switch (name) {
+                case CREATION_TIME_NAME:
+                    this.setTimes(null, null, (FileTime) value);
+                    break;
+                case LAST_ACCESS_TIME_NAME:
+                    this.setTimes(null, (FileTime) value, null);
+                    break;
+                case LAST_MODIFIED_TIME_NAME:
+                    this.setTimes((FileTime) value, null, null);
+                    break;
+                case SIZE_NAME:
+                case FILE_KEY_NAME:
+                case IS_DIRECTORY_NAME:
+                case IS_REGULAR_FILE_NAME:
+                case IS_SYMBOLIC_LINK_NAME:
+                case IS_OTHER_NAME:
+                    throw new IllegalArgumentException("'" + name + "' is a read-only attribute.");
+                default:
+                    //ignored
+                    break;
+            }
+
+        }
+
+        protected Set<String> getAllowedAttributes() {
+            return allowedAttr;
+        }
+    }
+
+    private static class MD5FileAttributeViewImpl extends BasicFileAttributeViewImpl implements
+        MCRMD5AttributeView<String> {
+
+        private static String MD5_NAME = "md5";
+
+        private static Set<String> allowedAttr = Sets.union(BasicFileAttributeViewImpl.allowedAttr,
+            Sets.newHashSet(MD5_NAME));
+
+        public MD5FileAttributeViewImpl(Path path) {
+            super(path);
+        }
+
+        @Override
+        public MCRFileAttributes<String> readAllAttributes() throws IOException {
+            return readAttributes();
+        }
+
+        @Override
+        public String name() {
+            return "md5";
+        }
+
+        @Override
+        protected Set<String> getAllowedAttributes() {
+            return allowedAttr;
+        }
+
+        @Override
+        protected Map<String, Object> buildMap(Set<String> requested, MCRFileAttributes<String> attrs) {
+            Map<String, Object> buildMap = super.buildMap(requested, attrs);
+            if (requested.contains(MD5_NAME)) {
+                buildMap.put(MD5_NAME, attrs.md5sum());
+            }
+            return buildMap;
+        }
+
+        @Override
+        public void setAttribute(String name, Object value) throws IOException {
+            if (MD5_NAME.equals(name)) {
+                MCRStoredNode node = resolveNode();
+                if (node instanceof MCRDirectory) {
+                    throw new IOException("Cannot set md5sum on directories: " + path);
+                }
+                ((MCRFile) node).setMD5((String) value);
+            } else {
+                super.setAttribute(name, value);
+            }
+        }
+
+    }
+
+}

--- a/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRFileSystemProvider.java
+++ b/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRFileSystemProvider.java
@@ -203,7 +203,7 @@ public class MCRFileSystemProvider extends FileSystemProvider {
         MCRPath mcrPath = MCRFileSystemUtils.checkPathAbsolute(dir);
         MCRStoredNode node = MCRFileSystemUtils.resolvePath(mcrPath);
         if (node instanceof MCRDirectory) {
-            return new MCRDirectoryStream((MCRDirectory) node, mcrPath);
+            return MCRDirectoryStream.getInstance((MCRDirectory) node, mcrPath);
         }
         throw new NotDirectoryException(dir.toString());
     }

--- a/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRFileSystemUtils.java
+++ b/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRFileSystemUtils.java
@@ -1,0 +1,284 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.datamodel.niofs.ifs2;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.ProviderMismatchException;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.common.config.MCRConfigurationException;
+import org.mycore.datamodel.ifs2.MCRDirectory;
+import org.mycore.datamodel.ifs2.MCRFile;
+import org.mycore.datamodel.ifs2.MCRFileCollection;
+import org.mycore.datamodel.ifs2.MCRFileStore;
+import org.mycore.datamodel.ifs2.MCRStoreManager;
+import org.mycore.datamodel.ifs2.MCRStoredNode;
+import org.mycore.datamodel.metadata.MCRObjectID;
+import org.mycore.datamodel.niofs.MCRAbstractFileSystem;
+import org.mycore.datamodel.niofs.MCRPath;
+
+/**
+ * @author Thomas Scheffler
+ *
+ */
+abstract class MCRFileSystemUtils {
+
+    private static final Logger LOGGER = LogManager.getLogger(MCRFileSystemUtils.class);
+
+    private static final String DEFAULT_CONFIG_PREFIX = "MCR.IFS.ContentStore.IFS2."; //todo: rename
+
+    public static final String STORE_ID_PREFIX = "IFS2_";
+
+    private static String getBaseDir() {
+        return MCRConfiguration2.getStringOrThrow(DEFAULT_CONFIG_PREFIX + "BaseDir");
+    }
+
+    private static String getDefaultSlotLayout() {
+        return MCRConfiguration2.getString(DEFAULT_CONFIG_PREFIX + "SlotLayout")
+            .orElseGet(() -> {
+                String baseID = "a_a";
+                String formatID = MCRObjectID.formatID(baseID, 1);
+                int patternLength = formatID.length() - baseID.length() - "_".length();
+                return patternLength - 4 + "-2-2";
+            });
+    }
+
+    static MCRFileCollection getFileCollection(String owner) throws IOException {
+        MCRObjectID derId = MCRObjectID.getInstance(owner);
+        MCRFileStore fileStore = getStore(derId.getBase());
+        MCRFileCollection fileCollection = fileStore
+            .retrieve(derId.getNumberAsInteger());
+        if (fileCollection == null) {
+            throw new NoSuchFileException(null, null,
+                "File collection " + owner + " is not available here: " + fileStore.getBaseDirectory());
+        }
+        return fileCollection;
+    }
+
+    static MCRFileStore getStore(String base) {
+        String storeBaseDir = getBaseDir();
+
+        String sid = STORE_ID_PREFIX + base;
+        storeBaseDir += File.separatorChar + base.replace("_", File.separator);
+
+        MCRFileStore store = MCRStoreManager.getStore(sid);
+        if (store == null) {
+            synchronized (MCRStoreManager.class) {
+                store = MCRStoreManager.getStore(sid);
+                if (store == null) {
+                    store = createStore(sid, storeBaseDir, base);
+                }
+            }
+        }
+        return store;
+    }
+
+    private static MCRFileStore createStore(String sid, String storeBaseDir, String base) {
+        try {
+            configureStore(sid, storeBaseDir, base);
+            return MCRStoreManager.createStore(sid, MCRFileStore.class);
+        } catch (Exception ex) {
+            String msg = "Could not create IFS2 file store with ID " + sid;
+            throw new MCRConfigurationException(msg, ex);
+        }
+    }
+
+    private static void configureStore(String sid, String storeBaseDir, String base) {
+        String storeConfigPrefix = "MCR.IFS2.Store." + sid + ".";
+        configureIfNotSet(storeConfigPrefix + "Class", MCRFileStore.class.getName());
+        configureIfNotSet(storeConfigPrefix + "BaseDir", storeBaseDir);
+        configureIfNotSet(storeConfigPrefix + "Prefix", base + "_");
+        configureIfNotSet(storeConfigPrefix + "SlotLayout", getDefaultSlotLayout());
+    }
+
+    private static void configureIfNotSet(String property, String value) {
+        MCRConfiguration2.getString(property)
+            .ifPresentOrElse(s -> {
+                //if set, do nothing
+            }, () -> {
+                MCRConfiguration2.set(property, value);
+                LOGGER.info("Configured {}={}", property, value);
+            });
+    }
+
+    static MCRPath checkPathAbsolute(Path path) {
+        MCRPath mcrPath = MCRPath.toMCRPath(path);
+        if (!(Objects.requireNonNull(mcrPath.getFileSystem(), "'path' requires a associated filesystem.")
+            .provider() instanceof MCRFileSystemProvider)) {
+            throw new ProviderMismatchException("Path does not match to this provider: " + path);
+        }
+        if (!mcrPath.isAbsolute()) {
+            throw new InvalidPathException(mcrPath.toString(), "'path' must be absolute.");
+        }
+        return mcrPath;
+    }
+
+    static String getOwnerID(MCRStoredNode node) {
+        MCRFileCollection collection = node.getRoot();
+        int intValue = collection.getID();
+        String storeId = collection.getStore().getID();
+        String baseId = storeId.substring(STORE_ID_PREFIX.length());
+        return MCRObjectID.formatID(baseId, intValue);
+    }
+
+    static MCRPath toPath(MCRStoredNode node) {
+        String ownerID = getOwnerID(node);
+        String path = node.getPath();
+        return MCRAbstractFileSystem.getPath(ownerID, path, MCRFileSystemProvider.getMCRIFSFileSystem());
+    }
+
+    static MCRFile getMCRFile(MCRPath ifsPath, boolean create, boolean createNew) throws IOException {
+        if (!ifsPath.isAbsolute()) {
+            throw new IllegalArgumentException("'path' needs to be absolute.");
+        }
+        MCRFile file;
+        MCRDirectory root = null;
+        boolean rootCreated = false;
+        try {
+            try {
+                root = getFileCollection(ifsPath.getOwner());
+            } catch (NoSuchFileException e) {
+                if (create || createNew) {
+                    MCRObjectID derId = MCRObjectID.getInstance(ifsPath.getOwner());
+                    root = getStore(derId.getBase()).create(derId.getNumberAsInteger());
+                    rootCreated = true;
+                } else {
+                    throw e;
+                }
+            }
+            MCRPath relativePath = toPath(root).relativize(ifsPath);
+            file = getMCRFile(root, relativePath, create, createNew);
+        } catch (Exception e) {
+            if (rootCreated) {
+                LOGGER.error("Exception while getting MCRFile {}. Removing created filesystem nodes.", ifsPath);
+                try {
+                    root.delete();
+                } catch (Exception de) {
+                    LOGGER.fatal("Error while deleting file system node: {}", root.getName(), de);
+                }
+            }
+            throw e;
+        }
+        return file;
+    }
+
+    static MCRFile getMCRFile(MCRDirectory baseDir, MCRPath relativePath, boolean create, boolean createNew)
+        throws IOException {
+        MCRPath ifsPath = relativePath;
+        if (relativePath.isAbsolute()) {
+            if (getOwnerID(baseDir).equals(relativePath.getOwner())) {
+                ifsPath = toPath(baseDir).relativize(relativePath);
+            } else
+                throw new IOException(relativePath + " is absolute does not fit to " + toPath(baseDir));
+        }
+        Deque<MCRStoredNode> created = new LinkedList<>();
+        MCRFile file;
+        try {
+            file = (MCRFile) baseDir.getNodeByPath(ifsPath.toString());
+            if (file != null && createNew) {
+                throw new FileAlreadyExistsException(toPath(baseDir).resolve(ifsPath).toString());
+            }
+            if (file == null & (create || createNew)) {
+                Path normalized = ifsPath.normalize();
+                MCRDirectory parent = baseDir;
+                int nameCount = normalized.getNameCount();
+                int directoryCount = nameCount - 1;
+                int i = 0;
+                while (i < directoryCount) {
+                    String curName = normalized.getName(i).toString();
+                    MCRDirectory curDir = (MCRDirectory) parent.getChild(curName);
+                    if (curDir == null) {
+                        curDir = parent.createDir(curName);
+                        created.addFirst(curDir);
+                    }
+                    i++;
+                    parent = curDir;
+                }
+                String fileName = normalized.getFileName().toString();
+                file = parent.createFile(fileName);
+                created.addFirst(file);
+            }
+        } catch (Exception e) {
+            if (create || createNew) {
+                LOGGER.error("Exception while getting MCRFile {}. Removing created filesystem nodes.", ifsPath);
+                while (created.peekFirst() != null) {
+                    MCRStoredNode node = created.pollFirst();
+                    try {
+                        node.delete();
+                    } catch (Exception de) {
+                        LOGGER.fatal("Error while deleting file system node: {}", node.getName(), de);
+                    }
+                }
+            }
+            throw e;
+        }
+        return file;
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T extends MCRStoredNode> T resolvePath(MCRPath path) throws IOException {
+        if (path.getNameCount() == 0) {
+            return (T) getFileCollection(path.getOwner());
+        }
+        //recursive call
+        String fileOrDir = path.getFileName().toString();
+        MCRDirectory parentDir = doResolveParent(path.getParent())
+            .map(MCRDirectory.class::cast)
+            .orElseThrow(() -> new NoSuchFileException(path.getParent().toString(), fileOrDir,
+                "parent directory does not exist"));
+
+        return (T) Optional.ofNullable(parentDir.getChild(fileOrDir))
+            .map(MCRStoredNode.class::cast)
+            .orElseThrow(
+                () -> new NoSuchFileException(path.getParent().toString(), fileOrDir, "file does not exist"));
+
+    }
+
+    private static Optional<MCRDirectory> doResolveParent(MCRPath parent) {
+        if (parent.getNameCount() == 0) {
+            MCRObjectID derId = MCRObjectID.getInstance(parent.getOwner());
+            return Optional.ofNullable(getStore(derId.getBase()))
+                .map(s -> {
+                    try {
+                        return s.retrieve(derId.getNumberAsInteger());
+                    } catch (IOException e) {
+                        LOGGER.warn("Exception while retrieving file collection " + derId, e);
+                        return null;
+                    }
+                });
+        }
+        //recursive call
+        String dirName = parent.getFileName().toString();
+        return doResolveParent(parent.getParent())
+            .map(p -> p.getChild(dirName))
+            .map(MCRDirectory.class::cast);
+    }
+
+}

--- a/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRFileTypeDetector.java
+++ b/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRFileTypeDetector.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.datamodel.niofs.ifs2;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.spi.FileTypeDetector;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.mycore.datamodel.ifs2.MCRDirectory;
+import org.mycore.datamodel.ifs2.MCRFile;
+import org.mycore.datamodel.ifs2.MCRStoredNode;
+import org.mycore.datamodel.niofs.MCRPath;
+
+/**
+ * @author Thomas Scheffler (yagee)
+ *
+ */
+public class MCRFileTypeDetector extends FileTypeDetector {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    /* (non-Javadoc)
+     * @see java.nio.file.spi.FileTypeDetector#probeContentType(java.nio.file.Path)
+     */
+    @Override
+    public String probeContentType(Path path) throws IOException {
+        LOGGER.debug(() -> "Probing content type of: " + path);
+        if (!(path.getFileSystem() instanceof MCRIFSFileSystem)) {
+            return null;
+        }
+        MCRStoredNode resolvePath = MCRFileSystemUtils.resolvePath(MCRPath.toMCRPath(path));
+        if (resolvePath instanceof MCRDirectory) {
+            throw new NoSuchFileException(path.toString());
+        }
+        MCRFile file = (MCRFile) resolvePath;
+        String mimeType = Files.probeContentType(file.getLocalPath());
+        LOGGER.debug(() -> "IFS mime-type: " + mimeType);
+        return mimeType;
+    }
+}

--- a/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRIFSFileSystem.java
+++ b/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/MCRIFSFileSystem.java
@@ -1,0 +1,140 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.datamodel.niofs.ifs2;
+
+import java.io.IOException;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystemException;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Objects;
+
+import org.apache.logging.log4j.LogManager;
+import org.mycore.datamodel.ifs2.MCRDirectory;
+import org.mycore.datamodel.ifs2.MCRStore;
+import org.mycore.datamodel.ifs2.MCRStoreCenter;
+import org.mycore.datamodel.metadata.MCRObjectID;
+import org.mycore.datamodel.niofs.MCRAbstractFileSystem;
+import org.mycore.datamodel.niofs.MCRPath;
+
+/**
+ * @author Thomas Scheffler (yagee)
+ *
+ */
+public class MCRIFSFileSystem extends MCRAbstractFileSystem {
+
+    private MCRFileSystemProvider provider;
+
+    MCRIFSFileSystem(MCRFileSystemProvider provider) {
+        super();
+        this.provider = provider;
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.FileSystem#provider()
+     */
+    @Override
+    public MCRFileSystemProvider provider() {
+        return provider;
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.FileSystem#getRootDirectories()
+     */
+    @Override
+    public Iterable<Path> getRootDirectories() {
+        return MCRStoreCenter.instance().getCurrentStores(org.mycore.datamodel.ifs2.MCRFileStore.class)
+            .filter(s -> s.getID().startsWith(MCRFileSystemUtils.STORE_ID_PREFIX))
+            .sorted(Comparator.comparing(MCRStore::getID))
+            .flatMap(s -> s.getStoredIDs()
+                .mapToObj(
+                    i -> MCRObjectID.formatID(s.getID().substring(MCRFileSystemUtils.STORE_ID_PREFIX.length()), i)))
+            .map(owner -> MCRAbstractFileSystem.getPath(owner, "/", this))
+            .map(Path.class::cast)::iterator;
+    }
+
+    /* (non-Javadoc)
+     * @see java.nio.file.FileSystem#getFileStores()
+     */
+    @Override
+    public Iterable<FileStore> getFileStores() {
+        return MCRStoreCenter.instance().getCurrentStores(org.mycore.datamodel.ifs2.MCRFileStore.class)
+            .filter(s -> s.getID().startsWith(MCRFileSystemUtils.STORE_ID_PREFIX))
+            .sorted(Comparator.comparing(MCRStore::getID))
+            .map(MCRStore::getID)
+            .distinct()
+            .map(storeId -> {
+                try {
+                    return MCRFileStore.getInstance(storeId);
+                } catch (IOException e) {
+                    LogManager.getLogger().error("Error while iterating FileStores.", e);
+                    return null;
+                }
+            })
+            .filter(Objects::nonNull)
+            .map(FileStore.class::cast)::iterator;
+    }
+
+    @Override
+    public void createRoot(String owner) throws FileSystemException {
+        MCRObjectID derId = MCRObjectID.getInstance(owner);
+        org.mycore.datamodel.ifs2.MCRFileStore fileStore = MCRFileSystemUtils.getStore(derId.getBase());
+        MCRPath rootPath = getPath(owner, "", this);
+        try {
+            if (fileStore.retrieve(derId.getNumberAsInteger()) != null) {
+                throw new FileAlreadyExistsException(rootPath.toString());
+            }
+            try {
+                MCRDirectory rootDirectory = fileStore.create(derId.getNumberAsInteger());
+            } catch (RuntimeException e) {
+                LogManager.getLogger(getClass()).warn("Catched RuntimeException while creating new root directory.", e);
+                throw new FileSystemException(rootPath.toString(), null, e.getMessage());
+            }
+        } catch (FileSystemException e) {
+            throw e;
+        } catch (IOException e) {
+            throw new FileSystemException(rootPath.toString(), null, e.getMessage());
+        }
+        LogManager.getLogger(getClass()).info("Created root directory: {}", rootPath);
+    }
+
+    @Override
+    public void removeRoot(String owner) throws FileSystemException {
+        MCRPath rootPath = getPath(owner, "", this);
+        MCRDirectory rootDirectory = null;
+        try {
+            rootDirectory = MCRFileSystemUtils.getFileCollection(owner);
+            if (rootDirectory.hasChildren()) {
+                throw new DirectoryNotEmptyException(rootPath.toString());
+            }
+            rootDirectory.delete();
+        } catch (FileSystemException e) {
+            throw e;
+        } catch (IOException e) {
+            throw new FileSystemException(rootPath.toString(), null, e.getMessage());
+        } catch (RuntimeException e) {
+            LogManager.getLogger(getClass()).warn("Catched RuntimeException while removing root directory.", e);
+            throw new FileSystemException(rootPath.toString(), null, e.getMessage());
+        }
+        LogManager.getLogger(getClass()).info("Removed root directory: {}", rootPath);
+    }
+
+}

--- a/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/package-info.java
+++ b/mycore-ifs/src/main/java/org/mycore/datamodel/niofs/ifs2/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Contains classes to build a {@link java.nio.file.FileSystem} on top of {@link org.mycore.datamodel.ifs2.MCRStoredNode}.
+ * @author Thomas Scheffler (yagee)
+ *
+ */
+package org.mycore.datamodel.niofs.ifs2;

--- a/mycore-ifs/src/main/java/org/mycore/frontend/cli/MCRIFSCommands.java
+++ b/mycore-ifs/src/main/java/org/mycore/frontend/cli/MCRIFSCommands.java
@@ -885,14 +885,7 @@ public class MCRIFSCommands {
                 .filter(Objects::nonNull)
                 .forEach(e -> {
                     if (!e.getKey().equals(e.getValue().getMD5())) {
-                        String path = null;
-                        try {
-                            path = e.getValue().getLocalFile().toPath().toAbsolutePath().toString();
-                        } catch (IOException e1) {
-                            LOGGER.warn("Could not get local file " + e.getValue().getName(), e);
-                            result.set(false);
-                            return;
-                        }
+                        String path = e.getValue().getLocalPath().toAbsolutePath().toString();
                         LOGGER.info("Update MD5 sum for file {} to {}",
                             path, e.getKey());
                         try {
@@ -942,14 +935,7 @@ public class MCRIFSCommands {
             .filter(Objects::nonNull)
             .forEach(e -> {
                 if (!e.getKey().equals(e.getValue().getMD5())) {
-                    String path = null;
-                    try {
-                        path = e.getValue().getLocalFile().toPath().toAbsolutePath().toString();
-                    } catch (IOException e1) {
-                        LOGGER.warn("Could not get local file.", e);
-                        result.set(false);
-                        path = e.getValue().getName();
-                    }
+                    String path = e.getValue().getLocalPath().toAbsolutePath().toString();
                     LOGGER.error("MD5 sum mismatch for file {}. DB:{}, mcrdata.xml:{}",
                         path, e.getKey(), e.getValue().getMD5());
                     result.set(false);

--- a/mycore-ifs/src/main/resources/META-INF/services/java.nio.file.spi.FileSystemProvider
+++ b/mycore-ifs/src/main/resources/META-INF/services/java.nio.file.spi.FileSystemProvider
@@ -1,1 +1,2 @@
 org.mycore.datamodel.niofs.ifs1.MCRFileSystemProvider
+org.mycore.datamodel.niofs.ifs2.MCRFileSystemProvider

--- a/mycore-ifs/src/main/resources/META-INF/services/java.nio.file.spi.FileTypeDetector
+++ b/mycore-ifs/src/main/resources/META-INF/services/java.nio.file.spi.FileTypeDetector
@@ -1,1 +1,2 @@
 org.mycore.datamodel.niofs.ifs1.MCRFileTypeDetector
+org.mycore.datamodel.niofs.ifs2.MCRFileTypeDetector

--- a/mycore-media/src/main/java/org/mycore/media/services/MCRPdfThumbnailGenerator.java
+++ b/mycore-media/src/main/java/org/mycore/media/services/MCRPdfThumbnailGenerator.java
@@ -1,9 +1,5 @@
 package org.mycore.media.services;
 
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.rendering.PDFRenderer;
-import org.mycore.datamodel.niofs.MCRPath;
-
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -11,6 +7,10 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.Optional;
 import java.util.regex.Pattern;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.mycore.datamodel.niofs.MCRPath;
 
 public class MCRPdfThumbnailGenerator implements MCRThumbnailGenerator {
 
@@ -23,8 +23,7 @@ public class MCRPdfThumbnailGenerator implements MCRThumbnailGenerator {
 
     @Override
     public Optional<BufferedImage> getThumbnail(MCRPath path, int size) throws IOException {
-        InputStream fileIS = Files.newInputStream(path.toPhysicalPath());
-        try (PDDocument pdf = PDDocument.load(fileIS)) {
+        try (InputStream fileIS = Files.newInputStream(path); PDDocument pdf = PDDocument.load(fileIS)) {
             float pdfWidth =  pdf.getPage(0).getCropBox().getWidth();
             float pdfHeight =  pdf.getPage(0).getCropBox().getHeight();
             final int newWidth = pdfWidth > pdfHeight ? (int) Math.ceil(size * pdfWidth / pdfHeight) : size;


### PR DESCRIPTION
use `MCR.NIO.DefaultScheme=ifs2` to activate

contains small optimizations (with API changes) to IFS2 classes

[Link to jira](https://mycore.atlassian.net/browse/MCR-2025).
