### PR TITLE
MCR-2156 fix last modified time is missing in tar file

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/MCRUtils.java
+++ b/mycore-base/src/main/java/org/mycore/common/MCRUtils.java
@@ -399,7 +399,13 @@ public class MCRUtils {
                 @Override
                 public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
                     Path absolutePath = dir.normalize().toAbsolutePath();
-                    Files.setLastModifiedTime(absolutePath, directoryTimes.get(absolutePath));
+                    FileTime lastModifiedTime = directoryTimes.get(absolutePath);
+                    if (lastModifiedTime != null) {
+                        Files.setLastModifiedTime(absolutePath, lastModifiedTime);
+                    } else {
+                        LOGGER.warn("Could not restore last modified time for {} from TAR file {}.", absolutePath,
+                            source);
+                    }
                     return super.postVisitDirectory(dir, exc);
                 }
             });


### PR DESCRIPTION
If directory is missing in TAR file we cannot restore
the original last modified time. Log a warning instead
of throwing an exception later on.

[Link to jira](https://mycore.atlassian.net/browse/MCR-2156).
