### PR TITLE
MCR-2194 Decouple Solr response header

### DIFF
--- a/mycore-solr/src/main/java/org/mycore/solr/proxy/MCRSolrProxyServlet.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/proxy/MCRSolrProxyServlet.java
@@ -76,11 +76,11 @@ import org.xml.sax.SAXException;
  * 
  * With the following configuration properties 
  * you can manipulate the response header. The entries will be replace the attributes of the incomming header.
- * If the new attribute text is empty, it will be remove the attribute.<br/><br/>
+ * If the new attribute text is empty, it will be remove the attribute.<br></br><br></br>
  * MCR.Solr.HTTPResponseHeader.{response_header_attribute_name}={new_response_header_attribute}
- * MCR.Solr.HTTPResponseHeader....=<br/><br/>
+ * MCR.Solr.HTTPResponseHeader....=<br></br><br></br>
  * 
- * You can set the maximum of connections to the SOLR server with the property<br/><br/>
+ * You can set the maximum of connections to the SOLR server with the property<br></br><br></br>
  * MCR.Solr.SelectProxy.MaxConnections={number}
  */
 public class MCRSolrProxyServlet extends MCRServlet {

--- a/mycore-solr/src/main/java/org/mycore/solr/proxy/MCRSolrProxyServlet.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/proxy/MCRSolrProxyServlet.java
@@ -71,6 +71,18 @@ import org.mycore.solr.MCRSolrClientFactory;
 import org.mycore.solr.MCRSolrConstants;
 import org.xml.sax.SAXException;
 
+/**
+ * This class implements a proxy for access to the SOLR backend.<br/><br/>
+ * 
+ * With the following configuration properties 
+ * you can manipulate the response header. The entries will be replace the attributes of the incomming header.
+ * If the new attribute text is empty, it will be remove the attribute.<br/><br/>
+ * MCR.Solr.HTTPResponseHeader.{response_header_attribute_name}={new_response_header_attribute}
+ * MCR.Solr.HTTPResponseHeader....=<br/><br/>
+ * 
+ * You can set the maximum of connections to the SOLR server with the property<br/><br/>
+ * MCR.Solr.SelectProxy.MaxConnections={number}
+ */
 public class MCRSolrProxyServlet extends MCRServlet {
 
     static final Logger LOGGER = LogManager.getLogger(MCRSolrProxyServlet.class);
@@ -96,6 +108,9 @@ public class MCRSolrProxyServlet extends MCRServlet {
     private static int MAX_CONNECTIONS = MCRConfiguration2
         .getOrThrow(SOLR_CONFIG_PREFIX + "SelectProxy.MaxConnections", Integer::parseInt);
 
+    private static Map<String,String> NEW_HTTP_RESPONSE_HEADER = MCRConfiguration2
+        .getSubPropertiesMap(SOLR_CONFIG_PREFIX + "HTTPResponseHeader.");
+    
     private CloseableHttpClient httpClient;
 
     private MCRIdleConnectionMonitorThread idleConnectionMonitorThread;
@@ -216,6 +231,15 @@ public class MCRSolrProxyServlet extends MCRServlet {
 
             // set all headers
             for (Header header : response.getAllHeaders()) {
+                LOGGER.debug("SOLR response header: " + header.getName() + " - " +header.getValue());
+                String headerName = header.getName();
+                if (NEW_HTTP_RESPONSE_HEADER.containsKey(headerName)) {
+                    String headerValue = NEW_HTTP_RESPONSE_HEADER.get(headerName);
+                    if (headerValue != null && headerValue.length() > 0) {
+                        resp.setHeader(headerName, headerValue);
+                    }
+                    continue;
+                }
                 if (!HTTP.TRANSFER_ENCODING.equals(header.getName())) {
                     resp.setHeader(header.getName(), header.getValue());
                 }

--- a/mycore-solr/src/main/java/org/mycore/solr/proxy/MCRSolrProxyServlet.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/proxy/MCRSolrProxyServlet.java
@@ -72,15 +72,15 @@ import org.mycore.solr.MCRSolrConstants;
 import org.xml.sax.SAXException;
 
 /**
- * This class implements a proxy for access to the SOLR backend.<br/><br/>
+ * This class implements a proxy for access to the SOLR backend.<br><br>
  * 
  * With the following configuration properties 
  * you can manipulate the response header. The entries will be replace the attributes of the incomming header.
- * If the new attribute text is empty, it will be remove the attribute.<br></br><br></br>
+ * If the new attribute text is empty, it will be remove the attribute.<br><br>
  * MCR.Solr.HTTPResponseHeader.{response_header_attribute_name}={new_response_header_attribute}
- * MCR.Solr.HTTPResponseHeader....=<br></br><br></br>
+ * MCR.Solr.HTTPResponseHeader....=<br><br>
  * 
- * You can set the maximum of connections to the SOLR server with the property<br></br><br></br>
+ * You can set the maximum of connections to the SOLR server with the property<br><br>
  * MCR.Solr.SelectProxy.MaxConnections={number}
  */
 public class MCRSolrProxyServlet extends MCRServlet {

--- a/mycore-solr/src/main/java/org/mycore/solr/proxy/MCRSolrProxyServlet.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/proxy/MCRSolrProxyServlet.java
@@ -231,16 +231,14 @@ public class MCRSolrProxyServlet extends MCRServlet {
 
             // set all headers
             for (Header header : response.getAllHeaders()) {
-                LOGGER.debug("SOLR response header: " + header.getName() + " - " +header.getValue());
+                LOGGER.debug("SOLR response header: {} - {}", header.getName(), header.getValue());
                 String headerName = header.getName();
                 if (NEW_HTTP_RESPONSE_HEADER.containsKey(headerName)) {
                     String headerValue = NEW_HTTP_RESPONSE_HEADER.get(headerName);
                     if (headerValue != null && headerValue.length() > 0) {
                         resp.setHeader(headerName, headerValue);
                     }
-                    continue;
-                }
-                if (!HTTP.TRANSFER_ENCODING.equals(header.getName())) {
+                } else {
                     resp.setHeader(header.getName(), header.getValue());
                 }
             }

--- a/mycore-solr/src/main/resources/components/solr/config/mycore.properties
+++ b/mycore-solr/src/main/resources/components/solr/config/mycore.properties
@@ -82,3 +82,6 @@ MCR.Solr.NestedDocuments=true
 # delay SOLR indexing (in ms) to avoid multiple indexing through multiple save events
 MCR.Solr.DelayIndexing_inMS=2000
 
+# changed SOLR response header attributes of MCRSolrProxyServlet
+MCR.Solr.HTTPResponseHeader.Transfer-Encoding=
+MCR.Solr.HTTPResponseHeader.Content-Security-Policy=default-src 'none'; base-uri 'none'; connect-src 'self'; form-action 'self'; font-src 'self'; frame-ancestors 'none'; img-src 'self'; media-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; worker-src 'self';


### PR DESCRIPTION
A property list can be used to replace / delete  SOLR response header
attributes (see javadoc)

[Link to jira](https://mycore.atlassian.net/browse/MCR-).
