### PR TITLE
MCR-2260 fix problem with cleaning SOLR configuration

### DIFF
--- a/mycore-solr/src/main/java/org/mycore/solr/commands/MCRSolrCommands.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/commands/MCRSolrCommands.java
@@ -131,8 +131,8 @@ public class MCRSolrCommands extends MCRAbstractCommands {
             + "by using the Solr schema api for core with the id {0}",
         order = 70)
     public static void reloadSolrConfiguration(String configType, String coreID) {
-        MCRSolrConfigReloader.cleanConfig(configType, coreID);
-        MCRSolrSchemaReloader.cleanSchema(configType, coreID);
+        MCRSolrConfigReloader.reset(configType, coreID);
+        MCRSolrSchemaReloader.reset(configType, coreID);
         MCRSolrSchemaReloader.processSchemaFiles(configType, coreID);
         MCRSolrConfigReloader.processConfigFiles(configType, coreID);
     }

--- a/mycore-solr/src/main/java/org/mycore/solr/commands/MCRSolrCommands.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/commands/MCRSolrCommands.java
@@ -131,7 +131,8 @@ public class MCRSolrCommands extends MCRAbstractCommands {
             + "by using the Solr schema api for core with the id {0}",
         order = 70)
     public static void reloadSolrConfiguration(String configType, String coreID) {
-        MCRSolrSchemaReloader.clearSchema(configType, coreID);
+        MCRSolrConfigReloader.cleanConfig(configType, coreID);
+        MCRSolrSchemaReloader.cleanSchema(configType, coreID);
         MCRSolrSchemaReloader.processSchemaFiles(configType, coreID);
         MCRSolrConfigReloader.processConfigFiles(configType, coreID);
     }

--- a/mycore-solr/src/main/java/org/mycore/solr/schema/MCRSolrConfigReloader.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/schema/MCRSolrConfigReloader.java
@@ -111,15 +111,18 @@ public class MCRSolrConfigReloader {
                 String ignoreListConfiguration = MCRConfiguration2
                     .getString("MCR.Solr.ObserverConfigTypes." + observedType + ".toClean").orElse("");
                 List<String> cleanList = Arrays.asList(ignoreListConfiguration.split("\\s*,\\s*"));
-                if (cleanList.size() == 0) {
+                if (cleanList.isEmpty()) {
                     continue;
                 }
                 JsonObject observedConfig = configPart.getAsJsonObject(observedType);
+                if (observedConfig == null) {
+                    continue;
+                }
                 Set<Map.Entry<String, JsonElement>> entries = observedConfig.entrySet();
                 for (Map.Entry<String, JsonElement> entry : entries) {
                     if (cleanList.contains(entry.getKey())) {
                         final JsonObject cleanJsonObject = new JsonObject();
-                        final String commandName = "delete-" + observedType.toLowerCase(Locale.ROOT);
+                        final String commandName = "delete-" + observedType.toLowerCase();
                         if (isKnownSolrConfigCommmand(commandName)) {
                             cleanJsonObject.addProperty(commandName, entry.getKey());
                             executeSolrCommand(coreURL, cleanJsonObject.toString());

--- a/mycore-solr/src/main/java/org/mycore/solr/schema/MCRSolrConfigReloader.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/schema/MCRSolrConfigReloader.java
@@ -122,7 +122,7 @@ public class MCRSolrConfigReloader {
                 for (Map.Entry<String, JsonElement> entry : entries) {
                     if (cleanList.contains(entry.getKey())) {
                         final JsonObject cleanJsonObject = new JsonObject();
-                        final String commandName = "delete-" + observedType.toLowerCase();
+                        final String commandName = "delete-" + observedType.toLowerCase(Locale.ROOT);
                         if (isKnownSolrConfigCommmand(commandName)) {
                             cleanJsonObject.addProperty(commandName, entry.getKey());
                             executeSolrCommand(coreURL, cleanJsonObject.toString());

--- a/mycore-solr/src/main/java/org/mycore/solr/schema/MCRSolrSchemaReloader.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/schema/MCRSolrSchemaReloader.java
@@ -75,7 +75,7 @@ public class MCRSolrSchemaReloader {
      * @param configType the name of the configuration directory containg the Solr core configuration
      * @param coreID the ID of the core, which the configuration should be applied to
      */
-    public static void clearSchema(String configType, String coreID) {
+    public static void cleanSchema(String configType, String coreID) {
 
         LOGGER.info("Clear SOLR schema for core " + coreID + " using configuration " + configType);
         try {

--- a/mycore-solr/src/main/java/org/mycore/solr/schema/MCRSolrSchemaReloader.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/schema/MCRSolrSchemaReloader.java
@@ -68,16 +68,16 @@ public class MCRSolrSchemaReloader {
         "plong", "string", "text_general");
 
     /**
-     * Remove all fields, dynamicFields, copyFields and fieldTypes in the SOLR schema for the given core. The fields,
+     * Removes all fields, dynamicFields, copyFields and fieldTypes in the SOLR schema for the given core. The fields,
      * dynamicFields, and types in the lists SOLR_DEFAULT_FIELDS, SOLR_DEFAULT_DYNAMIC_FIELDS, 
      * SOLR_DEFAULT_DYNAMIC_FIELDS are excluded from remove.
      *
      * @param configType the name of the configuration directory containg the Solr core configuration
      * @param coreID the ID of the core, which the configuration should be applied to
      */
-    public static void cleanSchema(String configType, String coreID) {
+    public static void reset(String configType, String coreID) {
 
-        LOGGER.info("Clear SOLR schema for core " + coreID + " using configuration " + configType);
+        LOGGER.info("Resetting SOLR schema for core " + coreID + " using configuration " + configType);
         try {
             SolrClient solrClient = MCRSolrClientFactory.get(coreID).map(MCRSolrCore::getClient)
                 .orElseThrow(() -> new MCRConfigurationException("The core " + coreID + " is not configured!"));


### PR DESCRIPTION
This change add a method to clean the SOLR configuration defined by
proerties before cleaning the schema.
Renaming the internal methods from clear to clean.

[Link to jira](https://mycore.atlassian.net/browse/MCR-2260).
