### PR TITLE
MCR-2250 fixed /api/v2 JSON output by jackson

### DIFF
--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClass.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClass.java
@@ -41,36 +41,37 @@ import org.mycore.datamodel.classifications2.MCRCategoryID;
 import org.mycore.datamodel.classifications2.MCRLabel;
 import org.mycore.datamodel.classifications2.impl.MCRCategoryImpl;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @XmlRootElement(name = "mycoreclass")
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "MCRClass",
     propOrder = {
-        "label",
         "url",
+        "label",
         "categories"
     })
 @XmlSeeAlso({ MCRClassCategory.class, MCRClassURL.class, MCRLabel.class })
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
+@JsonPropertyOrder({ "ID", "url", "labels", "categories" })
 public class MCRClass {
 
     @XmlElement(required = true)
-    @JsonProperty("labels")
     protected List<MCRLabel> label;
 
     protected MCRClassURL url;
 
     @XmlElementWrapper(name = "categories")
     @XmlElement(name = "category")
-    @JsonProperty("categories")
     protected List<MCRClassCategory> categories;
 
     @XmlAttribute(name = "ID", required = true)
     @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
     protected String id;
 
+    @JsonGetter("labels")
     public List<MCRLabel> getLabel() {
         if (label == null) {
             label = new ArrayList<>();
@@ -86,6 +87,7 @@ public class MCRClass {
         this.url = value;
     }
 
+    @JsonGetter("categories")
     public List<MCRClassCategory> getCategories() {
         return categories;
     }
@@ -94,6 +96,7 @@ public class MCRClass {
         this.categories = value;
     }
 
+    @JsonGetter
     public String getID() {
         return id;
     }

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClass.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClass.java
@@ -49,8 +49,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "MCRClass",
     propOrder = {
-        "url",
         "label",
+        "url",
         "categories"
     })
 @XmlSeeAlso({ MCRClassCategory.class, MCRClassURL.class, MCRLabel.class })

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClassCategory.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClassCategory.java
@@ -43,8 +43,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "MCRClassCategory",
     propOrder = {
-        "url",
         "label",
+        "url",
         "category"
     })
 @XmlSeeAlso({ MCRLabel.class, MCRClassURL.class })

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClassCategory.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClassCategory.java
@@ -36,23 +36,24 @@ import org.mycore.datamodel.classifications2.MCRCategory;
 import org.mycore.datamodel.classifications2.MCRCategoryID;
 import org.mycore.datamodel.classifications2.MCRLabel;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "MCRClassCategory",
     propOrder = {
-        "label",
         "url",
+        "label",
         "category"
     })
 @XmlSeeAlso({ MCRLabel.class, MCRClassURL.class })
 @XmlRootElement(name = "category")
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
+@JsonPropertyOrder({ "ID", "url", "labels", "categories" })
 public class MCRClassCategory {
 
     @XmlElement(required = true)
-    @JsonProperty("labels")
     protected List<MCRLabel> label;
 
     protected MCRClassURL url;
@@ -63,6 +64,7 @@ public class MCRClassCategory {
     @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
     protected String id;
 
+    @JsonGetter("labels")
     public List<MCRLabel> getLabel() {
         if (label == null) {
             label = new ArrayList<>();
@@ -78,7 +80,7 @@ public class MCRClassCategory {
         this.url = value;
     }
 
-    @JsonProperty("categories")
+    @JsonGetter("categories")
     public List<MCRClassCategory> getCategory() {
         if (category == null) {
             category = new ArrayList<>();
@@ -86,6 +88,7 @@ public class MCRClassCategory {
         return this.category;
     }
 
+    @JsonGetter
     public String getID() {
         return id;
     }

--- a/mycore-restapi/pom.xml
+++ b/mycore-restapi/pom.xml
@@ -31,6 +31,10 @@
       <artifactId>jackson-jaxrs-base</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>

--- a/mycore-restapi/src/main/java/org/mycore/restapi/v2/MCRRestV2App.java
+++ b/mycore-restapi/src/main/java/org/mycore/restapi/v2/MCRRestV2App.java
@@ -37,6 +37,8 @@ import org.mycore.restapi.MCRRemoveMsgBodyFilter;
 import org.mycore.restapi.converter.MCRWrappedXMLWriter;
 import org.mycore.restapi.v1.MCRRestAPIAuthentication;
 
+import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+
 import io.swagger.v3.jaxrs2.integration.JaxrsOpenApiContextBuilder;
 import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
 import io.swagger.v3.oas.integration.OpenApiConfigurationException;
@@ -58,6 +60,8 @@ public class MCRRestV2App extends MCRJerseyRestApp {
         register(MCRNoFormDataPutFilter.class);
         register(MCRDropSessionFilter.class);
         register(MCRExceptionMapper.class);
+        //after removing the following line, test if json output from MCRRestClassification is still OK
+        register(JacksonJaxbJsonProvider.class); //jetty >= 2.31, do not use DefaultJacksonJaxbJsonProvider
         setupOAS();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@ Applications based on MyCoRe use a common core, which provides the functionality
     <hk2.version>2.6.1</hk2.version>
     <httpcomponents.version>4.5.12</httpcomponents.version>
     <httpcore.version>4.4.13</httpcore.version>
-    <jackson.version>2.11.1</jackson.version>
+    <jackson.version>2.11.2</jackson.version>
     <jakarta.activation.version>1.2.2</jakarta.activation.version>
     <jakarta.mail.version>1.6.5</jakarta.mail.version>
     <java.target.version>11</java.target.version>

--- a/pom.xml
+++ b/pom.xml
@@ -809,6 +809,11 @@ Applications based on MyCoRe use a common core, which provides the functionality
         <version>${jackson.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-json-provider</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jaxb-annotations</artifactId>
         <version>${jackson.version}</version>


### PR DESCRIPTION
jersey 2.31 does use a new JacksonJaxbJsonProvider

[Link to jira](https://mycore.atlassian.net/browse/MCR-2250).
