### PR TITLE
MCR-2235 add searchfield derivateType

### DIFF
--- a/mycore-solr/src/main/resources/components/solr/config/solr/main/solr-schema.json
+++ b/mycore-solr/src/main/resources/components/solr/config/solr/main/solr-schema.json
@@ -368,6 +368,12 @@
   },
   {
     "add-field": {
+      "name": "derivateType",
+      "type": "string"
+    }
+  },
+  {
+    "add-field": {
       "name": "derivateID",
       "type": "string"
     }

--- a/mycore-solr/src/main/resources/components/solr/config/solr/main/solr-schema.json
+++ b/mycore-solr/src/main/resources/components/solr/config/solr/main/solr-schema.json
@@ -369,7 +369,8 @@
   {
     "add-field": {
       "name": "derivateType",
-      "type": "string"
+      "type": "string",
+      "multiValued": true
     }
   },
   {

--- a/mycore-solr/src/main/resources/xsl/solr-basetemplate.xsl
+++ b/mycore-solr/src/main/resources/xsl/solr-basetemplate.xsl
@@ -57,6 +57,11 @@
     <field name="derivateOrder">
       <xsl:value-of select="@order"/>
     </field>
+    <xsl:for-each select="derivate/classifications/classification[@classid='derivate_types'][1]/@categid">
+      <field name="derivateType">
+        <xsl:value-of select="." />
+      </field>
+    </xsl:for-each>
     <xsl:for-each select="derivate/titles/title">
       <field name="derivateTitle">
         <xsl:value-of select="text()"/>

--- a/mycore-solr/src/main/resources/xsl/solr-basetemplate.xsl
+++ b/mycore-solr/src/main/resources/xsl/solr-basetemplate.xsl
@@ -57,9 +57,9 @@
     <field name="derivateOrder">
       <xsl:value-of select="@order"/>
     </field>
-    <xsl:for-each select="derivate/classifications/classification[@classid='derivate_types'][1]/@categid">
+    <xsl:for-each select="derivate/classifications/classification[@classid='derivate_types']">
       <field name="derivateType">
-        <xsl:value-of select="." />
+        <xsl:value-of select="./@categid" />
       </field>
     </xsl:for-each>
     <xsl:for-each select="derivate/titles/title">


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-2235).

This implementation assumes, that there is only ONE derivate_type for each derivate.
If we agree on this - please merge.
If multiple derivate_types shall be allowed, the code needs to be adjusted:
The field needs to be set to multivalued and xpath modified.