### PR TITLE
MCR-2345 Viewer is sending request for same tiles multiple times

### DIFF
--- a/mycore-viewer/src/main/typescript/modules/base/widgets/canvas/TileImagePage.ts
+++ b/mycore-viewer/src/main/typescript/modules/base/widgets/canvas/TileImagePage.ts
@@ -143,7 +143,6 @@ namespace mycore.viewer.widgets.canvas {
                     // backbuffer content is the same
                     return;
                 } else {
-                    this.abortLoadingTiles();
                     // need to draw the full buffer, because zoom level changed or never drawed before
                     this.vBackBuffer.width = newBackBuffer.size.width * 256;
                     this.vBackBuffer.height = newBackBuffer.size.height * 256;

--- a/mycore-viewer/src/main/typescript/modules/base/widgets/canvas/TileImagePage.ts
+++ b/mycore-viewer/src/main/typescript/modules/base/widgets/canvas/TileImagePage.ts
@@ -178,14 +178,11 @@ namespace mycore.viewer.widgets.canvas {
 
         }
 
-        protected static EMPTY_FUNCTION = () => {
-        };
-
         protected abortLoadingTiles() {
             this.vLoadingTiles.forEach((k, v) => {
-                v.onerror = TileImagePage.EMPTY_FUNCTION;
-                v.onload = TileImagePage.EMPTY_FUNCTION;
-                v.src = '#';
+                delete v.src;
+                delete v.onload;
+                delete v.onerror;
             });
             this.vLoadingTiles.clear();
         }


### PR DESCRIPTION
removed abortLoadingTiles for buffer redraw

[Link to jira](https://mycore.atlassian.net/browse/MCR-2345).

LoadingTiles does not need to be aborted. Because request was already send to Server and the tile might be needed later.
Aborting the tile load has the consequence that the Viewer is sending a request for the same tile multiple times. Especially for the first image, when the viewer ist loading.