### PR TITLE
MCR-2140 Make XPaths unique in editors

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/xml/MCRXPathBuilder.java
+++ b/mycore-base/src/main/java/org/mycore/common/xml/MCRXPathBuilder.java
@@ -25,6 +25,8 @@ import org.jdom2.Namespace;
 import org.jdom2.Parent;
 import org.mycore.common.MCRConstants;
 
+import java.util.List;
+
 /**
  * Builds an absolute XPath expression for a given element or attribute within a JDOM XML structure.
  *
@@ -34,7 +36,7 @@ public class MCRXPathBuilder {
 
     /**
      * Builds an absolute XPath expression for a given element or attribute within a JDOM XML structure.
-     * In case any ancestor element in context is not the first one, the XPath will also contain a position predicate.
+     * For each element that is not the root element, the XPath will also contain a position predicate.
      * For all namespaces commonly used in MyCoRe, their namespace prefixes will be used.
      *
      * @param object a JDOM element or attribute
@@ -52,7 +54,7 @@ public class MCRXPathBuilder {
 
     /**
      * Builds an absolute XPath expression for the given attribute within a JDOM XML structure.
-     * In case any ancestor element in context is not the first one, the XPath will also contain position predicates.
+     * For each element that is not the root element, the XPath will also contain a position predicate.
      * For all namespaces commonly used in MyCoRe, their namespace prefixes will be used.
      *
      * @param attribute a JDOM attribute
@@ -68,7 +70,7 @@ public class MCRXPathBuilder {
 
     /**
      * Builds an absolute XPath expression for the given element within a JDOM XML structure.
-     * In case any ancestor element in context is not the first one, the XPath will also contain position predicates.
+     * For each element that is not the root element, the XPath will also contain a position predicate.
      * For all namespaces commonly used in MyCoRe, their namespace prefixes will be used.
      *
      * @param element a JDOM element
@@ -120,7 +122,9 @@ public class MCRXPathBuilder {
         }
 
         Element parentElement = (Element) parent;
-        int pos = parentElement.getChildren(element.getName(), element.getNamespace()).indexOf(element);
-        return (pos == 0 ? "" : "[" + ++pos + "]");
+        List<Element> siblings = parentElement.getChildren(element.getName(), element.getNamespace());
+        int pos = siblings.indexOf(element) + 1;
+
+        return "[" + pos + "]";
     }
 }

--- a/mycore-base/src/test/java/org/mycore/common/xml/MCRXPathBuilderTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/xml/MCRXPathBuilderTest.java
@@ -48,15 +48,15 @@ public class MCRXPathBuilderTest extends MCRTestCase {
         new Document(root);
 
         assertEquals("/root", MCRXPathBuilder.buildXPath(root));
-        assertEquals("/root/contributor", MCRXPathBuilder.buildXPath(author));
-        assertEquals("/root/title", MCRXPathBuilder.buildXPath(title1));
+        assertEquals("/root/contributor[1]", MCRXPathBuilder.buildXPath(author));
+        assertEquals("/root/title[1]", MCRXPathBuilder.buildXPath(title1));
         assertEquals("/root/title[2]", MCRXPathBuilder.buildXPath(title2));
-        assertEquals("/root/contributor/@role", MCRXPathBuilder.buildXPath(role));
-        assertEquals("/root/contributor/@xml:lang", MCRXPathBuilder.buildXPath(lang));
+        assertEquals("/root/contributor[1]/@role", MCRXPathBuilder.buildXPath(role));
+        assertEquals("/root/contributor[1]/@xml:lang", MCRXPathBuilder.buildXPath(lang));
 
         root.detach();
         assertEquals("root", MCRXPathBuilder.buildXPath(root));
-        assertEquals("root/contributor", MCRXPathBuilder.buildXPath(author));
+        assertEquals("root/contributor[1]", MCRXPathBuilder.buildXPath(author));
     }
 
     @Test
@@ -69,7 +69,7 @@ public class MCRXPathBuilderTest extends MCRTestCase {
         container.addContent(mods);
 
         assertEquals("/container", MCRXPathBuilder.buildXPath(container));
-        assertEquals("/container/mods:mods", MCRXPathBuilder.buildXPath(mods));
-        assertEquals("/container/mods:mods/mods:name", MCRXPathBuilder.buildXPath(name));
+        assertEquals("/container/mods:mods[1]", MCRXPathBuilder.buildXPath(mods));
+        assertEquals("/container/mods:mods[1]/mods:name[1]", MCRXPathBuilder.buildXPath(name));
     }
 }

--- a/mycore-xeditor/src/main/java/org/mycore/frontend/xeditor/MCREditorSubmission.java
+++ b/mycore-xeditor/src/main/java/org/mycore/frontend/xeditor/MCREditorSubmission.java
@@ -77,12 +77,6 @@ public class MCREditorSubmission {
         }
     }
 
-    private void removeXPaths2CheckResubmission(MCRBinding binding) {
-        for (Object node : binding.getBoundNodes()) {
-            xPaths2CheckResubmission.remove(MCRXPathBuilder.buildXPath(node));
-        }
-    }
-
     public void emptyNotResubmittedNodes() throws JDOMException, JaxenException {
         for (String xPath : xPaths2CheckResubmission) {
             MCRBinding binding = new MCRBinding(xPath, false, session.getRootBinding());
@@ -150,9 +144,11 @@ public class MCREditorSubmission {
             value = MCRXMLFunctions.normalizeUnicode(value);
             value = MCRXMLHelper.removeIllegalChars(value);
             binding.setValue(i, value);
+
+            Object node = binding.getBoundNodes().get(i);
+            xPaths2CheckResubmission.remove(MCRXPathBuilder.buildXPath(node));
         }
 
-        removeXPaths2CheckResubmission(binding);
         binding.detach();
     }
 

--- a/mycore-xeditor/src/main/java/org/mycore/frontend/xeditor/MCRXEditorTransformer.java
+++ b/mycore-xeditor/src/main/java/org/mycore/frontend/xeditor/MCRXEditorTransformer.java
@@ -74,6 +74,8 @@ public class MCRXEditorTransformer {
 
     private boolean withinSelectElement = false;
 
+    private boolean withinSelectMultiple = false;
+
     private boolean buildFilterXSL;
 
     public MCRXEditorTransformer(MCREditorSession editorSession, MCRParameterCollector transformationParameters) {
@@ -212,12 +214,17 @@ public class MCRXEditorTransformer {
         return currentBinding.hasValue(value);
     }
 
-    public void toggleWithinSelectElement() {
+    public void toggleWithinSelectElement(String attrMultiple) {
         withinSelectElement = !withinSelectElement;
+        withinSelectMultiple = "multiple".equals(attrMultiple);
     }
 
     public boolean isWithinSelectElement() {
         return withinSelectElement;
+    }
+
+    public boolean isWithinSelectMultiple() {
+        return withinSelectMultiple;
     }
 
     public String replaceXPaths(String text) {

--- a/mycore-xeditor/src/main/resources/xsl/items2options.xsl
+++ b/mycore-xeditor/src/main/resources/xsl/items2options.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xed="http://www.mycore.de/xeditor">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <!-- Transforms output of "classification:editorComplete:*" URIs to xeditor compatible format -->
   <xsl:param name="CurrentLang" />
   <xsl:param name="DefaultLang" />
@@ -28,7 +28,7 @@
     <xsl:variable name="toolTip">
       <xsl:apply-templates select="." mode="toolTip" />
     </xsl:variable>
-    
+
     <xsl:choose>
 	    <xsl:when test="label[lang('x-group')] and not($allSelectable='true')">
 		   	<optgroup title="{$toolTip}">

--- a/mycore-xeditor/src/main/resources/xsl/xeditor-templates.xsl
+++ b/mycore-xeditor/src/main/resources/xsl/xeditor-templates.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xed="http://www.mycore.de/xeditor">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:include href="copynodes.xsl" />
   <xsl:include href="xslInclude:xeditorTemplates" />
 </xsl:stylesheet>

--- a/mycore-xeditor/src/test/java/org/mycore/frontend/xeditor/MCRBindingTest.java
+++ b/mycore-xeditor/src/test/java/org/mycore/frontend/xeditor/MCRBindingTest.java
@@ -154,7 +154,7 @@ public class MCRBindingTest extends MCRTestCase {
         MCRBinding documentBinding = new MCRBinding("document", true, rootBinding);
 
         MCRBinding id = new MCRBinding("name[@id][1]/@id", null, "id", documentBinding);
-        assertEquals("/document/name/@id", id.getAbsoluteXPath());
+        assertEquals("/document/name[1]/@id", id.getAbsoluteXPath());
         assertEquals("n1", id.getValue());
         binding = new MCRBinding("note[@href=concat('#',$id)]", true, documentBinding);
         Element note = (Element) (binding.getBoundNode());

--- a/mycore-xeditor/src/test/java/org/mycore/frontend/xeditor/MCREditorSubmissionTest.java
+++ b/mycore-xeditor/src/test/java/org/mycore/frontend/xeditor/MCREditorSubmissionTest.java
@@ -48,9 +48,9 @@ public class MCREditorSubmissionTest extends MCRTestCase {
         session.setEditedXML(new Document(new MCRNodeBuilder().buildElement(template, null, null)));
 
         Map<String, String[]> submittedValues = new HashMap<>();
-        submittedValues.put("/document/title", new String[] { "Title" });
-        submittedValues.put("/document/author/@firstName", new String[] { "Jim" });
-        submittedValues.put("/document/author/@lastName", new String[] { "" });
+        submittedValues.put("/document/title[1]", new String[] { "Title" });
+        submittedValues.put("/document/author[1]/@firstName", new String[] { "Jim" });
+        submittedValues.put("/document/author[1]/@lastName", new String[] { "" });
         session.getSubmission().setSubmittedValues(submittedValues);
         session.getSubmission().emptyNotResubmittedNodes();
 
@@ -62,7 +62,7 @@ public class MCREditorSubmissionTest extends MCRTestCase {
     }
 
     @Test
-    public void testSubmitCheckbox() throws JaxenException, JDOMException, IOException {
+    public void testSubmitSingleCheckbox() throws JaxenException, JDOMException, IOException {
         String template = "document[@archive='false']";
         MCREditorSession session = new MCREditorSession();
         session.setEditedXML(new Document(new MCRNodeBuilder().buildElement(template, null, null)));
@@ -84,14 +84,48 @@ public class MCREditorSubmissionTest extends MCRTestCase {
     }
 
     @Test
-    public void testSubmitSelectOptions()
+    public void testSubmitSelectSingleOption()
         throws JaxenException, JDOMException, IOException {
-        String template = "document[category='a'][category[2]='b'][category[3]='c']";
+        String template = "document[category='a']";
         MCREditorSession session = new MCREditorSession();
         session.setEditedXML(new Document(new MCRNodeBuilder().buildElement(template, null, null)));
 
         session.getSubmission()
-            .mark2checkResubmission(new MCRBinding("/document/category", true, session.getRootBinding()));
+            .mark2checkResubmission(new MCRBinding("/document/category[1]", true, session.getRootBinding()));
+        session.getSubmission().emptyNotResubmittedNodes();
+
+        List<Element> categories = session.getEditedXML().getRootElement().getChildren("category");
+        assertEquals(1, categories.size());
+        assertEquals("", categories.get(0).getText());
+
+        session.getSubmission()
+            .mark2checkResubmission(new MCRBinding("/document/category[1]", true, session.getRootBinding()));
+
+        Map<String, String[]> submittedValues = new HashMap<>();
+        submittedValues.put("/document/category[1]", new String[] { "b" });
+        session.getSubmission().setSubmittedValues(submittedValues);
+
+        session.getSubmission().emptyNotResubmittedNodes();
+
+        categories = session.getEditedXML().getRootElement().getChildren("category");
+        assertEquals(1, categories.size());
+        assertEquals("b", categories.get(0).getText());
+    }
+
+    @Test
+    public void testSubmitSelectMultipleOptions()
+        throws JaxenException, JDOMException, IOException {
+        String template = "document[category[1]='a'][category[2]='b'][category[3]='c']";
+        MCREditorSession session = new MCREditorSession();
+        session.setEditedXML(new Document(new MCRNodeBuilder().buildElement(template, null, null)));
+
+        session.getSubmission()
+            .mark2checkResubmission(new MCRBinding("/document/category[1]", true, session.getRootBinding()));
+        session.getSubmission()
+            .mark2checkResubmission(new MCRBinding("/document/category[2]", true, session.getRootBinding()));
+        session.getSubmission()
+            .mark2checkResubmission(new MCRBinding("/document/category[3]", true, session.getRootBinding()));
+
         session.getSubmission().emptyNotResubmittedNodes();
 
         List<Element> categories = session.getEditedXML().getRootElement().getChildren("category");
@@ -101,7 +135,11 @@ public class MCREditorSubmissionTest extends MCRTestCase {
         assertEquals("", categories.get(2).getText());
 
         session.getSubmission()
-            .mark2checkResubmission(new MCRBinding("/document/category", true, session.getRootBinding()));
+            .mark2checkResubmission(new MCRBinding("/document/category[1]", true, session.getRootBinding()));
+        session.getSubmission()
+            .mark2checkResubmission(new MCRBinding("/document/category[2]", true, session.getRootBinding()));
+        session.getSubmission()
+            .mark2checkResubmission(new MCRBinding("/document/category[3]", true, session.getRootBinding()));
 
         Map<String, String[]> submittedValues = new HashMap<>();
         submittedValues.put("/document/category", new String[] { "c", "d" });
@@ -116,7 +154,11 @@ public class MCREditorSubmissionTest extends MCRTestCase {
         assertEquals("", categories.get(2).getText());
 
         session.getSubmission()
-            .mark2checkResubmission(new MCRBinding("/document/category", true, session.getRootBinding()));
+            .mark2checkResubmission(new MCRBinding("/document/category[1]", true, session.getRootBinding()));
+        session.getSubmission()
+            .mark2checkResubmission(new MCRBinding("/document/category[2]", true, session.getRootBinding()));
+        session.getSubmission()
+            .mark2checkResubmission(new MCRBinding("/document/category[3]", true, session.getRootBinding()));
 
         submittedValues.clear();
         submittedValues.put("/document/category", new String[] { "a", "b", "c", "d" });

--- a/mycore-xeditor/src/test/java/org/mycore/frontend/xeditor/MCRXEditorTransformerTest.java
+++ b/mycore-xeditor/src/test/java/org/mycore/frontend/xeditor/MCRXEditorTransformerTest.java
@@ -35,9 +35,11 @@ import org.junit.Test;
 import org.mycore.common.MCRSessionMgr;
 import org.mycore.common.MCRTestCase;
 import org.mycore.common.content.MCRContent;
+import org.mycore.common.content.MCRJDOMContent;
 import org.mycore.common.content.MCRSourceContent;
 import org.mycore.common.xml.MCRXMLHelper;
 import org.mycore.common.xsl.MCRParameterCollector;
+import org.mycore.frontend.MCRFrontendUtil;
 import org.xml.sax.SAXException;
 
 /**
@@ -76,13 +78,20 @@ public class MCRXEditorTransformerTest extends MCRTestCase {
         MCRContent transformed = new MCRXEditorTransformer(session, pc).transform(input);
 
         Document expected = MCRSourceContent.getInstance("resource:" + expectedOutputFile).asXML();
+
         MCRBinding binding = new MCRBinding("//input[@type='hidden'][@name='_xed_session']/@value", true,
             new MCRBinding(expected));
         binding.setValue(session.getID() + "-" + session.getChangeTracker().getChangeCounter());
 
+        binding = new MCRBinding("//form/@action", true, new MCRBinding(expected));
+        binding.setValue(MCRFrontendUtil.getBaseURL() + "servlets/XEditor");
+
         String msg = "Transformed output is different to " + expectedOutputFile;
         boolean isEqual = MCRXMLHelper.deepEqual(expected, transformed.asXML());
         if (!isEqual) {
+            System.out.println("---------- expected: ----------");
+            System.out.println(new MCRJDOMContent(expected).asString());
+            System.out.println("---------- transformed: ----------");
             System.out.println(transformed.asString());
         }
         assertTrue(msg, isEqual);
@@ -175,5 +184,11 @@ public class MCRXEditorTransformerTest extends MCRTestCase {
         session = testTransformation("testDefaultValue-editor.xml", "testDefaultValue-input.xml",
             "testDefaultValue-transformed2.xml");
         assertEquals("false", session.getEditedXML().getRootElement().getAttributeValue("publish"));
+    }
+
+    @Test
+    public void testSelect() throws IOException, URISyntaxException, TransformerException, JDOMException,
+        SAXException, JaxenException {
+        testTransformation("testSelect-editor.xml", "testSelect-source.xml", "testSelect-transformed.xml");
     }
 }

--- a/mycore-xeditor/src/test/java/org/mycore/frontend/xeditor/validation/MCRXEditorValidatorTest.java
+++ b/mycore-xeditor/src/test/java/org/mycore/frontend/xeditor/validation/MCRXEditorValidatorTest.java
@@ -102,7 +102,7 @@ public class MCRXEditorValidatorTest extends MCRTestCase {
         assertFalse(session.getValidator().isValid());
         assertEquals("true", session.getVariables().get(MCRXEditorValidator.XED_VALIDATION_FAILED));
 
-        checkResult(session, "/document/year", MCRValidationResults.MARKER_ERROR);
+        checkResult(session, "/document/year[1]", MCRValidationResults.MARKER_ERROR);
         checkResult(session, "/document/year[2]", MCRValidationResults.MARKER_SUCCESS);
         checkResult(session, "/document/year[3]", MCRValidationResults.MARKER_DEFAULT);
     }
@@ -115,7 +115,7 @@ public class MCRXEditorValidatorTest extends MCRTestCase {
         assertFalse(session.getValidator().isValid());
         assertEquals("true", session.getVariables().get(MCRXEditorValidator.XED_VALIDATION_FAILED));
 
-        checkResult(session, "/document/price", MCRValidationResults.MARKER_SUCCESS);
+        checkResult(session, "/document/price[1]", MCRValidationResults.MARKER_SUCCESS);
         checkResult(session, "/document/price[2]", MCRValidationResults.MARKER_ERROR);
         checkResult(session, "/document/price[3]", MCRValidationResults.MARKER_DEFAULT);
     }
@@ -128,7 +128,7 @@ public class MCRXEditorValidatorTest extends MCRTestCase {
         assertFalse(session.getValidator().isValid());
         assertEquals("true", session.getVariables().get(MCRXEditorValidator.XED_VALIDATION_FAILED));
 
-        checkResult(session, "/document/year", MCRValidationResults.MARKER_SUCCESS);
+        checkResult(session, "/document/year[1]", MCRValidationResults.MARKER_SUCCESS);
         checkResult(session, "/document/year[2]", MCRValidationResults.MARKER_ERROR);
         checkResult(session, "/document/year[3]", MCRValidationResults.MARKER_DEFAULT);
     }

--- a/mycore-xeditor/src/test/resources/testBasicInputComponents-transformed1.xml
+++ b/mycore-xeditor/src/test/resources/testBasicInputComponents-transformed1.xml
@@ -2,12 +2,12 @@
 
 <html>
   <body>
-    <form action="http://localhost:8291/servlets/XEditor" method="post">
-      <input name="/document/title" value="" type="text" />
-      <input name="/document/author/firstName" value="" id="firstName" />
-      <input name="/document/author/lastName" value="" type="text" id="lastName" />
-      <textarea name="/document/abstract" />
-      <select name="/document/type" id="type">
+    <form action="/servlets/XEditor" method="post">
+      <input name="/document/title[1]" value="" type="text" />
+      <input name="/document/author[1]/firstName[1]" value="" id="firstName" />
+      <input name="/document/author[1]/lastName[1]" value="" type="text" id="lastName" />
+      <textarea name="/document/abstract[1]" />
+      <select name="/document/type[1]" id="type">
         <optgroup label="Publikation">
           <option value="journal">Zeitschrift</option>
           <option value="article">Artikel</option>
@@ -19,7 +19,7 @@
       <input name="/document/service" id="oai" value="oai" type="checkbox" />
       <input name="/document/service" id="urn" value="urn" type="checkbox" checked="checked" />
       <div style="visibility:hidden">
-        <input value="type service" name="_xed_check" type="hidden" />
+        <input value="type[1] service[1]" name="_xed_check" type="hidden" />
         <input value="1-10" name="_xed_session" type="hidden" />
       </div>
     </form>

--- a/mycore-xeditor/src/test/resources/testBasicInputComponents-transformed2.xml
+++ b/mycore-xeditor/src/test/resources/testBasicInputComponents-transformed2.xml
@@ -3,13 +3,13 @@
 <html>
   <body>
     <form action="http://localhost:8291/servlets/XEditor" method="post">
-      <input name="/document/title" value="Der neue XEditor - Utopie oder Wahnsinn?" type="text" />
-      <input name="/document/author/firstName" value="Frank" id="firstName" />
-      <input name="/document/author/lastName" value="Lützenkirchen" type="text" id="lastName" />
-      <textarea name="/document/abstract">Der XEditor ermöglicht es, HTML-Formulare zur
+      <input name="/document/title[1]" value="Der neue XEditor - Utopie oder Wahnsinn?" type="text" />
+      <input name="/document/author[1]/firstName[1]" value="Frank" id="firstName" />
+      <input name="/document/author[1]/lastName[1]" value="Lützenkirchen" type="text" id="lastName" />
+      <textarea name="/document/abstract[1]">Der XEditor ermöglicht es, HTML-Formulare zur
         Bearbeitung von XML-Dokumenten zu verwenden.
       </textarea>
-      <select name="/document/type" id="type">
+      <select name="/document/type[1]" id="type">
         <optgroup label="Publikation">
           <option value="journal">Zeitschrift</option>
           <option selected="selected" value="article">Artikel</option>
@@ -22,7 +22,7 @@
       <input name="/document/service" checked="checked" id="urn" value="urn" type="checkbox" />
       <div style="visibility:hidden">
         <input value="testBasicInputComponents-source.xml" name="input" type="hidden" />
-        <input value="type service service[2]" name="_xed_check" type="hidden" />
+        <input value="type[1] service[1] service[2]" name="_xed_check" type="hidden" />
         <input value="1-3" name="_xed_session" type="hidden" />
       </div>
     </form>

--- a/mycore-xeditor/src/test/resources/testNamespaces-transformed.xml
+++ b/mycore-xeditor/src/test/resources/testNamespaces-transformed.xml
@@ -3,8 +3,8 @@
 <html>
   <body>
     <form action="http://localhost:8291/servlets/XEditor" method="post">
-      <input name="/mods:mods/mods:titleInfo/mods:title" value="Test" type="text" />
-      <input name="/mods:mods/mods:relatedItem/@xlink:href" value="" type="text" />
+      <input name="/mods:mods/mods:titleInfo[1]/mods:title[1]" value="Test" type="text" />
+      <input name="/mods:mods/mods:relatedItem[1]/@xlink:href" value="" type="text" />
       <div style="visibility:hidden">
         <input value="testNamespaces-source.xml" name="input" type="hidden" />
         <input value="1-1" name="_xed_session" type="hidden" />

--- a/mycore-xeditor/src/test/resources/testPreload-transformed.xml
+++ b/mycore-xeditor/src/test/resources/testPreload-transformed.xml
@@ -4,22 +4,22 @@
   <form action="http://localhost:8291/servlets/XEditor" method="post">
 
     <label for="title">Titel:</label>
-    <input name="/document/title" value="" id="title" />
+    <input name="/document/title[1]" value="" id="title" />
 
     <label for="author.first">Vorname:</label>
-    <input name="/document/author/first" value="" id="author.first" />
-    
+    <input name="/document/author[1]/first[1]" value="" id="author.first" />
+
     <label for="author.last">Nachname:</label>
-    <input name="/document/author/Last" value="" id="author.last" />
+    <input name="/document/author[1]/Last[1]" value="" id="author.last" />
 
     <label for="publisher">Verlag:</label>
-    <input name="/document/origin/publisher" value="" id="publisher" />
+    <input name="/document/origin[1]/publisher[1]" value="" id="publisher" />
 
     <label for="edition">Auflage:</label>
-    <input name="/document/origin/edition" value="" id="edition" />
+    <input name="/document/origin[1]/edition[1]" value="" id="edition" />
 
     <label for="year">Erscheinungsjahr:</label>
-    <input name="/document/origin/year" value="" id="year" />
+    <input name="/document/origin[1]/year[1]" value="" id="year" />
 
     <div style="visibility:hidden">
       <input value="1-0" name="_xed_session" type="hidden" />

--- a/mycore-xeditor/src/test/resources/testRepeats-transformed.xml
+++ b/mycore-xeditor/src/test/resources/testRepeats-transformed.xml
@@ -3,7 +3,7 @@
   <form action="http://localhost:8291/servlets/XEditor" method="post">
     <a id="rep-1" />
     <div>
-      <input name="/document/service" value="oai" type="text" />
+      <input name="/document/service[1]" value="oai" type="text" />
     </div>
     <a id="rep-2" />
     <div>
@@ -11,7 +11,7 @@
     </div>
     <a id="rep-3" />
     <div>
-      <input name="/document/name" value="" type="text" />
+      <input name="/document/name[1]" value="" type="text" />
     </div>
     <button name="_xed_submit_down:/document|1|build|name[(@type = &quot;personal&quot;)]|rep-3" class="btn btn-secondary" type="submit">
       <i class="fas fa-arrow-down" />

--- a/mycore-xeditor/src/test/resources/testSelect-editor.xml
+++ b/mycore-xeditor/src/test/resources/testSelect-editor.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<html>
+  <body>
+    <xed:form xmlns:xed="http://www.mycore.de/xeditor">
+      <xed:source uri="resource:{$input}" />
+      <xed:bind xpath="document">
+        <xed:bind xpath="type">
+          <select id="type">
+            <optgroup label="Publikation">
+              <option value="journal">Zeitschrift</option>
+              <option value="article">Artikel</option>
+            </optgroup>
+            <optgroup label="Sonstiges">
+              <option value="video">Video</option>
+            </optgroup>
+          </select>
+        </xed:bind>
+        <xed:bind xpath="service">
+          <select id="service" multiple="multiple">
+            <option value="doi">DOI vergeben</option>
+            <option value="urn">URN vergeben</option>
+            <option value="epic">ePic vergeben</option>
+          </select>
+        </xed:bind>
+      </xed:bind>
+    </xed:form>
+  </body>
+</html>

--- a/mycore-xeditor/src/test/resources/testSelect-source.xml
+++ b/mycore-xeditor/src/test/resources/testSelect-source.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<document>
+  <type>article</type>
+  <service>doi</service>
+  <service>urn</service>
+</document>

--- a/mycore-xeditor/src/test/resources/testSelect-transformed.xml
+++ b/mycore-xeditor/src/test/resources/testSelect-transformed.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<html>
+  <body>
+    <form action="/servlets/XEditor" method="post">
+      <select name="/document/type[1]" id="type">
+        <optgroup label="Publikation">
+          <option value="journal">Zeitschrift</option>
+          <option selected="selected" value="article">Artikel</option>
+        </optgroup>
+        <optgroup label="Sonstiges">
+          <option value="video">Video</option>
+        </optgroup>
+      </select>
+      <select name="/document/service" id="service" multiple="multiple">
+        <option selected="selected" value="doi">DOI vergeben</option>
+        <option selected="selected" value="urn">URN vergeben</option>
+        <option value="epic">ePic vergeben</option>
+      </select>
+      <div style="visibility:hidden">
+        <input value="testSelect-source.xml" name="input" type="hidden" />
+        <input value="type[1] service[1] service[2]" name="_xed_check" type="hidden" />
+        <input value="1-2" name="_xed_session" type="hidden" />
+      </div>
+    </form>
+  </body>
+</html>

--- a/mycore-xeditor/src/test/resources/testValidation-transformed1.xml
+++ b/mycore-xeditor/src/test/resources/testValidation-transformed1.xml
@@ -4,10 +4,10 @@
   <body>
     <form action="http://localhost:8291/servlets/XEditor" method="post">
       <div class="form-group ">
-        <input name="/document/title" value="Der neue XEditor - Utopie oder Wahnsinn?" type="text" />
+        <input name="/document/title[1]" value="Der neue XEditor - Utopie oder Wahnsinn?" type="text" />
       </div>
       <div class="form-group ">
-        <input name="/document/year" value="" type="text" />
+        <input name="/document/year[1]" value="" type="text" />
       </div>
       <div style="visibility:hidden">
         <input value="testBasicInputComponents-source.xml" name="input" type="hidden" />

--- a/mycore-xeditor/src/test/resources/testValidation-transformed2.xml
+++ b/mycore-xeditor/src/test/resources/testValidation-transformed2.xml
@@ -4,10 +4,10 @@
   <body>
     <form action="http://localhost:8291/servlets/XEditor" method="post">
       <div class="form-group ">
-        <input name="/document/title" value="" type="text" />
+        <input name="/document/title[1]" value="" type="text" />
       </div>
       <div class="form-group ">
-        <input name="/document/year" value="" type="text" />
+        <input name="/document/year[1]" value="" type="text" />
       </div>
       <div style="visibility:hidden">
         <input value="1-1" name="_xed_session" type="hidden" />

--- a/mycore-xeditor/src/test/resources/testValidation-transformed3.xml
+++ b/mycore-xeditor/src/test/resources/testValidation-transformed3.xml
@@ -7,11 +7,11 @@
       <span class="help-inline">Titel erforderlich, muss utopisch sein!</span>
       <div class="form-group mcr-invalid">
         <span class="help-inline">Titel erforderlich, muss utopisch sein!</span>
-        <input name="/document/title" value="" type="text" />
+        <input name="/document/title[1]" value="" type="text" />
         <span class="help-inline">Titel erforderlich, muss utopisch sein!</span>
       </div>
       <div class="form-group ">
-        <input name="/document/year" value="" type="text" />
+        <input name="/document/year[1]" value="" type="text" />
       </div>
       <div style="visibility:hidden">
         <input value="1-1" name="_xed_session" type="hidden" />

--- a/mycore-xeditor/src/test/resources/testXPathSubstitution-transformed.xml
+++ b/mycore-xeditor/src/test/resources/testXPathSubstitution-transformed.xml
@@ -4,7 +4,7 @@
   <form action="http://localhost:8291/servlets/XEditor" method="post">
     <div>
       Diese Publikation mit dem Titel "Der neue XEditor - Utopie oder Wahnsinn?" dürfen Sie als John Doe bearbeiten.
-      <input name="/document/title" value="Der neue XEditor - Utopie oder Wahnsinn?" type="text" size="40" />
+      <input name="/document/title[1]" value="Der neue XEditor - Utopie oder Wahnsinn?" type="text" size="40" />
     </div>
     <div style="visibility:hidden">
       <input value="testBasicInputComponents-source.xml" name="input" type="hidden" />


### PR DESCRIPTION
* Fixed buildXPath() to always use pos predicates for elements
* Updated tests
* Rename tests to be more specific
* Checkboxes may be multiple, xpath [1] still means "all"
* Fixed select multiple handling and added test
* Fixed resubmission check for select multiple values
* Fixed unused imports

[Link to jira](https://mycore.atlassian.net/browse/MCR-2140).
