### PR TITLE
MCR-1978 use static initializer to init static variables

### DIFF
--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRServlet.java
@@ -109,12 +109,7 @@ public class MCRServlet extends HttpServlet {
         return LAYOUT_SERVICE;
     }
 
-    @Override
-    public void init() throws ServletException {
-        super.init();
-        if (LAYOUT_SERVICE == null) {
-            LAYOUT_SERVICE = MCRLayoutService.instance();
-        }
+    static {
         try {
             SESSION_NETMASK_IPV4 = InetAddress.getByName(SESSION_NETMASK_IPV4_STRING).getAddress();
         } catch (UnknownHostException e) {
@@ -126,6 +121,14 @@ public class MCRServlet extends HttpServlet {
         } catch (UnknownHostException e) {
             throw new MCRConfigurationException("MCR.Servlet.Session.NetMask.IPv6 is not a correct IPv6 network mask.",
                 e);
+        }
+    }
+
+    @Override
+    public void init() throws ServletException {
+        super.init();
+        if (LAYOUT_SERVICE == null) {
+            LAYOUT_SERVICE = MCRLayoutService.instance();
         }
     }
 


### PR DESCRIPTION
Need to initialize static variables with static initializer, otherwise MCRServlet#getSession and other static methods throw NPE.
[Link to jira](https://mycore.atlassian.net/browse/MCR-1978).
