### PR TITLE
MCR-1978 Validate Session IP with Netmask

### DIFF
--- a/mycore-base/src/main/resources/config/mycore.properties
+++ b/mycore-base/src/main/resources/config/mycore.properties
@@ -418,3 +418,19 @@ MCR.Startup.Class=org.mycore.backend.jpa.MCRJPABootstrapper,org.mycore.datamodel
 MCR.Website.ReadAccessVerification=true
 
 MCR.URIResolver.xslIncludes.MyCoReWebPage=classificationBrowser.xsl
+
+##############################################################################
+# Session-Validation NetMasks
+##############################################################################
+
+# MyCoRe assumes that any change in IPs between 2 accesses is a session
+# hijacking attempt and invalidates said session.
+# To add some leniency to the IP validation, for example in an environment
+# where IPs are frequently reassigned from a random pool, you can
+# change the netmasks used to compare both IPs here.
+# These default values mean that only the exact same IP will be permitted.
+# (essentially no masking)
+
+# MCR.Servlet.Session.NetMask.IPv4=255.255.255.255
+# MCR.Servlet.Session.NetMask.IPv6=FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF
+


### PR DESCRIPTION
Validating the session's last IP against the new IP with configurable netmasks
"MCR.Servlet.Session.NetMask.IPv4" and "MCR.Servlet.Session.NetMask.IPv6".

[Link to jira](https://mycore.atlassian.net/browse/MCR-).
