### PR TITLE
MCR-2254 fix IllegalArgumentException on Windows

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/content/transformer/MCRXSLTransformer.java
+++ b/mycore-base/src/main/java/org/mycore/common/content/transformer/MCRXSLTransformer.java
@@ -270,6 +270,8 @@ public class MCRXSLTransformer extends MCRParameterizedTransformer {
         if (fileName == null) {
             return null;
         }
+        //MCR-2254, ':' in fileName causes problems on Windows
+        fileName = fileName.replace(':', '_');
         return FilenameUtils.removeExtension(fileName) + "." + getFileExtension();
     }
 


### PR DESCRIPTION
NTFS ADS separator (’:’) in file name is forbidden

[Link to jira](https://mycore.atlassian.net/browse/MCR-2254).
