### PR TITLE
MCR-2390 fixed NPE if no mods:url is given

### DIFF
--- a/mycore-mods/src/main/java/org/mycore/mods/csl/MCRModsItemDataProvider.java
+++ b/mycore-mods/src/main/java/org/mycore/mods/csl/MCRModsItemDataProvider.java
@@ -130,7 +130,7 @@ public class MCRModsItemDataProvider extends MCRItemDataProvider {
                 .map(Element::getTextNormalize)
             .or(() -> Optional.of(MCRFrontendUtil.getBaseURL() + "receive/" + id)
                 .filter(url -> this.wrapper.getMCRObject().getStructure().getDerivates().size() > 0))
-            .or(()-> Optional.of(wrapper.getElement("mods:relatedItem[@type='host']/mods:location/mods:url"))
+            .or(()-> Optional.ofNullable(wrapper.getElement("mods:relatedItem[@type='host']/mods:location/mods:url"))
                         .map(Element::getTextNormalize))
             .ifPresent(idb::URL);
     }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-2390).

Got NPE if no mods:url is given, see stack trace:
```
Caused by: java.lang.NullPointerException
        at java.base/java.util.Objects.requireNonNull(Objects.java:221)
        at java.base/java.util.Optional.<init>(Optional.java:107)
        at java.base/java.util.Optional.of(Optional.java:120)
        at org.mycore.mods.csl.MCRModsItemDataProvider.lambda$processURL$6(MCRModsItemDataProvider.java:133)
        at java.base/java.util.Optional.or(Optional.java:318)
        at org.mycore.mods.csl.MCRModsItemDataProvider.processURL(MCRModsItemDataProvider.java:133)
        at org.mycore.mods.csl.MCRModsItemDataProvider.retrieveItem(MCRModsItemDataProvider.java:96)
        at org.mycore.mods.csl.MCRListModsItemDataProvider.addContent(MCRListModsItemDataProvider.java:62)
        at org.mycore.csl.MCRCSLTransformer.transform(MCRCSLTransformer.java:125)
        ... 57 more
```
