### PR TITLE
MIR-936 configure UTF-8 as output format to prevent problems parsing

### DIFF
--- a/mycore-mods/src/main/resources/components/mods/config/mycore.properties
+++ b/mycore-mods/src/main/resources/components/mods/config/mycore.properties
@@ -15,8 +15,8 @@ MCR.ContentTransformer.bibmods.MIMEType=text/xml
 # First produce MODS, then make BibTeX out of it
 MCR.ContentTransformer.mods2bibtex.Class=org.mycore.common.content.transformer.MCRBibUtilsTransformer
 # local.property: system command for xml2bib
-MCR.ContentTransformer.mods2bibtex.Command=xml2bib -b -w
-MCR.ContentTransformer.mods2bibtex.MIMEType=application/x-bibtex
+MCR.ContentTransformer.mods2bibtex.Command=xml2bib -b -w -o UTF-8
+MCR.ContentTransformer.mods2bibtex.MIMEType=text/plain; charset\="UTF-8"
 MCR.ContentTransformer.mods2bibtex.FileExtension=bib
 MCR.ContentTransformer.bibtex.Class=org.mycore.common.content.transformer.MCRTransformerPipe
 MCR.ContentTransformer.bibtex.Steps=bibmods, mods2bibtex


### PR DESCRIPTION
configure UTF-8 as output format to prevent problems parsing german quotes

[Link to jira](https://mycore.atlassian.net/browse/MIR-936).
