### PR TITLE
MCR-2271 Abstract MCRMetadataStore structure

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/xml/MCRURIResolver.java
+++ b/mycore-base/src/main/java/org/mycore/common/xml/MCRURIResolver.java
@@ -1491,7 +1491,7 @@ public final class MCRURIResolver implements URIResolver {
                 v.setAttribute("user", version.getUser());
                 v.setAttribute("date", MCRXMLFunctions.getISODate(version.getDate(), null));
                 v.setAttribute("r", Long.toString(version.getRevision()));
-                v.setAttribute("action", Character.toString(version.getType()));
+                v.setAttribute("action", Character.toString(String.valueOf(version.getState()).charAt(0)));
                 e.addContent(v);
             }
             return new JDOMSource(e);

--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRCreatorCache.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRCreatorCache.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.mycore.datamodel.ifs2.MCRMetadataVersion;
+import org.mycore.datamodel.ifs2.MCRMetadataVersion.MCRMetadataVersionState;
 import org.mycore.datamodel.metadata.MCRMetadataManager;
 import org.mycore.datamodel.metadata.MCRObjectID;
 
@@ -60,7 +61,7 @@ public class MCRCreatorCache {
                             .map(versions -> versions.stream()
                                 .sorted(Comparator.comparingLong(MCRMetadataVersion::getRevision)
                                     .reversed())
-                                .filter(v -> v.getType() == MCRMetadataVersion.CREATED).findFirst()
+                                .filter(v -> v.getState() == MCRMetadataVersionState.CREATED).findFirst()
                                 .map(version -> {
                                     LOGGER.info(
                                         "Found creator {} in revision {} of {}",

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRMetadata.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRMetadata.java
@@ -1,0 +1,627 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.datamodel.ifs2;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jdom2.JDOMException;
+import org.mycore.common.MCRPersistenceException;
+import org.mycore.common.MCRUsageException;
+import org.mycore.common.content.MCRByteContent;
+import org.mycore.common.content.MCRContent;
+import org.mycore.common.content.MCRPathContent;
+import org.mycore.common.content.streams.MCRByteArrayOutputStream;
+import org.mycore.datamodel.ifs2.MCRMetadataVersion.MCRMetadataVersionState;
+import org.tmatesoft.svn.core.ISVNLogEntryHandler;
+import org.tmatesoft.svn.core.SVNCommitInfo;
+import org.tmatesoft.svn.core.SVNException;
+import org.tmatesoft.svn.core.SVNLogEntry;
+import org.tmatesoft.svn.core.SVNLogEntryPath;
+import org.tmatesoft.svn.core.SVNNodeKind;
+import org.tmatesoft.svn.core.SVNProperty;
+import org.tmatesoft.svn.core.SVNPropertyValue;
+import org.tmatesoft.svn.core.io.ISVNEditor;
+import org.tmatesoft.svn.core.io.SVNRepository;
+import org.tmatesoft.svn.core.io.diff.SVNDeltaGenerator;
+import org.xml.sax.SAXException;
+
+/**
+ * A generic interface to {@link MCRMetadataStore}s.
+ * 
+ * An MCRMetadata instance represents an object that is (to be) stored in an
+ * MCRMetadataStore. It has an immutable set of information about its associated store & ID,
+ * everything else is queried from the store.
+ * 
+ * @author Christoph Neidahl (OPNA2608)
+ *
+ */
+public class MCRMetadata {
+
+    protected static final Logger LOGGER = LogManager.getLogger();
+
+    /**
+     * The {@link MCRMetadataStore} object this MCRMetadata object belongs to.
+     */
+    private final MCRMetadataStore store;
+
+    /**
+     * The object's ID.
+     */
+    private final int id;
+
+    /**
+     * Syncing status. Set to <code>false</code> if this object's information
+     * couldn't or hasn't been synced with the linked store yet.
+     * 
+     * Possible reasons for a negative syncing status with the store:
+     * <ul>
+     *   <li>
+     *     The object has just been instantiated and no CRUD operations have been called yet.
+     *   </li>
+     *   <li>
+     *     An exception has occurred while communicating with the store backend.
+     *   </li>
+     * </ul>
+     */
+    private boolean synced = false;
+
+    /**
+     * The revision of the MyCoRe metadata object this instance references.
+     * 
+     * May be <code>null</code> if
+     * <ul>
+     *   <li>
+     *     No revision has been specified on object instantiation.
+     *   </li>
+     *   <li>
+     *     {@link #delete()} has been called and the store implementation is incapable of tracking
+     *     {@link MCRMetadataVersionState.DELETED} revisions.
+     *   </li>
+     * </ul>
+     */
+    protected Long revision;
+
+    /**
+     * The current revision's file contents.
+     * 
+     * May be <code>null</code> if
+     * <ul>
+     *   <li>
+     *     The object has just been instantiated and no CRU operations have been called yet.
+     *   </li>
+     *   <li>
+     *     {@link #delete()} has been called successfully or a {@link MCRVersioningMetadtaState.DELETED}
+     *     revision is used
+     *   </li>
+     * </ul>
+     */
+    protected MCRContent content;
+
+    /**
+     * TODO
+     */
+    protected String user;
+
+    /**
+     * The current revision's commit date.
+     * 
+     * May be <code>null</code> if
+     * <ul>
+     *   <li>
+     *     The object has just been instantiated and no CRU operations have been called yet.
+     *   </li>
+     *   <li>
+     *     {@link #delete()} has been called successfully and the store implementation is incapable of tracking
+     *     {@link MCRMetadataVersionState.DELETED} revisions.
+     *   </li>
+     * </ul>
+     */
+    protected Date date;
+
+    /**
+     * TODO
+     * @param store
+     * @param id
+     */
+    public MCRMetadata(MCRMetadataStore store, int id) {
+        this.store = store;
+        this.id = id;
+    }
+
+    /**
+     * TODO
+     * @param store
+     * @param id
+     * @param revision
+     */
+    public MCRMetadata(MCRMetadataStore store, int id, long revision) {
+        this(store, id);
+        this.revision = revision;
+    }
+
+    /***** START COMPATIBILITY *****/
+
+    /**
+     * TODO needs to be moved into the SVN store eventually
+     * @param type
+     * @param content
+     * @throws MCRPersistenceException
+     */
+    private void commit(MCRMetadataVersionState type, MCRContent content) throws MCRPersistenceException {
+        String commitMsg = type.toString().toLowerCase(Locale.ROOT) + " metadata object " + getFullID()
+            + " in store";
+        SVNCommitInfo info;
+        try {
+            MCRVersioningMetadataStore svnStore = (MCRVersioningMetadataStore) (store);
+            SVNRepository repository = svnStore.getRepository();
+
+            if (type != MCRMetadataVersionState.DELETED) {
+                String[] paths = store.getSlotPaths(getID());
+                int existing = paths.length - 1;
+                for (; existing >= 0; existing--) {
+                    if (!repository.checkPath(paths[existing], -1).equals(SVNNodeKind.NONE)) {
+                        break;
+                    }
+                }
+
+                existing += 1;
+
+                ISVNEditor editor = repository.getCommitEditor(commitMsg, null);
+                editor.openRoot(-1);
+
+                // Create directories in SVN that do not exist yet
+                for (int i = existing; i < paths.length - 1; i++) {
+                    LOGGER.debug("SVN create directory {}", paths[i]);
+                    editor.addDir(paths[i], null, -1);
+                    editor.closeDir();
+                }
+
+                // Commit file changes
+                String filePath = paths[paths.length - 1];
+                if (existing < paths.length) {
+                    editor.addFile(filePath, null, -1);
+                } else {
+                    editor.openFile(filePath, -1);
+                }
+
+                editor.applyTextDelta(filePath, null);
+                SVNDeltaGenerator deltaGenerator = new SVNDeltaGenerator();
+
+                String checksum;
+                try (InputStream in = content.getContentInputStream()) {
+                    checksum = deltaGenerator.sendDelta(filePath, in, editor, true);
+                }
+
+                if (store.shouldForceXML()) {
+                    editor.changeFileProperty(filePath, SVNProperty.MIME_TYPE, SVNPropertyValue.create("text/xml"));
+                }
+
+                editor.closeFile(filePath, checksum);
+
+                editor.closeDir(); // root
+                info = editor.closeEdit();
+                if (MCRVersioningMetadataStore.shouldSyncLastModifiedOnSVNCommit()) {
+                    setLastModified(info.getDate());
+                }
+            } else {
+                ISVNEditor editor = repository.getCommitEditor(commitMsg, null);
+                editor.openRoot(-1);
+
+                editor.deleteEntry(store.getSlotPath(getID()), -1);
+
+                editor.closeDir();
+                info = editor.closeEdit();
+            }
+            LOGGER.info("SVN commit of {} finished, new revision {}", type.toString(), info.getNewRevision());
+        } catch (SVNException | IOException e) {
+            throw new MCRPersistenceException("Failed to commit changes to SVN repository!", e);
+        }
+    }
+
+    private static final Map<String, MCRMetadataVersionState> TYPE_STATE_MAPPING = Stream
+        .of(new AbstractMap.SimpleImmutableEntry<>("A", MCRMetadataVersionState.CREATED),
+            new AbstractMap.SimpleImmutableEntry<>("M", MCRMetadataVersionState.UPDATED),
+            new AbstractMap.SimpleImmutableEntry<>("R", MCRMetadataVersionState.UPDATED), /* should not occur */
+            new AbstractMap.SimpleImmutableEntry<>("D", MCRMetadataVersionState.DELETED))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    private String getFilePath() {
+        return "/" + store.getSlotPath(getID());
+    }
+
+    private String getDirectory() {
+        String path = getFilePath();
+        return path.substring(0, path.lastIndexOf('/'));
+    }
+
+    /**
+     * TODO copied from MCRVersionedMetadata, needs to be moved into stores
+     * @param revision
+     * @return
+     * @throws IOException
+     */
+    public MCRMetadataVersion getRevision(long revision) throws IOException {
+        try {
+            if (revision < 0) {
+                revision = getLastPresentRevision();
+                if (revision < 0) {
+                    LOGGER.warn("Metadata object {} in store {} has no last revision!", getID(), store.getID());
+                    return null;
+                }
+            }
+            MCRVersioningMetadataStore svnStore = (MCRVersioningMetadataStore) (store);
+            SVNRepository repository = svnStore.getRepository();
+            String path = getFilePath();
+            String dir = getDirectory();
+            @SuppressWarnings("unchecked")
+            Collection<SVNLogEntry> log = repository.log(new String[] { dir }, null, revision, revision, true, true);
+            for (SVNLogEntry logEntry : log) {
+                SVNLogEntryPath svnLogEntryPath = logEntry.getChangedPaths().get(path);
+                if (svnLogEntryPath != null) {
+                    char type = svnLogEntryPath.getType();
+                    return new MCRMetadataVersion(this, logEntry.getRevision(), logEntry.getAuthor(),
+                        logEntry.getDate(),
+                        TYPE_STATE_MAPPING.get(String.valueOf(type)));
+                }
+            }
+            LOGGER.warn("Metadata object {} in store {} has no revision ''{}''!", getID(), getStore().getID(),
+                getRevision());
+            return null;
+        } catch (SVNException svnExc) {
+            throw new IOException(svnExc);
+        }
+    }
+
+    public long getLastPresentRevision() throws SVNException {
+        return getLastRevision(false);
+    }
+
+    private long getLastRevision(boolean deleted) throws SVNException {
+        SVNRepository repository = ((MCRVersioningMetadataStore) (store)).getRepository();
+        if (repository.getLatestRevision() == 0) {
+            //new repository cannot hold a revision yet (MCR-1196)
+            return -1;
+        }
+        final String path = getFilePath();
+        String dir = getDirectory();
+        LastRevisionLogHandler lastRevisionLogHandler = new LastRevisionLogHandler(path, deleted);
+        int limit = 0; //we stop through LastRevisionFoundException
+        try {
+            repository.log(new String[] { dir }, repository.getLatestRevision(), 0, true, true, limit, false, null,
+                lastRevisionLogHandler);
+        } catch (LastRevisionFoundException ignored) {
+        }
+        return lastRevisionLogHandler.getLastRevision();
+    }
+
+    private Long getLastRevision() {
+        try {
+            long lastRevision = getLastRevision(true);
+            return lastRevision < 0 ? null : lastRevision;
+        } catch (SVNException e) {
+            LOGGER.warn("Could not get last revision of: {}_{}", getStore(), id, e);
+            return null;
+        }
+    }
+
+    /**
+     * TODO wrapper until implemented cleanly in stores
+     * @param metadata
+     * @param content
+     * @throws MCRPersistenceException
+     */
+    private void createTransitionHelper(MCRContent content) throws MCRPersistenceException {
+        // TODO replace with calls into store
+        try {
+            if (store.shouldForceXML()) {
+                content = content.ensureXML();
+            }
+            Path xmlPath = store.getSlot(getID());
+            if (!Files.exists(xmlPath.getParent())) {
+                Files.createDirectories(xmlPath.getParent());
+            }
+            content.sendTo(xmlPath);
+            if (store instanceof MCRVersioningMetadataStore) {
+                commit(MCRMetadataVersionState.CREATED, content);
+            }
+        } catch (SAXException | IOException | JDOMException e) {
+            throw new MCRPersistenceException("Failed to create " + getFullID() + "!", e);
+        }
+    }
+
+    /**
+     * TODO wrapper until implemented cleanly in stores
+     * @param metadata
+     * @param content
+     * @throws MCRPersistenceException
+     */
+    private MCRContent readTransitionHelper() throws MCRPersistenceException {
+        //TODO replace with calls into store
+        // shared by both stores
+        try {
+            if (!MCRVersioningMetadataStore.class.isInstance(store) || revision == null) {
+                Path xmlPath = store.getSlot(getID());
+                if (Files.exists(xmlPath)) {
+                    MCRPathContent pathContent = new MCRPathContent(xmlPath);
+                    pathContent.setDocType(store.forceDocType);
+                    return pathContent;
+                    // if XML store, exit here with no content
+                } else if (!MCRVersioningMetadataStore.class.isInstance(store)) {
+                    return null;
+                }
+            }
+            // if SVN store, check the SVN repo
+            // if no revision specified, default to latest one
+            if (revision == null) {
+                revision = getLastRevision();
+            }
+            SVNRepository svnRepo = ((MCRVersioningMetadataStore) (store)).getRepository();
+            MCRByteArrayOutputStream baos = new MCRByteArrayOutputStream();
+            svnRepo.getFile(store.getSlotPath(getID()), revision, null, baos);
+            baos.close();
+            return new MCRByteContent(baos.getBuffer(), 0, baos.size(), getDate().getTime());
+        } catch (SVNException | IOException e) {
+            throw new MCRPersistenceException("Failed to read " + getFullID() + "!", e);
+        }
+    }
+
+    /**
+     * TODO wrapper until implemented cleanly in stores
+     * @param metadata
+     * @param content
+     * @throws MCRPersistenceException
+     */
+    private void updateTransitionHelper(MCRContent content) throws MCRPersistenceException {
+
+    }
+
+    /**
+     * TODO wrapper until implemented cleanly in stores
+     * @throws MCRPersistenceException
+     */
+    private void deleteTransitionHelper() throws MCRPersistenceException {
+
+    }
+
+    private MCRMetadataVersion getMetadataVersionTransitionHelper(int id, long revision)
+        throws MCRPersistenceException {
+        return new MCRMetadataVersion(this, MCRMetadataVersionState.CREATED);
+    }
+
+    /**
+     * TODO implement XML + SVN wrapper
+     * @param metadata
+     * @return
+     * @throws MCRPersistenceException
+     */
+    private static MCRMetadataVersion getMetadataVersionLastTransitionHelper(MCRMetadata metadata)
+        throws MCRPersistenceException {
+        return null;
+    }
+
+    /**
+     * TODO implement XML + SVN wrapper
+     * @param metadata
+     * @return
+     * @throws MCRPersistenceException
+     */
+    private static Date getLastModifiedTransitionHelper(MCRMetadata metadata) throws MCRPersistenceException {
+        return null;
+    }
+
+    private static void setLastModifiedTransitionHelper(MCRMetadata metadata, Date date) throws MCRUsageException {
+
+    }
+
+    /***** END COMPATIBILITY *****/
+
+    public void create(MCRContent content) throws MCRPersistenceException {
+        try {
+            // store.createContent(this, content);
+            createTransitionHelper(content);
+            this.content = content;
+            // revision = store.getMetadataVersionLast(id).getRevision();
+            revision = getMetadataVersionLastTransitionHelper(this).getRevision();
+            // date = store.getLastModified(this);
+            date = getLastModifiedTransitionHelper(this);
+            synced = true;
+        } catch (MCRPersistenceException e) {
+            synced = false;
+            throw new MCRPersistenceException(
+                "Failed to create " + getFullID() + ", revision " + revision + " in store!", e);
+        }
+    }
+
+    public MCRContent read() throws MCRPersistenceException {
+        try {
+            if (revision == null) {
+                LOGGER.info("Reading " + getFullID() + " without revision requested, querying for latest revision.");
+                // revision = store.getMetadataVersionLast(id).getRevision();
+                revision = getMetadataVersionLastTransitionHelper(this).getRevision();
+            }
+            // content = store.readContent(this);
+            content = readTransitionHelper();
+            // date = store.getLastModified(this);
+            date = getLastModifiedTransitionHelper(this);
+            synced = true;
+            return content;
+        } catch (MCRPersistenceException e) {
+            synced = false;
+            throw new MCRPersistenceException(
+                "Failed to read " + getFullID() + ", revision " + revision + " from store!", e);
+        }
+    }
+
+    public void update(MCRContent content) throws MCRPersistenceException {
+        try {
+            // store.updateContent(this, content);
+            updateTransitionHelper(content);
+            // revision = getVersionLast().getRevision();
+            revision = getMetadataVersionLastTransitionHelper(this).getRevision();
+            // date = store.getLastModified(this);
+            date = getLastModifiedTransitionHelper(this);
+            this.content = content;
+            synced = true;
+        } catch (MCRPersistenceException e) {
+            synced = false;
+            throw new MCRPersistenceException(
+                "Failed to update " + getFullID() + ", revision " + revision + " in store!", e);
+        }
+    }
+
+    public void delete() throws MCRPersistenceException {
+        try {
+            // store.deleteContent(this);
+            deleteTransitionHelper();
+            // MCRMetadataVersion newVersion = getVersionLast();
+            MCRMetadataVersion newVersion = getMetadataVersionLastTransitionHelper(this);
+            // store may return null if deletion removes object history
+            if (newVersion != null) {
+                revision = newVersion.getRevision();
+                date = newVersion.getDate();
+            } else {
+                revision = null;
+                date = null;
+            }
+            this.content = null;
+            synced = true;
+        } catch (MCRPersistenceException e) {
+            synced = false;
+            throw new MCRPersistenceException(
+                "Failed to delete " + getFullID() + ", revision " + revision + " from store!", e);
+        }
+    }
+
+    public boolean isSynced() {
+        return synced;
+    }
+
+    public String getBase() {
+        return store.getID();
+    }
+
+    public int getID() {
+        return id;
+    }
+
+    public String getFullID() {
+        return store.getID() + "_" + store.createIDWithLeadingZeros(id);
+    }
+
+    public Long getRevision() {
+        return revision;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public MCRMetadataStore getStore() {
+        return store;
+    }
+
+    public MCRMetadataVersion getMetadataVersion() {
+        return getMetadataVersionTransitionHelper(getID(), revision);
+    }
+
+    public boolean isRevisionDeleted() {
+        MCRMetadataVersion thisVersion = getMetadataVersion();
+        // TODO replace with calls into store
+        if (store instanceof MCRVersioningMetadataStore) {
+            return thisVersion.getState() == MCRMetadataVersionState.DELETED;
+        } else {
+            return thisVersion != null;
+        }
+    }
+
+    public boolean isLatestDeleted() {
+        MCRMetadataVersion latestVersion = getMetadataVersionLastTransitionHelper(this);
+        // TODO replace with calls into store
+        if (store instanceof MCRVersioningMetadataStore) {
+            return latestVersion.getState() == MCRMetadataVersionState.DELETED;
+        } else {
+            return latestVersion != null;
+        }
+    }
+
+    public void restore() throws MCRPersistenceException {
+        getMetadataVersionLastTransitionHelper(this).getMetadataObject().update(read());
+    }
+
+    public void setLastModified(Date date) throws MCRUsageException {
+        // store.setLastModified(this, date);
+        setLastModifiedTransitionHelper(this, date);
+    }
+    
+    /***** START COMPATIBILITY INNER CLASSES *****/
+    
+    
+
+    private static final class LastRevisionFoundException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+    }
+
+    private static final class LastRevisionLogHandler implements ISVNLogEntryHandler {
+        private final String path;
+
+        long lastRevision = -1;
+
+        private boolean deleted;
+
+        private LastRevisionLogHandler(String path, boolean deleted) {
+            this.path = path;
+            this.deleted = deleted;
+        }
+
+        @Override
+        public void handleLogEntry(SVNLogEntry logEntry) throws SVNException {
+            SVNLogEntryPath svnLogEntryPath = logEntry.getChangedPaths().get(path);
+            if (svnLogEntryPath != null) {
+                char type = svnLogEntryPath.getType();
+                if (deleted || type != SVNLogEntryPath.TYPE_DELETED) {
+                    lastRevision = logEntry.getRevision();
+                    //no other way to stop svnkit from logging
+                    throw new LastRevisionFoundException();
+                }
+            }
+        }
+
+        long getLastRevision() {
+            return lastRevision;
+        }
+    }
+    
+    /***** END COMPATIBILITY INNER CLASSES *****/
+}

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRMetadataVersion.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRMetadataVersion.java
@@ -38,7 +38,7 @@ import org.tmatesoft.svn.core.SVNException;
 import org.tmatesoft.svn.core.io.SVNRepository;
 
 /**
- * Provides information about the revision of a {@link MCRVersionedMetadata} object
+ * Provides information about the revision of a {@link MCRMetadata} object
  * at the time of object instantiation. This includes the revision number, date,
  * state ({@link MCRMetadataVersionState}), the committer and a reference to the metadata object itself.
  * 
@@ -74,7 +74,7 @@ public class MCRMetadataVersion {
      * The metadata object this version belongs to.
      */
     @XmlTransient
-    private final MCRVersionedMetadata vm;
+    private final MCRMetadata vm;
 
     /**
      * The revision number of this version.
@@ -114,10 +114,13 @@ public class MCRMetadataVersion {
      * @param state
      *            what object state does it represent ({@link MCRMetadataVersionState})
      */
-    public MCRMetadataVersion(MCRVersionedMetadata vm, long revision, String user, Date date,
-        MCRMetadataVersionState state) {
+    public MCRMetadataVersion(MCRMetadata vm, MCRMetadataVersionState state) {
+        this(vm, vm.getRevision(), vm.getUser(), vm.getDate(), state);
+    }
+    
+    public MCRMetadataVersion(MCRMetadata vm, long revision, String user, Date date, MCRMetadataVersionState state) {
         LOGGER.debug("Instantiating version information for {}_{} in revision {}.", vm.getStore().id,
-            vm.getStore().createIDWithLeadingZeros(vm.getID()), revision);
+            vm.getStore().createIDWithLeadingZeros(vm.getID()), vm.getRevision());
         this.vm = vm;
         this.revision = revision;
         this.user = user;
@@ -130,7 +133,7 @@ public class MCRMetadataVersion {
      * 
      * @return the metadata object this version belongs to
      */
-    public MCRVersionedMetadata getMetadataObject() {
+    public MCRMetadata getMetadataObject() {
         return vm;
     }
 
@@ -199,7 +202,7 @@ public class MCRMetadataVersion {
             throw new MCRUsageException(msg);
         }
         try {
-            SVNRepository repository = vm.getStore().getRepository();
+            SVNRepository repository = ((MCRVersioningMetadataStore) (vm.getStore())).getRepository();
             MCRByteArrayOutputStream baos = new MCRByteArrayOutputStream();
             repository.getFile(vm.getStore().getSlotPath(vm.getID()), revision, null, baos);
             baos.close();

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRStore.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRStore.java
@@ -538,7 +538,7 @@ public abstract class MCRStore {
         this.storeConfig = storeConfig;
     }
 
-    private String createIDWithLeadingZeros(final int id) {
+    String createIDWithLeadingZeros(final int id) {
         final NumberFormat numWithLeadingZerosFormat = NumberFormat.getIntegerInstance(Locale.ROOT);
         numWithLeadingZerosFormat.setMinimumIntegerDigits(idLength);
         numWithLeadingZerosFormat.setGroupingUsed(false);

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRVersionedMetadata.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRVersionedMetadata.java
@@ -269,7 +269,8 @@ public class MCRVersionedMetadata extends MCRStoredMetadata {
                 if (svnLogEntryPath != null) {
                     char type = svnLogEntryPath.getType();
                     versions.add(
-                        new MCRMetadataVersion(this, entry.getRevision(), entry.getAuthor(), entry.getDate(),
+                        new MCRMetadataVersion(new MCRMetadata(getStore(), getID(), entry.getRevision()),
+                            entry.getRevision(), entry.getAuthor(), entry.getDate(),
                             TYPE_STATE_MAPPING.get(String.valueOf(type))));
                 }
             }
@@ -306,7 +307,8 @@ public class MCRVersionedMetadata extends MCRStoredMetadata {
                 SVNLogEntryPath svnLogEntryPath = logEntry.getChangedPaths().get(path);
                 if (svnLogEntryPath != null) {
                     char type = svnLogEntryPath.getType();
-                    return new MCRMetadataVersion(this, logEntry.getRevision(), logEntry.getAuthor(),
+                    return new MCRMetadataVersion(new MCRMetadata(getStore(), getID(), logEntry.getRevision()),
+                        logEntry.getRevision(), logEntry.getAuthor(),
                         logEntry.getDate(),
                         TYPE_STATE_MAPPING.get(String.valueOf(type)));
                 }

--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/history/MCRMetadataHistoryCommands.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/history/MCRMetadataHistoryCommands.java
@@ -49,6 +49,7 @@ import org.mycore.datamodel.common.MCRCreatorCache;
 import org.mycore.datamodel.common.MCRXMLMetadataManager;
 import org.mycore.datamodel.ifs2.MCRMetadataStore;
 import org.mycore.datamodel.ifs2.MCRMetadataVersion;
+import org.mycore.datamodel.ifs2.MCRMetadataVersion.MCRMetadataVersionState;
 import org.mycore.datamodel.ifs2.MCRVersionedMetadata;
 import org.mycore.datamodel.ifs2.MCRVersioningMetadataStore;
 import org.mycore.datamodel.metadata.MCRDerivate;
@@ -262,7 +263,7 @@ public class MCRMetadataHistoryCommands {
         for (MCRMetadataVersion version : versions) {
             String user = version.getUser();
             Instant revDate = version.getDate().toInstant();
-            if (version.getType() == MCRMetadataVersion.DELETED) {
+            if (version.getState() == MCRMetadataVersionState.DELETED) {
                 if (exist) {
                     items.add(delete(derId, user, revDate));
                     exist = false;
@@ -270,7 +271,7 @@ public class MCRMetadataHistoryCommands {
             } else {
                 //created or updated
                 int timeOffset = 0;
-                if (version.getType() == MCRMetadataVersion.CREATED && !exist) {
+                if (version.getState() == MCRMetadataVersionState.CREATED && !exist) {
                     items.add(create(derId, user, revDate));
                     timeOffset = 1;
                     exist = true;
@@ -304,7 +305,7 @@ public class MCRMetadataHistoryCommands {
         for (MCRMetadataVersion version : versions) {
             String user = version.getUser();
             Instant revDate = version.getDate().toInstant();
-            if (version.getType() == MCRMetadataVersion.DELETED) {
+            if (version.getState() == MCRMetadataVersionState.DELETED) {
                 if (exist) {
                     items.add(delete(objId, user, revDate));
                     exist = false;
@@ -312,7 +313,7 @@ public class MCRMetadataHistoryCommands {
             } else {
                 //created or updated
                 int timeOffset = 0;
-                if (version.getType() == MCRMetadataVersion.CREATED && !exist) {
+                if (version.getState() == MCRMetadataVersionState.CREATED && !exist) {
                     items.add(create(objId, user, revDate));
                     timeOffset = 1;
                     exist = true;

--- a/mycore-base/src/main/java/org/mycore/frontend/cli/MCRObjectCommands.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/cli/MCRObjectCommands.java
@@ -784,7 +784,7 @@ public class MCRObjectCommands extends MCRAbstractCommands {
             List<MCRMetadataVersion> revisions = MCRXMLMetadataManager.instance().listRevisions(mcrId);
             for (MCRMetadataVersion revision : revisions) {
                 log.append(revision.getRevision()).append(" ");
-                log.append(revision.getType()).append(" ");
+                log.append(String.valueOf(revision.getState()).charAt(0)).append(" ");
                 log.append(sdf.format(revision.getDate())).append(" ");
                 log.append(revision.getUser());
                 log.append("\n");

--- a/mycore-base/src/test/java/org/mycore/datamodel/ifs2/MCRVersioningMetadataStoreTest.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/ifs2/MCRVersioningMetadataStoreTest.java
@@ -127,7 +127,8 @@ public class MCRVersioningMetadataStoreTest extends MCRIFS2VersioningTestCase {
         assertNotNull(versions);
         assertEquals(1, versions.size());
         MCRMetadataVersion mv = versions.get(0);
-        assertSame(mv.getMetadataObject(), vm);
+        // assertSame(mv.getMetadataObject(), vm);
+        assertEquals(mv.getMetadataObject().read(), vm.getMetadata());
         assertEquals(baseRev, mv.getRevision());
         assertEquals(MCRSessionMgr.getCurrentSession().getUserInformation().getUserID(), mv.getUser());
         assertEquals(MCRMetadataVersionState.CREATED, mv.getState());

--- a/mycore-base/src/test/java/org/mycore/datamodel/ifs2/MCRVersioningMetadataStoreTest.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/ifs2/MCRVersioningMetadataStoreTest.java
@@ -38,6 +38,7 @@ import org.mycore.common.MCRSessionMgr;
 import org.mycore.common.MCRUsageException;
 import org.mycore.common.content.MCRContent;
 import org.mycore.common.content.MCRJDOMContent;
+import org.mycore.datamodel.ifs2.MCRMetadataVersion.MCRMetadataVersionState;
 
 /**
  * JUnit test for MCRVersioningMetadataStore
@@ -129,7 +130,7 @@ public class MCRVersioningMetadataStoreTest extends MCRIFS2VersioningTestCase {
         assertSame(mv.getMetadataObject(), vm);
         assertEquals(baseRev, mv.getRevision());
         assertEquals(MCRSessionMgr.getCurrentSession().getUserInformation().getUserID(), mv.getUser());
-        assertEquals(MCRMetadataVersion.CREATED, mv.getType());
+        assertEquals(MCRMetadataVersionState.CREATED, mv.getState());
 
         bzzz();
         Document xml2 = new Document(new Element("bango"));
@@ -143,7 +144,7 @@ public class MCRVersioningMetadataStoreTest extends MCRIFS2VersioningTestCase {
         assertEquals(baseRev, mv.getRevision());
         mv = versions.get(1);
         assertEquals(vm.getRevision(), mv.getRevision());
-        assertEquals(MCRMetadataVersion.UPDATED, mv.getType());
+        assertEquals(MCRMetadataVersionState.UPDATED, mv.getState());
 
         bzzz();
         Document xml3 = new Document(new Element("bongo"));
@@ -190,10 +191,10 @@ public class MCRVersioningMetadataStoreTest extends MCRIFS2VersioningTestCase {
         vm = getVersStore().create(new MCRJDOMContent(xml1), vm.getID());
         List<MCRMetadataVersion> versions = vm.listVersions();
         assertEquals(4, versions.size());
-        assertEquals(MCRMetadataVersion.CREATED, versions.get(0).getType());
-        assertEquals(MCRMetadataVersion.UPDATED, versions.get(1).getType());
-        assertEquals(MCRMetadataVersion.DELETED, versions.get(2).getType());
-        assertEquals(MCRMetadataVersion.CREATED, versions.get(3).getType());
+        assertEquals(MCRMetadataVersionState.CREATED, versions.get(0).getState());
+        assertEquals(MCRMetadataVersionState.UPDATED, versions.get(1).getState());
+        assertEquals(MCRMetadataVersionState.DELETED, versions.get(2).getState());
+        assertEquals(MCRMetadataVersionState.CREATED, versions.get(3).getState());
         versions.get(1).restore();
         assertEquals("bango", vm.getMetadata().asXML().getRootElement().getName());
     }

--- a/mycore-migration/src/main/java/org/mycore/migration/cli/MCRMigrationCommands.java
+++ b/mycore-migration/src/main/java/org/mycore/migration/cli/MCRMigrationCommands.java
@@ -65,6 +65,7 @@ import org.mycore.datamodel.common.MCRLinkTableManager;
 import org.mycore.datamodel.common.MCRXMLMetadataManager;
 import org.mycore.datamodel.ifs2.MCRMetadataVersion;
 import org.mycore.datamodel.ifs2.MCRVersionedMetadata;
+import org.mycore.datamodel.ifs2.MCRMetadataVersion.MCRMetadataVersionState;
 import org.mycore.datamodel.metadata.MCRBase;
 import org.mycore.datamodel.metadata.MCRDerivate;
 import org.mycore.datamodel.metadata.MCRMetaDerivateLink;
@@ -122,7 +123,7 @@ public class MCRMigrationCommands {
                 List<MCRMetadataVersion> versions = versionedMetadata.listVersions();
                 MCRMetadataVersion firstVersion = versions.get(0);
                 for (MCRMetadataVersion version : versions) {
-                    if (version.getType() == 'A') {
+                    if (version.getState() == MCRMetadataVersionState.CREATED) {
                         firstVersion = version; // get last 'added'
                     }
                 }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-2271).

This PR has been in development for afew months and went through several different implementation ideas, I'm still in the middle of cleaning up leftover debugging code and unnecessary changes but I think it's ready for a general review by MyCoRe core developers. All tests pass locally and I could use an MCRMetadataStore-based application with this new code as-is, but I didn't do much testing on the SVN side of things.

---

This is a restructuring of the Metadata-Store <-> Metadata <-> Metadata-Version code.

- I created MCRMetadata, a storage-agnostic class to interface with Metadata-Stores.
This obsoletes the store-bound MCRStoredMetadata and MCRVersionedMetadata classes as a universal metadata object class. Most MCRMetadata operations map to abstract MCRMetadataStore ones that are left up to the associated store to implement. The term "revision" has been changed to mean an object's revision instead of a global SVN repository one.

- The Metadata-Store has been further abstracted.
MCRMetadataStore previously was an unversioned storage implementation using a local directory-file structure according to the specified slots. This new implementation has abstract CRUD methods that extending Metadata-Stores are supposed to implement, along with several convenience/compatibility methods that all wrap around to abstract ones. As far as this new MCRMetadataStore is concerned, all stores are assumed to handle versioning operations and information: a lack of versioning would be implemented by only ever listing & knowing one version of an object. The simple directory-file implementation has been extracted to MCRXMLMetadataStore & implements this.

- The SVN-based Metadata-Store has been renamed to MCRSVNXMLMetadataStore to better reflect its inheritance.
I tried to do a decoupled SVN-only store, but it would've been an even bigger undertaking to do this in a clean manner and didn't seem worth the effort. Along with the changed meaning of revision, this would've caused (more significant) performance drawbacks due to the SVNKit library lacking methods to conveniently get revisions of *files* as opposed to revisions of the *repository*.

- Some MCRMetadataVersion renaming/rewriting

- Changes throughout MyCoRe to accommodate the changed classes

---

I know this is a *big* PR, but I hope you're still able to give me some feedback on the ideas and changes proposed here. Cheers!