### PR TITLE
MCR-2398 MCRXMLMetadataManager Interface

### DIFF
--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRDefaultXMLMetadataManager.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRDefaultXMLMetadataManager.java
@@ -94,7 +94,7 @@ import org.mycore.datamodel.metadata.history.MCRMetadataHistoryManager;
  * @author Jens Kupferschmidt
  * @author Thomas Scheffler (yagee)
  */
-public class MCRDefaultXMLMetadataManager implements MCRXMLMetadataManager {
+public class MCRDefaultXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
 
     private static final Logger LOGGER = LogManager.getLogger();
 

--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRDefaultXMLMetadataManager.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRDefaultXMLMetadataManager.java
@@ -94,7 +94,7 @@ import org.mycore.datamodel.metadata.history.MCRMetadataHistoryManager;
  * @author Jens Kupferschmidt
  * @author Thomas Scheffler (yagee)
  */
-public class MCRDefaultXMLMetadataManager extends MCRXMLMetadataManager {
+public class MCRDefaultXMLMetadataManager implements MCRXMLMetadataManager {
 
     private static final Logger LOGGER = LogManager.getLogger();
 

--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRDefaultXMLMetadataManager.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRDefaultXMLMetadataManager.java
@@ -1,0 +1,773 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.datamodel.common;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jdom2.Document;
+import org.mycore.common.MCRCache;
+import org.mycore.common.MCRPersistenceException;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.common.config.MCRConfigurationBase;
+import org.mycore.common.config.MCRConfigurationException;
+import org.mycore.common.content.MCRByteContent;
+import org.mycore.common.content.MCRContent;
+import org.mycore.common.content.MCRJDOMContent;
+import org.mycore.datamodel.ifs2.MCRMetadataStore;
+import org.mycore.datamodel.ifs2.MCRMetadataVersion;
+import org.mycore.datamodel.ifs2.MCRObjectIDFileSystemDate;
+import org.mycore.datamodel.ifs2.MCRStore;
+import org.mycore.datamodel.ifs2.MCRStoreCenter;
+import org.mycore.datamodel.ifs2.MCRStoreManager;
+import org.mycore.datamodel.ifs2.MCRStoredMetadata;
+import org.mycore.datamodel.ifs2.MCRVersionedMetadata;
+import org.mycore.datamodel.ifs2.MCRVersioningMetadataStore;
+import org.mycore.datamodel.metadata.MCRObject;
+import org.mycore.datamodel.metadata.MCRObjectID;
+import org.mycore.datamodel.metadata.history.MCRMetadataHistoryManager;
+
+/**
+ * Manages persistence of MCRObject and MCRDerivate xml metadata.
+ * Provides methods to create, retrieve, update and delete object metadata
+ * using IFS2 MCRMetadataStore instances.
+ *
+ * For configuration, at least the following properties must be set:
+ *
+ * MCR.Metadata.Store.BaseDir=/path/to/metadata/dir
+ * MCR.Metadata.Store.SVNBase=file:///path/to/local/svndir/
+ *
+ * Both directories will be created if they do not exist yet.
+ * For each project and type, a subdirectory will be created,
+ * for example %MCR.Metadata.Store.BaseDir%/DocPortal/document/.
+ *
+ * The default IFS2 store is MCRVersioningMetadataStore, which
+ * versions metadata using SVN in local repositories below SVNBase.
+ * If you do not want versioning and would like to have better
+ * performance, change the following property to
+ *
+ * MCR.Metadata.Store.DefaultClass=org.mycore.datamodel.ifs2.MCRMetadataStore
+ *
+ * It is also possible to change individual properties per project and object type
+ * and overwrite the defaults, for example
+ *
+ * MCR.IFS2.Store.Class=org.mycore.datamodel.ifs2.MCRVersioningMetadataStore
+ * MCR.IFS2.Store.SVNRepositoryURL=file:///use/other/location/for/document/versions/
+ * MCR.IFS2.Store.SlotLayout=2-2-2-2
+ *
+ * See documentation of MCRStore and MCRMetadataStore for details.
+ *
+ * @author Frank Lützenkirchen
+ * @author Jens Kupferschmidt
+ * @author Thomas Scheffler (yagee)
+ */
+public class MCRDefaultXMLMetadataManager extends MCRXMLMetadataManager {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    /** The singleton */
+    private static MCRDefaultXMLMetadataManager SINGLETON;
+
+    private HashSet<String> createdStores;
+
+    /**
+     * The default IFS2 Metadata store class to use, set by MCR.Metadata.Store.DefaultClass
+     */
+    @SuppressWarnings("rawtypes")
+    private Class defaultClass;
+
+    /**
+     * The default subdirectory slot layout for IFS2 metadata store, is 4-2-2 for 8-digit IDs,
+     * that means DocPortal_document_0000001 will be stored in the file
+     * DocPortal/document/0000/00/DocPortal_document_00000001.xml
+     */
+    private String defaultLayout;
+
+    /**
+     * The base directory for all IFS2 metadata stores used, set by MCR.Metadata.Store.BaseDir
+     */
+    private Path basePath;
+
+    /**
+     * The local base directory for IFS2 versioned metadata using SVN, set URI by MCR.Metadata.Store.SVNBase
+     */
+    private Path svnPath;
+
+    /**
+     * The local file:// uri of all SVN versioned metadata, set URI by MCR.Metadata.Store.SVNBase
+     */
+    private URI svnBase;
+
+    protected MCRDefaultXMLMetadataManager() {
+        this.createdStores = new HashSet<>();
+        reload();
+    }
+
+    /** Returns the singleton */
+    public static synchronized MCRDefaultXMLMetadataManager instance() {
+        if (SINGLETON == null) {
+            SINGLETON = new MCRDefaultXMLMetadataManager();
+        }
+        return SINGLETON;
+    }
+
+    /**
+     * Reads configuration properties, checks and creates base directories and builds the singleton
+     */
+    public synchronized void reload() {
+        String pattern = MCRConfiguration2.getString("MCR.Metadata.ObjectID.NumberPattern").orElse("0000000000");
+        defaultLayout = pattern.length() - 4 + "-2-2";
+
+        String base = MCRConfiguration2.getStringOrThrow("MCR.Metadata.Store.BaseDir");
+        basePath = Paths.get(base);
+        checkPath(basePath, "base");
+
+        defaultClass = MCRConfiguration2.<MCRVersioningMetadataStore>getClass("MCR.Metadata.Store.DefaultClass")
+            .orElse(MCRVersioningMetadataStore.class);
+        if (MCRVersioningMetadataStore.class.isAssignableFrom(defaultClass)) {
+            try {
+                String svnBaseValue = MCRConfiguration2.getStringOrThrow("MCR.Metadata.Store.SVNBase");
+                if (!svnBaseValue.endsWith("/")) {
+                    svnBaseValue += '/';
+                }
+                svnBase = new URI(svnBaseValue);
+                LOGGER.info("SVN Base: {}", svnBase);
+                if (svnBase.getScheme() == null) {
+                    String workingDirectory = (new File(".")).getAbsolutePath();
+                    URI root = new File(MCRConfiguration2.getString("MCR.datadir").orElse(workingDirectory)).toURI();
+                    URI resolved = root.resolve(svnBase);
+                    LOGGER.warn("Resolved {} to {}", svnBase, resolved);
+                    svnBase = resolved;
+                }
+            } catch (URISyntaxException ex) {
+                String msg = "Syntax error in MCR.Metadata.Store.SVNBase property: " + svnBase;
+                throw new MCRConfigurationException(msg, ex);
+            }
+            if (svnBase.getScheme().equals("file")) {
+                svnPath = Paths.get(svnBase);
+                checkPath(svnPath, "svn");
+            }
+        }
+        closeCreatedStores();
+    }
+
+    private synchronized void closeCreatedStores() {
+        for (String storeId : createdStores) {
+            MCRStoreCenter.instance().removeStore(storeId);
+        }
+        createdStores.clear();
+    }
+
+    /**
+     * Checks the directory configured exists and is readable and writable, or creates it
+     * if it does not exist yet.
+     *
+     * @param path the path to check
+     * @param type metadata store type
+     */
+    private void checkPath(Path path, String type) {
+        if (!Files.exists(path)) {
+            try {
+                if (!Files.exists(Files.createDirectories(path))) {
+                    throw new MCRConfigurationException(
+                        "The metadata store " + type + " directory " + path.toAbsolutePath() + " does not exist.");
+                }
+            } catch (Exception ex) {
+                String msg = "Exception while creating metadata store " + type + " directory " + path.toAbsolutePath();
+                throw new MCRConfigurationException(msg, ex);
+            }
+        } else {
+            if (!Files.isDirectory(path)) {
+                throw new MCRConfigurationException(
+                    "Metadata store " + type + " " + path.toAbsolutePath() + " is a file, not a directory");
+            }
+            if (!Files.isReadable(path)) {
+                throw new MCRConfigurationException(
+                    "Metadata store " + type + " directory " + path.toAbsolutePath() + " is not readable");
+            }
+            if (!Files.isWritable(path)) {
+                throw new MCRConfigurationException(
+                    "Metadata store " + type + " directory " + path.toAbsolutePath() + " is not writeable");
+            }
+        }
+    }
+
+    /**
+     * Returns IFS2 MCRMetadataStore for the given MCRObjectID base, which is {project}_{type}
+     *
+     * @param base the MCRObjectID base, e.g. DocPortal_document
+     */
+    private MCRMetadataStore getStore(String base) {
+        String[] split = base.split("_");
+        return getStore(split[0], split[1], false);
+    }
+
+    /**
+     * Returns IFS2 MCRMetadataStore for the given MCRObjectID base, which is {project}_{type}
+     *
+     * @param base the MCRObjectID base, e.g. DocPortal_document
+     * @param readOnly If readOnly, the store will not be created if it does not exist yet. Instead an exception
+     *                 is thrown.
+     * @return the metadata store
+     */
+    private MCRMetadataStore getStore(String base, boolean readOnly) {
+        String[] split = base.split("_");
+        return getStore(split[0], split[1], readOnly);
+    }
+
+    /**
+     * Returns IFS2 MCRMetadataStore used to store metadata of the given MCRObjectID
+     *
+     * @param mcrid the mycore object identifier
+     * @param readOnly If readOnly, the store will not be created if it does not exist yet. Instead an exception
+     *                 is thrown.
+     * @return the metadata store
+     */
+    private MCRMetadataStore getStore(MCRObjectID mcrid, boolean readOnly) {
+        return getStore(mcrid.getProjectId(), mcrid.getTypeId(), readOnly);
+    }
+
+    /**
+     * Returns IFS2 MCRMetadataStore for the given project and object type
+     *
+     * @param project the project, e.g. DocPortal
+     * @param type the object type, e.g. document
+     * @param readOnly if readOnly, this method will throw an exception if the store does not exist's yet
+     * @return the metadata store
+     */
+    private MCRMetadataStore getStore(String project, String type, boolean readOnly) {
+        String projectType = getStoryKey(project, type);
+        String prefix = "MCR.IFS2.Store." + projectType + ".";
+        String forceXML = MCRConfiguration2.getString(prefix + "ForceXML").orElse(null);
+        if (forceXML == null) {
+            synchronized (this) {
+                forceXML = MCRConfiguration2.getString(prefix + "ForceXML").orElse(null);
+                if (forceXML == null) {
+                    try {
+                        setupStore(project, type, prefix, readOnly);
+                    } catch (ReflectiveOperationException e) {
+                        throw new MCRPersistenceException(
+                            new MessageFormat("Could not instantiate store for project {0} and object type {1}.",
+                                Locale.ROOT).format(new Object[] { project, type }),
+                            e);
+                    }
+                }
+            }
+        }
+        MCRMetadataStore store = MCRStoreManager.getStore(projectType);
+        if (store == null) {
+            throw new MCRPersistenceException(
+                new MessageFormat("Metadata store for project {0} and object type {1} is unconfigured.", Locale.ROOT)
+                    .format(new Object[] { project, type }));
+        }
+        return store;
+    }
+
+    /**
+     * Try to validate a store.
+     * @param base The base ID of a to-be-validated store
+     */
+    public void verifyStore(String base) {
+        MCRMetadataStore store = getStore(base);
+        if (store instanceof MCRVersioningMetadataStore) {
+            LOGGER.info("Verifying SVN history of {}.", base);
+            ((MCRVersioningMetadataStore) (getStore(base))).verify();
+        } else {
+            LOGGER.warn("Cannot verify unversioned store {}!", base);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setupStore(String project, String objectType, String configPrefix, boolean readOnly)
+        throws ReflectiveOperationException {
+        String baseID = getStoryKey(project, objectType);
+        Class<? extends MCRStore> clazz = MCRConfiguration2.<MCRStore>getClass(configPrefix + "Class")
+            .orElseGet(() -> {
+                MCRConfiguration2.set(configPrefix + "Class", defaultClass.getName());
+                return defaultClass;
+            });
+        if (MCRVersioningMetadataStore.class.isAssignableFrom(clazz)) {
+            String property = configPrefix + "SVNRepositoryURL";
+            String svnURL = MCRConfiguration2.getString(property).orElse(null);
+            if (svnURL == null) {
+                String relativeURI = new MessageFormat("{0}/{1}/", Locale.ROOT)
+                    .format(new Object[] { project, objectType });
+                URI repURI = svnBase.resolve(relativeURI);
+                LOGGER.info("Resolved {} to {} for {}", relativeURI, repURI.toASCIIString(), property);
+                MCRConfiguration2.set(property, repURI.toASCIIString());
+                checkAndCreateDirectory(svnPath.resolve(project), project, objectType, configPrefix, readOnly);
+            }
+        }
+
+        Path typePath = basePath.resolve(project).resolve(objectType);
+        checkAndCreateDirectory(typePath, project, objectType, configPrefix, readOnly);
+
+        String slotLayout = MCRConfiguration2.getString(configPrefix + "SlotLayout").orElse(null);
+        if (slotLayout == null) {
+            MCRConfiguration2.set(configPrefix + "SlotLayout", defaultLayout);
+        }
+        MCRConfiguration2.set(configPrefix + "BaseDir", typePath.toAbsolutePath().toString());
+        MCRConfiguration2.set(configPrefix + "ForceXML", String.valueOf(true));
+        String value = "derivate".equals(objectType) ? "mycorederivate" : "mycoreobject";
+        MCRConfiguration2.set(configPrefix + "ForceDocType", value);
+        createdStores.add(baseID);
+        MCRStoreManager.createStore(baseID, clazz);
+    }
+
+    private void checkAndCreateDirectory(Path path, String project, String objectType, String configPrefix,
+        boolean readOnly) {
+        if (Files.exists(path)) {
+            return;
+        }
+        if (readOnly) {
+            throw new MCRPersistenceException(String.format(Locale.ENGLISH,
+                "Path does not exists ''%s'' to set up store for project ''%s'' and objectType ''%s'' "
+                    + "and config prefix ''%s''. We are not willing to create it for an read only operation.",
+                path.toAbsolutePath(), project, objectType, configPrefix));
+        }
+        try {
+            if (!Files.exists(Files.createDirectories(path))) {
+                throw new FileNotFoundException(path.toAbsolutePath() + " does not exists.");
+            }
+        } catch (Exception e) {
+            throw new MCRPersistenceException(String.format(Locale.ENGLISH,
+                "Couldn'e create directory ''%s'' to set up store for project ''%s'' and objectType ''%s'' "
+                    + "and config prefix ''%s''",
+                path.toAbsolutePath(), project, objectType, configPrefix));
+        }
+    }
+
+    private String getStoryKey(String project, String objectType) {
+        return project + "_" + objectType;
+    }
+
+    /**
+     * Stores metadata of a new MCRObject in the persistent store.
+     *
+     * @param mcrid the MCRObjectID
+     * @param xml the xml metadata of the MCRObject
+     * @param lastModified the date of last modification to set
+     * @return the stored metadata as IFS2 object
+     * @throws MCRPersistenceException the object couldn't be created due persistence problems
+     */
+    public MCRStoredMetadata create(MCRObjectID mcrid, Document xml, Date lastModified) throws MCRPersistenceException {
+        return create(mcrid, new MCRJDOMContent(xml), lastModified);
+    }
+
+    /**
+     * Stores metadata of a new MCRObject in the persistent store.
+     *
+     * @param mcrid the MCRObjectID
+     * @param xml the xml metadata of the MCRObject
+     * @param lastModified the date of last modification to set
+     * @return the stored metadata as IFS2 object
+     * @throws MCRPersistenceException the object couldn't be created due persistence problems
+     */
+    public MCRStoredMetadata create(MCRObjectID mcrid, byte[] xml, Date lastModified) throws MCRPersistenceException {
+        return create(mcrid, new MCRByteContent(xml, lastModified.getTime()), lastModified);
+    }
+
+    /**
+     * Stores metadata of a new MCRObject in the persistent store.
+     *
+     * @param mcrid the MCRObjectID
+     * @param xml the xml metadata of the MCRObject
+     * @param lastModified the date of last modification to set
+     * @return the stored metadata as IFS2 object
+     * @throws MCRPersistenceException the object couldn't be created due persistence problems
+     */
+    public MCRStoredMetadata create(MCRObjectID mcrid, MCRContent xml, Date lastModified)
+        throws MCRPersistenceException {
+        try {
+            MCRStoredMetadata sm = getStore(mcrid, false).create(xml, mcrid.getNumberAsInteger());
+            sm.setLastModified(lastModified);
+            MCRConfigurationBase.systemModified();
+            return sm;
+        } catch (Exception exc) {
+            throw new MCRPersistenceException("Error while storing object: " + mcrid, exc);
+        }
+    }
+
+    public void delete(MCRObjectID mcrid) throws MCRPersistenceException {
+        try {
+            getStore(mcrid, true).delete(mcrid.getNumberAsInteger());
+            MCRConfigurationBase.systemModified();
+        } catch (Exception exc) {
+            throw new MCRPersistenceException("Error while deleting object: " + mcrid, exc);
+        }
+    }
+
+    /**
+     * Updates metadata of existing MCRObject in the persistent store.
+     *
+     * @param mcrid the MCRObjectID
+     * @param xml the xml metadata of the MCRObject
+     * @param lastModified the date of last modification to set
+     * @return the stored metadata as IFS2 object
+     * @throws MCRPersistenceException the object couldn't be updated due persistence problems
+     */
+    public MCRStoredMetadata update(MCRObjectID mcrid, Document xml, Date lastModified) throws MCRPersistenceException {
+        return update(mcrid, new MCRJDOMContent(xml), lastModified);
+    }
+
+    /**
+     * Updates metadata of existing MCRObject in the persistent store.
+     *
+     * @param mcrid the MCRObjectID
+     * @param xml the xml metadata of the MCRObject
+     * @param lastModified the date of last modification to set
+     * @return the stored metadata as IFS2 object
+     */
+    public MCRStoredMetadata update(MCRObjectID mcrid, MCRContent xml, Date lastModified)
+        throws MCRPersistenceException {
+        if (!exists(mcrid)) {
+            throw new MCRPersistenceException("Object to update does not exist: " + mcrid);
+        }
+        try {
+            MCRStoredMetadata sm = getStore(mcrid, false).retrieve(mcrid.getNumberAsInteger());
+            sm.update(xml);
+            sm.setLastModified(lastModified);
+            MCRConfigurationBase.systemModified();
+            return sm;
+        } catch (Exception exc) {
+            throw new MCRPersistenceException("Unable to update object " + mcrid, exc);
+        }
+    }
+
+    public MCRContent retrieveContent(MCRObjectID mcrid) throws IOException {
+        MCRContent metadata;
+        MCRStoredMetadata storedMetadata = retrieveStoredMetadata(mcrid);
+        if (storedMetadata == null || storedMetadata.isDeleted()) {
+            return null;
+        }
+        metadata = storedMetadata.getMetadata();
+        return metadata;
+    }
+
+    /**
+     * @param mcrid
+     *            the id of the object to be retrieved
+     * @param revision
+     *            the revision to be returned, specify -1 if you want to
+     *            retrieve the latest revision (includes deleted objects also)
+     * @return a {@link MCRContent} representing the {@link MCRObject} of the
+     *         given revision or <code>null</code> if there is no such object
+     *         with the given revision
+     */
+    public MCRContent retrieveContent(MCRObjectID mcrid, long revision) throws IOException {
+        LOGGER.info("Getting object {} in revision {}", mcrid, revision);
+        MCRMetadataVersion version = getMetadataVersion(mcrid, revision);
+        if (version != null) {
+            return version.retrieve();
+        }
+        return null;
+    }
+
+    /**
+     * Returns the {@link MCRMetadataVersion} of the given id and revision.
+     *
+     * @param mcrId
+     *            the id of the object to be retrieved
+     * @param rev
+     *            the revision to be returned, specify -1 if you want to
+     *            retrieve the latest revision (includes deleted objects also)
+     * @return a {@link MCRMetadataVersion} representing the {@link MCRObject} of the
+     *         given revision or <code>null</code> if there is no such object
+     *         with the given revision
+     * @throws IOException version metadata couldn't be retrieved due an i/o error
+     */
+    private MCRMetadataVersion getMetadataVersion(MCRObjectID mcrId, long rev) throws IOException {
+        MCRVersionedMetadata versionedMetaData = getVersionedMetaData(mcrId);
+        if (versionedMetaData == null) {
+            return null;
+        }
+        return versionedMetaData.getRevision(rev);
+    }
+
+    /**
+     * Lists all versions of this metadata object available in the
+     * subversion repository.
+     *
+     * @param id
+     *            the id of the object to be retrieved
+     * @return {@link List} with all {@link MCRMetadataVersion} of
+     *         the given object or null if the id is null or the metadata
+     *         store doesn't support versioning
+     */
+    public List<MCRMetadataVersion> listRevisions(MCRObjectID id) throws IOException {
+        MCRVersionedMetadata vm = getVersionedMetaData(id);
+        if (vm == null) {
+            return null;
+        }
+        return vm.listVersions();
+    }
+
+    public MCRVersionedMetadata getVersionedMetaData(MCRObjectID id) throws IOException {
+        if (id == null) {
+            return null;
+        }
+        MCRMetadataStore metadataStore = getStore(id, true);
+        if (!(metadataStore instanceof MCRVersioningMetadataStore)) {
+            return null;
+        }
+        MCRVersioningMetadataStore verStore = (MCRVersioningMetadataStore) metadataStore;
+        return verStore.retrieve(id.getNumberAsInteger());
+    }
+
+    /**
+     * Retrieves stored metadata xml as IFS2 metadata object.
+     *
+     * @param mcrid the MCRObjectID
+     */
+    private MCRStoredMetadata retrieveStoredMetadata(MCRObjectID mcrid) throws IOException {
+        return getStore(mcrid, true).retrieve(mcrid.getNumberAsInteger());
+    }
+
+    /**
+     * This method returns the highest stored ID number for a given MCRObjectID
+     * base, or 0 if no object is stored for this type and project.
+     *
+     * @param project
+     *            the project ID part of the MCRObjectID base
+     * @param type
+     *            the type ID part of the MCRObjectID base
+     * @exception MCRPersistenceException
+     *                if a persistence problem is occurred
+     * @return the highest stored ID number as a String
+     */
+    public int getHighestStoredID(String project, String type) {
+        MCRMetadataStore store;
+        try {
+            store = getStore(project, type, true);
+        } catch (MCRPersistenceException persistenceException) {
+            // store does not exists -> return 0
+            return 0;
+        }
+        int highestStoredID = store.getHighestStoredID();
+        //fixes MCR-1534 (IDs once deleted should never be used again)
+        return Math.max(highestStoredID, MCRMetadataHistoryManager.getHighestStoredID(project, type)
+            .map(MCRObjectID::getNumberAsInteger)
+            .orElse(0));
+    }
+
+    /**
+     * Checks if an object with the given MCRObjectID exists in the store.
+     */
+    public boolean exists(MCRObjectID mcrid) throws MCRPersistenceException {
+        try {
+            if (mcrid == null) {
+                return false;
+            }
+            MCRMetadataStore store;
+            try {
+                store = getStore(mcrid, true);
+            } catch (MCRPersistenceException persistenceException) {
+                // the store couldn't be retrieved, the object does not exists
+                return false;
+            }
+            return store.exists(mcrid.getNumberAsInteger());
+        } catch (Exception exc) {
+            throw new MCRPersistenceException("Unable to check if object exists " + mcrid, exc);
+        }
+    }
+
+    /**
+     * Lists all MCRObjectIDs stored for the given base, which is {project}_{type}
+     *
+     * @param base the MCRObjectID base, e.g. DocPortal_document
+     */
+    public List<String> listIDsForBase(String base) {
+        MCRMetadataStore store;
+        try {
+            store = getStore(base, true);
+        } catch (MCRPersistenceException e) {
+            LOGGER.warn("Store for '{}' does not exist.", base);
+            return Collections.emptyList();
+        }
+
+        List<String> list = new ArrayList<>();
+        Iterator<Integer> it = store.listIDs(MCRStore.ASCENDING);
+        String[] idParts = MCRObjectID.getIDParts(base);
+        while (it.hasNext()) {
+            list.add(MCRObjectID.formatID(idParts[0], idParts[1], it.next()));
+        }
+        return list;
+    }
+
+    /**
+     * Lists all MCRObjectIDs stored for the given object type, for all projects
+     *
+     * @param type the MCRObject type, e.g. document
+     * @return list of all mycore identifiers found in the metadata store for the given type
+     */
+    public List<String> listIDsOfType(String type) {
+        try (Stream<Path> streamBasePath = list(basePath)) {
+            return streamBasePath.flatMap(projectPath -> {
+                final String project = projectPath.getFileName().toString();
+                return list(projectPath).flatMap(typePath -> {
+                    if (type.equals(typePath.getFileName().toString())) {
+                        final String base = getStoryKey(project, type);
+                        return listIDsForBase(base).stream();
+                    }
+                    return Stream.empty();
+                });
+            }).collect(Collectors.toList());
+        }
+    }
+
+    /**
+     * Lists all MCRObjectIDs of all types and projects stored in any metadata store
+     *
+     * @return list of all mycore identifiers found in the metadata store
+     */
+    public List<String> listIDs() {
+        try (Stream<Path> streamBasePath = list(basePath)) {
+            return streamBasePath.flatMap(projectPath -> {
+                final String project = projectPath.getFileName().toString();
+                return list(projectPath).flatMap(typePath -> {
+                    final String type = typePath.getFileName().toString();
+                    final String base = getStoryKey(project, type);
+                    return listIDsForBase(base).stream();
+                });
+            }).collect(Collectors.toList());
+        }
+    }
+
+    /**
+     * Returns all stored object types of MCRObjects/MCRDerivates.
+     *
+     * @return collection of object types
+     * @see MCRObjectID#getTypeId()
+     */
+    public Collection<String> getObjectTypes() {
+        try (Stream<Path> streamBasePath = list(basePath)) {
+            return streamBasePath.flatMap(this::list)
+                .map(Path::getFileName)
+                .map(Path::toString)
+                .filter(MCRObjectID::isValidType)
+                .distinct()
+                .collect(Collectors.toSet());
+        }
+    }
+
+    /**
+     * Returns all used base ids of MCRObjects/MCRDerivates.
+     *
+     * @return collection of object types
+     * @see MCRObjectID#getBase()
+     */
+    public Collection<String> getObjectBaseIds() {
+        try (Stream<Path> streamBasePath = list(basePath)) {
+            return streamBasePath.flatMap(this::list)
+                .filter(p -> MCRObjectID.isValidType(p.getFileName().toString()))
+                .map(p -> p.getParent().getFileName() + "_" + p.getFileName())
+                .collect(Collectors.toSet());
+        }
+    }
+
+    /**
+     * Returns the entries of the given path. Throws a MCRException if an I/O-Exceptions occur.
+     *
+     * @return stream of project directories
+     */
+    private Stream<Path> list(Path path) {
+        try {
+            return Files.list(path);
+        } catch (IOException ioException) {
+            throw new MCRPersistenceException(
+                "unable to list files of IFS2 metadata directory " + path.toAbsolutePath(), ioException);
+        }
+    }
+
+    /**
+     * returns an enhanced list of object ids and their last modified date
+     * @param ids MCRObject ids
+     * @throws IOException thrown by {@link MCRObjectIDFileSystemDate}
+     */
+    public List<MCRObjectIDDate> retrieveObjectDates(List<String> ids) throws IOException {
+        List<MCRObjectIDDate> objidlist = new ArrayList<>(ids.size());
+        for (String id : ids) {
+            MCRStoredMetadata sm = this.retrieveStoredMetadata(MCRObjectID.getInstance(id));
+            objidlist.add(new MCRObjectIDFileSystemDate(sm, id));
+        }
+        return objidlist;
+    }
+
+    /**
+     * Returns the time when the xml data of a MCRObject was last modified.
+     * @return output of {@link MCRStoredMetadata#getLastModified()}
+     * @throws IOException thrown by {@link MCRMetadataStore#retrieve(int)}
+     */
+    public long getLastModified(MCRObjectID id) throws IOException {
+        MCRMetadataStore store = getStore(id, true);
+        MCRStoredMetadata metadata = store.retrieve(id.getNumberAsInteger());
+        if (metadata != null) {
+            return metadata.getLastModified().getTime();
+        }
+        return -1;
+    }
+
+    public MCRCache.ModifiedHandle getLastModifiedHandle(final MCRObjectID id, final long expire, TimeUnit unit) {
+        return new StoreModifiedHandle(this, id, expire, unit);
+    }
+
+    private static final class StoreModifiedHandle implements MCRCache.ModifiedHandle {
+        private final MCRDefaultXMLMetadataManager mm;
+
+        private final long expire;
+
+        private final MCRObjectID id;
+
+        private StoreModifiedHandle(MCRDefaultXMLMetadataManager mm, MCRObjectID id, long time, TimeUnit unit) {
+            this.mm = mm;
+            this.expire = unit.toMillis(time);
+            this.id = id;
+        }
+
+        @Override
+        public long getCheckPeriod() {
+            return expire;
+        }
+
+        @Override
+        public long getLastModified() throws IOException {
+            return mm.getLastModified(id);
+        }
+    }
+}

--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRXMLMetadataManager.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRXMLMetadataManager.java
@@ -44,30 +44,32 @@ import org.mycore.datamodel.metadata.MCRObjectID;
 import org.xml.sax.SAXException;
 
 /**
- * Provides an interface for persistence managers of MCRObject and MCRDerivate xml metadata
- * with methods to create, retrieve, update and delete object metadata
- * using IFS2 MCRMetadataStore instances.
+ * Provides an abstract class for persistence managers of MCRObject and MCRDerivate xml
+ * metadata to extend, with methods to perform CRUD operations on object metadata.
  * 
- * The default metadata manager is MCRXMLMetadataManager. If you wish to use
- * another manager implementation instead, change the following property accordingly.
+ * The default xml metadata manager is MCRDefaultXMLMetadataManager. If you wish to use
+ * another manager implementation instead, change the following property accordingly:
  * 
- * MCR.Metadata.Manager.Class=full.qualified.class.name.of.manager.here
+ * MCR.Metadata.Manager.Class=org.mycore.datamodel.common.MCRDefaultXMLMetadataManager
+ * 
+ * Xml metadata managers have a default class they will instantiate for every store.
+ * If you wish to use a different default class, change the following property
+ * accordingly. For example, when using the MCRDefaultXMLMetadataManager:
  *
- * For configuration, at least the following properties must be set:
+ * MCR.Metadata.Store.DefaultClass=org.mycore.datamodel.ifs2.MCRVersioningMetadataStore
  *
+ * The following directory will be used by xml metadata managers to keep up-to-date
+ * store contents in. This directory will be created if it does not exist yet.
+ * 
  * MCR.Metadata.Store.BaseDir=/path/to/metadata/dir
- * MCR.Metadata.Store.SVNBase=file:///path/to/local/svndir/
- *
- * Both directories will be created if they do not exist yet.
- * For each project and type, a subdirectory will be created,
+ * 
+ * For each project and type, subdirectories will be created below this path,
  * for example %MCR.Metadata.Store.BaseDir%/DocPortal/document/.
- *
- * The default IFS2 store is MCRVersioningMetadataStore, which
- * versions metadata using SVN in local repositories below SVNBase.
- * If you do not want versioning and would like to have better
- * performance, change the following property to
- *
- * MCR.Metadata.Store.DefaultClass=org.mycore.datamodel.ifs2.MCRMetadataStore
+ * 
+ * If an SVN-based store is configured, then the following property will be used to
+ * store & manage local SVN repositories:
+ * 
+ * MCR.Metadata.Store.SVNBase=file:///path/to/local/svndir/
  *
  * It is also possible to change individual properties per project and object type
  * and overwrite the defaults, for example
@@ -76,7 +78,8 @@ import org.xml.sax.SAXException;
  * MCR.IFS2.Store.SVNRepositoryURL=file:///use/other/location/for/document/versions/
  * MCR.IFS2.Store.SlotLayout=2-2-2-2
  *
- * See documentation of MCRStore and MCRMetadataStore for details.
+ * See documentation of MCRStore, MCRMetadataStore and the MCRXMLMetadataManager
+ * extensions (e.g. MCRDefaultXMLMetadataManager) for details.
  *
  * @author Christoph Neidahl (OPNA2608)
  */

--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRXMLMetadataManager.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRXMLMetadataManager.java
@@ -46,12 +46,12 @@ import org.xml.sax.SAXException;
 /**
  * Provides an abstract class for persistence managers of MCRObject and MCRDerivate xml
  * metadata to extend, with methods to perform CRUD operations on object metadata.
- * 
+ *
  * The default xml metadata manager is MCRDefaultXMLMetadataManager. If you wish to use
  * another manager implementation instead, change the following property accordingly:
- * 
+ *
  * MCR.Metadata.Manager.Class=org.mycore.datamodel.common.MCRDefaultXMLMetadataManager
- * 
+ *
  * Xml metadata managers have a default class they will instantiate for every store.
  * If you wish to use a different default class, change the following property
  * accordingly. For example, when using the MCRDefaultXMLMetadataManager:
@@ -60,15 +60,15 @@ import org.xml.sax.SAXException;
  *
  * The following directory will be used by xml metadata managers to keep up-to-date
  * store contents in. This directory will be created if it does not exist yet.
- * 
+ *
  * MCR.Metadata.Store.BaseDir=/path/to/metadata/dir
- * 
+ *
  * For each project and type, subdirectories will be created below this path,
  * for example %MCR.Metadata.Store.BaseDir%/DocPortal/document/.
- * 
+ *
  * If an SVN-based store is configured, then the following property will be used to
- * store & manage local SVN repositories:
- * 
+ * store and manage local SVN repositories:
+ *
  * MCR.Metadata.Store.SVNBase=file:///path/to/local/svndir/
  *
  * It is also possible to change individual properties per project and object type

--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRXMLMetadataManager.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRXMLMetadataManager.java
@@ -24,8 +24,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jdom2.Document;
 import org.jdom2.JDOMException;
 import org.mycore.common.MCRCache;
@@ -82,41 +80,29 @@ import org.xml.sax.SAXException;
  *
  * @author Christoph Neidahl (OPNA2608)
  */
-public abstract class MCRXMLMetadataManager {
-    private static final Logger LOGGER = LogManager.getLogger(MCRXMLMetadataManager.class);
-
-    private static MCRXMLMetadataManager implementation;
-
+public interface MCRXMLMetadataManager {
     /**
      * Reads the MCR.Metadata.Manager.Class to instantiate and return the configured xml metadata manager.
      * If MCR.Metadata.Manager.Class is not set, an instance of {@link MCRDefaultXMLMetadataManager} is returned.
      *
      * @return an instance of the configured xml metadata manager if any is set, or MCRDefaultXMLMetadataManager
      */
-    public static synchronized MCRXMLMetadataManager instance() {
-        try {
-            if (implementation == null) {
-                implementation = MCRConfiguration2
-                    .getSingleInstanceOf("MCR.Metadata.Manager.Class", MCRDefaultXMLMetadataManager.class).get();
-            }
-        } catch (Exception e) {
-            LOGGER.error(e);
-        }
-
-        return implementation;
+    static MCRXMLMetadataManager instance() {
+        return MCRConfiguration2.getSingleInstanceOf("MCR.Metadata.Manager.Class", MCRDefaultXMLMetadataManager.class)
+            .get();
     }
 
     /**
      * Reads configuration properties, checks and creates base directories and builds the singleton.
      */
-    public abstract void reload();
+    void reload();
 
     /**
      * Try to validate a store.
      *
      * @param base The base ID of a to-be-validated store
      */
-    public abstract void verifyStore(String base);
+    void verifyStore(String base);
 
     /**
      * Stores metadata of a new MCRObject in the persistent store.
@@ -127,7 +113,8 @@ public abstract class MCRXMLMetadataManager {
      * @return the stored metadata as IFS2 object
      * @throws MCRPersistenceException the object couldn't be created due persistence problems
      */
-    public MCRStoredMetadata create(MCRObjectID mcrid, Document xml, Date lastModified) throws MCRPersistenceException {
+    default MCRStoredMetadata create(MCRObjectID mcrid, Document xml, Date lastModified)
+        throws MCRPersistenceException {
         return create(mcrid, new MCRJDOMContent(xml), lastModified);
     }
 
@@ -140,7 +127,7 @@ public abstract class MCRXMLMetadataManager {
      * @return the stored metadata as IFS2 object
      * @throws MCRPersistenceException the object couldn't be created due persistence problems
      */
-    public MCRStoredMetadata create(MCRObjectID mcrid, byte[] xml, Date lastModified) throws MCRPersistenceException {
+    default MCRStoredMetadata create(MCRObjectID mcrid, byte[] xml, Date lastModified) throws MCRPersistenceException {
         return create(mcrid, new MCRByteContent(xml, lastModified.getTime()), lastModified);
     }
 
@@ -153,14 +140,14 @@ public abstract class MCRXMLMetadataManager {
      * @return the stored metadata as IFS2 object
      * @throws MCRPersistenceException the object couldn't be created due persistence problems
      */
-    public abstract MCRStoredMetadata create(MCRObjectID mcrid, MCRContent xml, Date lastModified)
+    MCRStoredMetadata create(MCRObjectID mcrid, MCRContent xml, Date lastModified)
         throws MCRPersistenceException;
 
-    public void delete(String mcrid) throws MCRPersistenceException {
+    default void delete(String mcrid) throws MCRPersistenceException {
         delete(MCRObjectID.getInstance(mcrid));
     }
 
-    public abstract void delete(MCRObjectID mcrid) throws MCRPersistenceException;
+    void delete(MCRObjectID mcrid) throws MCRPersistenceException;
 
     /**
      * Updates metadata of existing MCRObject in the persistent store.
@@ -171,7 +158,8 @@ public abstract class MCRXMLMetadataManager {
      * @return the stored metadata as IFS2 object
      * @throws MCRPersistenceException the object couldn't be updated due persistence problems
      */
-    public MCRStoredMetadata update(MCRObjectID mcrid, Document xml, Date lastModified) throws MCRPersistenceException {
+    default MCRStoredMetadata update(MCRObjectID mcrid, Document xml, Date lastModified)
+        throws MCRPersistenceException {
         return update(mcrid, new MCRJDOMContent(xml), lastModified);
     }
 
@@ -184,7 +172,7 @@ public abstract class MCRXMLMetadataManager {
      * @return the stored metadata as IFS2 object
      * @throws MCRPersistenceException the object couldn't be created or updated due persistence problems
      */
-    public MCRStoredMetadata createOrUpdate(MCRObjectID mcrid, Document xml, Date lastModified)
+    default MCRStoredMetadata createOrUpdate(MCRObjectID mcrid, Document xml, Date lastModified)
         throws MCRPersistenceException {
         if (exists(mcrid)) {
             return update(mcrid, xml, lastModified);
@@ -201,7 +189,7 @@ public abstract class MCRXMLMetadataManager {
      * @param lastModified the date of last modification to set
      * @return the stored metadata as IFS2 object
      */
-    public MCRStoredMetadata update(MCRObjectID mcrid, byte[] xml, Date lastModified) throws MCRPersistenceException {
+    default MCRStoredMetadata update(MCRObjectID mcrid, byte[] xml, Date lastModified) throws MCRPersistenceException {
         return update(mcrid, new MCRByteContent(xml, lastModified.getTime()), lastModified);
     }
 
@@ -213,7 +201,7 @@ public abstract class MCRXMLMetadataManager {
      * @param lastModified the date of last modification to set
      * @return the stored metadata as IFS2 object
      */
-    public abstract MCRStoredMetadata update(MCRObjectID mcrid, MCRContent xml, Date lastModified)
+    MCRStoredMetadata update(MCRObjectID mcrid, MCRContent xml, Date lastModified)
         throws MCRPersistenceException;
 
     /**
@@ -222,7 +210,7 @@ public abstract class MCRXMLMetadataManager {
      * @param mcrid the MCRObjectID
      * @return null if metadata is not present
      */
-    public Document retrieveXML(MCRObjectID mcrid) throws IOException, JDOMException, SAXException {
+    default Document retrieveXML(MCRObjectID mcrid) throws IOException, JDOMException, SAXException {
         MCRContent metadata = retrieveContent(mcrid);
         return metadata == null ? null : metadata.asXML();
     }
@@ -233,7 +221,7 @@ public abstract class MCRXMLMetadataManager {
      * @param mcrid the MCRObjectID
      * @return null if metadata is not present
      */
-    public byte[] retrieveBLOB(MCRObjectID mcrid) throws IOException {
+    default byte[] retrieveBLOB(MCRObjectID mcrid) throws IOException {
         MCRContent metadata = retrieveContent(mcrid);
         return metadata == null ? null : metadata.asByteArray();
     }
@@ -247,7 +235,7 @@ public abstract class MCRXMLMetadataManager {
      *         <code>null</code> if there is no such object
      * @throws IOException
      */
-    public abstract MCRContent retrieveContent(MCRObjectID mcrid) throws IOException;
+    MCRContent retrieveContent(MCRObjectID mcrid) throws IOException;
 
     /**
      * Retrieves the content of a specific revision of a metadata object.
@@ -262,7 +250,7 @@ public abstract class MCRXMLMetadataManager {
      *         with the given revision
      * @throws IOException
      */
-    public abstract MCRContent retrieveContent(MCRObjectID mcrid, long revision) throws IOException;
+    MCRContent retrieveContent(MCRObjectID mcrid, long revision) throws IOException;
 
     /**
      * Lists all versions of this metadata object available in the
@@ -274,7 +262,7 @@ public abstract class MCRXMLMetadataManager {
      *         the given object or null if the id is null or the metadata
      *         store doesn't support versioning
      */
-    public abstract List<MCRMetadataVersion> listRevisions(MCRObjectID id) throws IOException;
+    List<MCRMetadataVersion> listRevisions(MCRObjectID id) throws IOException;
 
     /**
      * Attempts to retrieve a versioned metadata object for a given ID.
@@ -285,7 +273,7 @@ public abstract class MCRXMLMetadataManager {
      *         or the store for the ID does not do versioning.
      * @throws IOException
      */
-    public abstract MCRVersionedMetadata getVersionedMetaData(MCRObjectID id) throws IOException;
+    MCRVersionedMetadata getVersionedMetaData(MCRObjectID id) throws IOException;
 
     /**
      * This method returns the highest stored ID number for a given MCRObjectID
@@ -299,7 +287,7 @@ public abstract class MCRXMLMetadataManager {
      *                if a persistence problem is occurred
      * @return the highest stored ID number as a String
      */
-    public abstract int getHighestStoredID(String project, String type);
+    int getHighestStoredID(String project, String type);
 
     /**
      * Checks if an object with the given MCRObjectID exists in the store.
@@ -309,7 +297,7 @@ public abstract class MCRXMLMetadataManager {
      * @return true if the ID exists, or false if it doesn't
      * @throws MCRPersistenceException if an error occurred in the store
      */
-    public abstract boolean exists(MCRObjectID mcrid) throws MCRPersistenceException;
+    boolean exists(MCRObjectID mcrid) throws MCRPersistenceException;
 
     /**
      * Lists all MCRObjectIDs stored for the given base, which is {project}_{type}
@@ -318,7 +306,7 @@ public abstract class MCRXMLMetadataManager {
      *            the MCRObjectID base, e.g. DocPortal_document
      * @return List of Strings with all MyCoRe identifiers found in the metadata stores for the given base
      */
-    public abstract List<String> listIDsForBase(String base);
+    List<String> listIDsForBase(String base);
 
     /**
      * Lists all MCRObjectIDs stored for the given object type, for all projects
@@ -327,14 +315,14 @@ public abstract class MCRXMLMetadataManager {
      *            the MCRObject type, e.g. document
      * @return List of Strings with all MyCoRe identifiers found in the metadata store for the given type
      */
-    public abstract List<String> listIDsOfType(String type);
+    List<String> listIDsOfType(String type);
 
     /**
      * Lists all MCRObjectIDs of all types and projects stored in any metadata store
      *
      * @return List of Strings with all MyCoRe identifiers found in the metadata store
      */
-    public abstract List<String> listIDs();
+    List<String> listIDs();
 
     /**
      * Returns all stored object types of MCRObjects/MCRDerivates.
@@ -342,7 +330,7 @@ public abstract class MCRXMLMetadataManager {
      * @return Collection of Strings with all object types
      * @see MCRObjectID#getTypeId()
      */
-    public abstract Collection<String> getObjectTypes();
+    Collection<String> getObjectTypes();
 
     /**
      * Returns all used base ids of MCRObjects/MCRDerivates.
@@ -350,7 +338,7 @@ public abstract class MCRXMLMetadataManager {
      * @return Collection of Strings with all object base identifier
      * @see MCRObjectID#getBase()
      */
-    public abstract Collection<String> getObjectBaseIds();
+    Collection<String> getObjectBaseIds();
 
     /**
      * Lists all objects with their last modification dates.
@@ -358,7 +346,7 @@ public abstract class MCRXMLMetadataManager {
      * @return List of {@link MCRObjectIDDate}
      * @throws IOException
      */
-    public List<MCRObjectIDDate> listObjectDates() throws IOException {
+    default List<MCRObjectIDDate> listObjectDates() throws IOException {
         return retrieveObjectDates(this.listIDs());
     }
 
@@ -368,7 +356,7 @@ public abstract class MCRXMLMetadataManager {
      * @param type type of object
      * @throws IOException
      */
-    public List<MCRObjectIDDate> listObjectDates(String type) throws IOException {
+    default List<MCRObjectIDDate> listObjectDates(String type) throws IOException {
         return retrieveObjectDates(this.listIDsOfType(type));
     }
 
@@ -378,14 +366,14 @@ public abstract class MCRXMLMetadataManager {
      * @param ids MCRObject ids
      * @throws IOException
      */
-    public abstract List<MCRObjectIDDate> retrieveObjectDates(List<String> ids) throws IOException;
+    List<MCRObjectIDDate> retrieveObjectDates(List<String> ids) throws IOException;
 
     /**
      * Returns the time the store's content was last modified
      *
      * @return Last modification date of the MyCoRe system
      */
-    public long getLastModified() {
+    default long getLastModified() {
         return MCRConfigurationBase.getSystemLastModified();
     }
 
@@ -397,7 +385,7 @@ public abstract class MCRXMLMetadataManager {
      * @return the last modification data of the object
      * @throws IOException thrown while retrieving the object from the store
      */
-    public abstract long getLastModified(MCRObjectID id) throws IOException;
+    long getLastModified(MCRObjectID id) throws IOException;
 
     /**
      *
@@ -407,5 +395,5 @@ public abstract class MCRXMLMetadataManager {
      * @param unit
      * @return
      */
-    public abstract MCRCache.ModifiedHandle getLastModifiedHandle(MCRObjectID id, long expire, TimeUnit unit);
+    MCRCache.ModifiedHandle getLastModifiedHandle(MCRObjectID id, long expire, TimeUnit unit);
 }

--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRXMLMetadataManager.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRXMLMetadataManager.java
@@ -18,26 +18,11 @@
 
 package org.mycore.datamodel.common;
 
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.text.MessageFormat;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -47,28 +32,26 @@ import org.mycore.common.MCRCache;
 import org.mycore.common.MCRPersistenceException;
 import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.config.MCRConfigurationBase;
-import org.mycore.common.config.MCRConfigurationException;
 import org.mycore.common.content.MCRByteContent;
 import org.mycore.common.content.MCRContent;
-import org.mycore.common.content.MCRJDOMContent;
 import org.mycore.datamodel.ifs2.MCRMetadataStore;
 import org.mycore.datamodel.ifs2.MCRMetadataVersion;
 import org.mycore.datamodel.ifs2.MCRObjectIDFileSystemDate;
-import org.mycore.datamodel.ifs2.MCRStore;
-import org.mycore.datamodel.ifs2.MCRStoreCenter;
-import org.mycore.datamodel.ifs2.MCRStoreManager;
 import org.mycore.datamodel.ifs2.MCRStoredMetadata;
 import org.mycore.datamodel.ifs2.MCRVersionedMetadata;
-import org.mycore.datamodel.ifs2.MCRVersioningMetadataStore;
 import org.mycore.datamodel.metadata.MCRObject;
 import org.mycore.datamodel.metadata.MCRObjectID;
-import org.mycore.datamodel.metadata.history.MCRMetadataHistoryManager;
 import org.xml.sax.SAXException;
 
 /**
- * Manages persistence of MCRObject and MCRDerivate xml metadata.
- * Provides methods to create, retrieve, update and delete object metadata
+ * Provides an interface for persistence managers of MCRObject and MCRDerivate xml metadata
+ * with methods to create, retrieve, update and delete object metadata
  * using IFS2 MCRMetadataStore instances.
+ * 
+ * The default metadata manager is MCRXMLMetadataManager. If you wish to use
+ * another manager implementation instead, change the following property accordingly.
+ * 
+ * MCR.Metadata.Manager.Class=full.qualified.class.name.of.manager.here
  *
  * For configuration, at least the following properties must be set:
  *
@@ -95,288 +78,39 @@ import org.xml.sax.SAXException;
  *
  * See documentation of MCRStore and MCRMetadataStore for details.
  *
- * @author Frank Lützenkirchen
- * @author Jens Kupferschmidt
- * @author Thomas Scheffler (yagee)
+ * @author Christoph Neidahl (OPNA2608)
  */
-public class MCRXMLMetadataManager {
+public abstract class MCRXMLMetadataManager {
+    private static final Logger LOGGER = LogManager.getLogger(MCRXMLMetadataManager.class);
 
-    private static final Logger LOGGER = LogManager.getLogger();
+    private static MCRXMLMetadataManager implementation;
 
-    /** The singleton */
-    private static MCRXMLMetadataManager SINGLETON;
-
-    private HashSet<String> createdStores;
-
-    /**
-     * The default IFS2 Metadata store class to use, set by MCR.Metadata.Store.DefaultClass
-     */
-    private Class defaultClass;
-
-    /**
-     * The default subdirectory slot layout for IFS2 metadata store, is 4-2-2 for 8-digit IDs,
-     * that means DocPortal_document_0000001 will be stored in the file
-     * DocPortal/document/0000/00/DocPortal_document_00000001.xml
-     */
-    private String defaultLayout;
-
-    /**
-     * The base directory for all IFS2 metadata stores used, set by MCR.Metadata.Store.BaseDir
-     */
-    private Path basePath;
-
-    /**
-     * The local base directory for IFS2 versioned metadata using SVN, set URI by MCR.Metadata.Store.SVNBase
-     */
-    private Path svnPath;
-
-    /**
-     * The local file:// uri of all SVN versioned metadata, set URI by MCR.Metadata.Store.SVNBase
-     */
-    private URI svnBase;
-
-    protected MCRXMLMetadataManager() {
-        this.createdStores = new HashSet<>();
-        reload();
-    }
-
-    /** Returns the singleton */
     public static synchronized MCRXMLMetadataManager instance() {
-        if (SINGLETON == null) {
-            SINGLETON = new MCRXMLMetadataManager();
+        try {
+            if (implementation == null) {
+                implementation = MCRConfiguration2
+                    .getSingleInstanceOf("MCR.Metadata.Manager.Class", MCRDefaultXMLMetadataManager.class).get();
+            }
+        } catch (Exception e) {
+            LOGGER.error(e);
         }
-        return SINGLETON;
+
+        return implementation;
     }
 
     /**
      * Reads configuration properties, checks and creates base directories and builds the singleton
      */
-    public synchronized void reload() {
-        String pattern = MCRConfiguration2.getString("MCR.Metadata.ObjectID.NumberPattern").orElse("0000000000");
-        defaultLayout = pattern.length() - 4 + "-2-2";
-
-        String base = MCRConfiguration2.getStringOrThrow("MCR.Metadata.Store.BaseDir");
-        basePath = Paths.get(base);
-        checkPath(basePath, "base");
-
-        defaultClass = MCRConfiguration2.<MCRVersioningMetadataStore>getClass("MCR.Metadata.Store.DefaultClass")
-            .orElse(MCRVersioningMetadataStore.class);
-        if (MCRVersioningMetadataStore.class.isAssignableFrom(defaultClass)) {
-            try {
-                String svnBaseValue = MCRConfiguration2.getStringOrThrow("MCR.Metadata.Store.SVNBase");
-                if (!svnBaseValue.endsWith("/")) {
-                    svnBaseValue += '/';
-                }
-                svnBase = new URI(svnBaseValue);
-                LOGGER.info("SVN Base: {}", svnBase);
-                if (svnBase.getScheme() == null) {
-                    String workingDirectory = (new File(".")).getAbsolutePath();
-                    URI root = new File(MCRConfiguration2.getString("MCR.datadir").orElse(workingDirectory)).toURI();
-                    URI resolved = root.resolve(svnBase);
-                    LOGGER.warn("Resolved {} to {}", svnBase, resolved);
-                    svnBase = resolved;
-                }
-            } catch (URISyntaxException ex) {
-                String msg = "Syntax error in MCR.Metadata.Store.SVNBase property: " + svnBase;
-                throw new MCRConfigurationException(msg, ex);
-            }
-            if (svnBase.getScheme().equals("file")) {
-                svnPath = Paths.get(svnBase);
-                checkPath(svnPath, "svn");
-            }
-        }
-        closeCreatedStores();
-    }
-
-    private synchronized void closeCreatedStores() {
-        for (String storeId : createdStores) {
-            MCRStoreCenter.instance().removeStore(storeId);
-        }
-        createdStores.clear();
-    }
-
-    /**
-     * Checks the directory configured exists and is readable and writable, or creates it
-     * if it does not exist yet.
-     *
-     * @param path the path to check
-     * @param type metadata store type
-     */
-    private void checkPath(Path path, String type) {
-        if (!Files.exists(path)) {
-            try {
-                if (!Files.exists(Files.createDirectories(path))) {
-                    throw new MCRConfigurationException(
-                        "The metadata store " + type + " directory " + path.toAbsolutePath() + " does not exist.");
-                }
-            } catch (Exception ex) {
-                String msg = "Exception while creating metadata store " + type + " directory " + path.toAbsolutePath();
-                throw new MCRConfigurationException(msg, ex);
-            }
-        } else {
-            if (!Files.isDirectory(path)) {
-                throw new MCRConfigurationException(
-                    "Metadata store " + type + " " + path.toAbsolutePath() + " is a file, not a directory");
-            }
-            if (!Files.isReadable(path)) {
-                throw new MCRConfigurationException(
-                    "Metadata store " + type + " directory " + path.toAbsolutePath() + " is not readable");
-            }
-            if (!Files.isWritable(path)) {
-                throw new MCRConfigurationException(
-                    "Metadata store " + type + " directory " + path.toAbsolutePath() + " is not writeable");
-            }
-        }
-    }
-
-    /**
-     * Returns IFS2 MCRMetadataStore for the given MCRObjectID base, which is {project}_{type}
-     *
-     * @param base the MCRObjectID base, e.g. DocPortal_document
-     */
-    private MCRMetadataStore getStore(String base) {
-        String[] split = base.split("_");
-        return getStore(split[0], split[1], false);
-    }
-
-    /**
-     * Returns IFS2 MCRMetadataStore for the given MCRObjectID base, which is {project}_{type}
-     *
-     * @param base the MCRObjectID base, e.g. DocPortal_document
-     * @param readOnly If readOnly, the store will not be created if it does not exist yet. Instead an exception
-     *                 is thrown.
-     * @return the metadata store
-     */
-    private MCRMetadataStore getStore(String base, boolean readOnly) {
-        String[] split = base.split("_");
-        return getStore(split[0], split[1], readOnly);
-    }
-
-    /**
-     * Returns IFS2 MCRMetadataStore used to store metadata of the given MCRObjectID
-     *
-     * @param mcrid the mycore object identifier
-     * @param readOnly If readOnly, the store will not be created if it does not exist yet. Instead an exception
-     *                 is thrown.
-     * @return the metadata store
-     */
-    private MCRMetadataStore getStore(MCRObjectID mcrid, boolean readOnly) {
-        return getStore(mcrid.getProjectId(), mcrid.getTypeId(), readOnly);
-    }
-
-    /**
-     * Returns IFS2 MCRMetadataStore for the given project and object type
-     *
-     * @param project the project, e.g. DocPortal
-     * @param type the object type, e.g. document
-     * @param readOnly if readOnly, this method will throw an exception if the store does not exist's yet
-     * @return the metadata store
-     */
-    private MCRMetadataStore getStore(String project, String type, boolean readOnly) {
-        String projectType = getStoryKey(project, type);
-        String prefix = "MCR.IFS2.Store." + projectType + ".";
-        String forceXML = MCRConfiguration2.getString(prefix + "ForceXML").orElse(null);
-        if (forceXML == null) {
-            synchronized (this) {
-                forceXML = MCRConfiguration2.getString(prefix + "ForceXML").orElse(null);
-                if (forceXML == null) {
-                    try {
-                        setupStore(project, type, prefix, readOnly);
-                    } catch (ReflectiveOperationException e) {
-                        throw new MCRPersistenceException(
-                            new MessageFormat("Could not instantiate store for project {0} and object type {1}.",
-                                Locale.ROOT).format(new Object[] { project, type }),
-                            e);
-                    }
-                }
-            }
-        }
-        MCRMetadataStore store = MCRStoreManager.getStore(projectType);
-        if (store == null) {
-            throw new MCRPersistenceException(
-                new MessageFormat("Metadata store for project {0} and object type {1} is unconfigured.", Locale.ROOT)
-                    .format(new Object[] { project, type }));
-        }
-        return store;
-    }
+    public abstract void reload();
 
     /**
      * Try to validate a store.
      * @param base The base ID of a to-be-validated store
      */
-    public void verifyStore(String base) {
-        MCRMetadataStore store = getStore(base);
-        if (store instanceof MCRVersioningMetadataStore) {
-            LOGGER.info("Verifying SVN history of {}.", base);
-            ((MCRVersioningMetadataStore) (getStore(base))).verify();
-        } else {
-            LOGGER.warn("Cannot verify unversioned store {}!", base);
-        }
-    }
+    public abstract void verifyStore(String base);
 
-    @SuppressWarnings("unchecked")
-    private void setupStore(String project, String objectType, String configPrefix, boolean readOnly)
-        throws ReflectiveOperationException {
-        String baseID = getStoryKey(project, objectType);
-        Class<? extends MCRStore> clazz = MCRConfiguration2.<MCRStore>getClass(configPrefix + "Class")
-            .orElseGet(() -> {
-                MCRConfiguration2.set(configPrefix + "Class", defaultClass.getName());
-                return defaultClass;
-            });
-        if (MCRVersioningMetadataStore.class.isAssignableFrom(clazz)) {
-            String property = configPrefix + "SVNRepositoryURL";
-            String svnURL = MCRConfiguration2.getString(property).orElse(null);
-            if (svnURL == null) {
-                String relativeURI = new MessageFormat("{0}/{1}/", Locale.ROOT)
-                    .format(new Object[] { project, objectType });
-                URI repURI = svnBase.resolve(relativeURI);
-                LOGGER.info("Resolved {} to {} for {}", relativeURI, repURI.toASCIIString(), property);
-                MCRConfiguration2.set(property, repURI.toASCIIString());
-                checkAndCreateDirectory(svnPath.resolve(project), project, objectType, configPrefix, readOnly);
-            }
-        }
-
-        Path typePath = basePath.resolve(project).resolve(objectType);
-        checkAndCreateDirectory(typePath, project, objectType, configPrefix, readOnly);
-
-        String slotLayout = MCRConfiguration2.getString(configPrefix + "SlotLayout").orElse(null);
-        if (slotLayout == null) {
-            MCRConfiguration2.set(configPrefix + "SlotLayout", defaultLayout);
-        }
-        MCRConfiguration2.set(configPrefix + "BaseDir", typePath.toAbsolutePath().toString());
-        MCRConfiguration2.set(configPrefix + "ForceXML", String.valueOf(true));
-        String value = "derivate".equals(objectType) ? "mycorederivate" : "mycoreobject";
-        MCRConfiguration2.set(configPrefix + "ForceDocType", value);
-        createdStores.add(baseID);
-        MCRStoreManager.createStore(baseID, clazz);
-    }
-
-    private void checkAndCreateDirectory(Path path, String project, String objectType, String configPrefix,
-        boolean readOnly) {
-        if (Files.exists(path)) {
-            return;
-        }
-        if (readOnly) {
-            throw new MCRPersistenceException(String.format(Locale.ENGLISH,
-                "Path does not exists ''%s'' to set up store for project ''%s'' and objectType ''%s'' "
-                    + "and config prefix ''%s''. We are not willing to create it for an read only operation.",
-                path.toAbsolutePath(), project, objectType, configPrefix));
-        }
-        try {
-            if (!Files.exists(Files.createDirectories(path))) {
-                throw new FileNotFoundException(path.toAbsolutePath() + " does not exists.");
-            }
-        } catch (Exception e) {
-            throw new MCRPersistenceException(String.format(Locale.ENGLISH,
-                "Couldn'e create directory ''%s'' to set up store for project ''%s'' and objectType ''%s'' "
-                    + "and config prefix ''%s''",
-                path.toAbsolutePath(), project, objectType, configPrefix));
-        }
-    }
-
-    private String getStoryKey(String project, String objectType) {
-        return project + "_" + objectType;
-    }
+    public abstract MCRStoredMetadata create(MCRObjectID mcrid, Document xml, Date lastModified)
+        throws MCRPersistenceException;
 
     /**
      * Stores metadata of a new MCRObject in the persistent store.
@@ -387,9 +121,8 @@ public class MCRXMLMetadataManager {
      * @return the stored metadata as IFS2 object
      * @throws MCRPersistenceException the object couldn't be created due persistence problems
      */
-    public MCRStoredMetadata create(MCRObjectID mcrid, Document xml, Date lastModified) throws MCRPersistenceException {
-        return create(mcrid, new MCRJDOMContent(xml), lastModified);
-    }
+    public abstract MCRStoredMetadata create(MCRObjectID mcrid, byte[] xml, Date lastModified)
+        throws MCRPersistenceException;
 
     /**
      * Stores metadata of a new MCRObject in the persistent store.
@@ -400,43 +133,14 @@ public class MCRXMLMetadataManager {
      * @return the stored metadata as IFS2 object
      * @throws MCRPersistenceException the object couldn't be created due persistence problems
      */
-    public MCRStoredMetadata create(MCRObjectID mcrid, byte[] xml, Date lastModified) throws MCRPersistenceException {
-        return create(mcrid, new MCRByteContent(xml, lastModified.getTime()), lastModified);
-    }
-
-    /**
-     * Stores metadata of a new MCRObject in the persistent store.
-     *
-     * @param mcrid the MCRObjectID
-     * @param xml the xml metadata of the MCRObject
-     * @param lastModified the date of last modification to set
-     * @return the stored metadata as IFS2 object
-     * @throws MCRPersistenceException the object couldn't be created due persistence problems
-     */
-    public MCRStoredMetadata create(MCRObjectID mcrid, MCRContent xml, Date lastModified)
-        throws MCRPersistenceException {
-        try {
-            MCRStoredMetadata sm = getStore(mcrid, false).create(xml, mcrid.getNumberAsInteger());
-            sm.setLastModified(lastModified);
-            MCRConfigurationBase.systemModified();
-            return sm;
-        } catch (Exception exc) {
-            throw new MCRPersistenceException("Error while storing object: " + mcrid, exc);
-        }
-    }
+    public abstract MCRStoredMetadata create(MCRObjectID mcrid, MCRContent xml, Date lastModified)
+        throws MCRPersistenceException;
 
     public void delete(String mcrid) throws MCRPersistenceException {
         delete(MCRObjectID.getInstance(mcrid));
     }
 
-    public void delete(MCRObjectID mcrid) throws MCRPersistenceException {
-        try {
-            getStore(mcrid, true).delete(mcrid.getNumberAsInteger());
-            MCRConfigurationBase.systemModified();
-        } catch (Exception exc) {
-            throw new MCRPersistenceException("Error while deleting object: " + mcrid, exc);
-        }
-    }
+    public abstract void delete(MCRObjectID mcrid) throws MCRPersistenceException;
 
     /**
      * Updates metadata of existing MCRObject in the persistent store.
@@ -447,9 +151,8 @@ public class MCRXMLMetadataManager {
      * @return the stored metadata as IFS2 object
      * @throws MCRPersistenceException the object couldn't be updated due persistence problems
      */
-    public MCRStoredMetadata update(MCRObjectID mcrid, Document xml, Date lastModified) throws MCRPersistenceException {
-        return update(mcrid, new MCRJDOMContent(xml), lastModified);
-    }
+    public abstract MCRStoredMetadata update(MCRObjectID mcrid, Document xml, Date lastModified)
+        throws MCRPersistenceException;
 
     /**
      * Creates or updates metadata of a MCRObject in the persistent store.
@@ -489,21 +192,8 @@ public class MCRXMLMetadataManager {
      * @param lastModified the date of last modification to set
      * @return the stored metadata as IFS2 object
      */
-    public MCRStoredMetadata update(MCRObjectID mcrid, MCRContent xml, Date lastModified)
-        throws MCRPersistenceException {
-        if (!exists(mcrid)) {
-            throw new MCRPersistenceException("Object to update does not exist: " + mcrid);
-        }
-        try {
-            MCRStoredMetadata sm = getStore(mcrid, false).retrieve(mcrid.getNumberAsInteger());
-            sm.update(xml);
-            sm.setLastModified(lastModified);
-            MCRConfigurationBase.systemModified();
-            return sm;
-        } catch (Exception exc) {
-            throw new MCRPersistenceException("Unable to update object " + mcrid, exc);
-        }
-    }
+    public abstract MCRStoredMetadata update(MCRObjectID mcrid, MCRContent xml, Date lastModified)
+        throws MCRPersistenceException;
 
     /**
      * Retrieves stored metadata xml as JDOM document
@@ -527,15 +217,7 @@ public class MCRXMLMetadataManager {
         return metadata == null ? null : metadata.asByteArray();
     }
 
-    public MCRContent retrieveContent(MCRObjectID mcrid) throws IOException {
-        MCRContent metadata;
-        MCRStoredMetadata storedMetadata = retrieveStoredMetadata(mcrid);
-        if (storedMetadata == null || storedMetadata.isDeleted()) {
-            return null;
-        }
-        metadata = storedMetadata.getMetadata();
-        return metadata;
-    }
+    public abstract MCRContent retrieveContent(MCRObjectID mcrid) throws IOException;
 
     /**
      * @param mcrid
@@ -547,35 +229,7 @@ public class MCRXMLMetadataManager {
      *         given revision or <code>null</code> if there is no such object
      *         with the given revision
      */
-    public MCRContent retrieveContent(MCRObjectID mcrid, long revision) throws IOException {
-        LOGGER.info("Getting object {} in revision {}", mcrid, revision);
-        MCRMetadataVersion version = getMetadataVersion(mcrid, revision);
-        if (version != null) {
-            return version.retrieve();
-        }
-        return null;
-    }
-
-    /**
-     * Returns the {@link MCRMetadataVersion} of the given id and revision.
-     *
-     * @param mcrId
-     *            the id of the object to be retrieved
-     * @param rev
-     *            the revision to be returned, specify -1 if you want to
-     *            retrieve the latest revision (includes deleted objects also)
-     * @return a {@link MCRMetadataVersion} representing the {@link MCRObject} of the
-     *         given revision or <code>null</code> if there is no such object
-     *         with the given revision
-     * @throws IOException version metadata couldn't be retrieved due an i/o error
-     */
-    private MCRMetadataVersion getMetadataVersion(MCRObjectID mcrId, long rev) throws IOException {
-        MCRVersionedMetadata versionedMetaData = getVersionedMetaData(mcrId);
-        if (versionedMetaData == null) {
-            return null;
-        }
-        return versionedMetaData.getRevision(rev);
-    }
+    public abstract MCRContent retrieveContent(MCRObjectID mcrid, long revision) throws IOException;
 
     /**
      * Lists all versions of this metadata object available in the
@@ -587,34 +241,9 @@ public class MCRXMLMetadataManager {
      *         the given object or null if the id is null or the metadata
      *         store doesn't support versioning
      */
-    public List<MCRMetadataVersion> listRevisions(MCRObjectID id) throws IOException {
-        MCRVersionedMetadata vm = getVersionedMetaData(id);
-        if (vm == null) {
-            return null;
-        }
-        return vm.listVersions();
-    }
+    public abstract List<MCRMetadataVersion> listRevisions(MCRObjectID id) throws IOException;
 
-    public MCRVersionedMetadata getVersionedMetaData(MCRObjectID id) throws IOException {
-        if (id == null) {
-            return null;
-        }
-        MCRMetadataStore metadataStore = getStore(id, true);
-        if (!(metadataStore instanceof MCRVersioningMetadataStore)) {
-            return null;
-        }
-        MCRVersioningMetadataStore verStore = (MCRVersioningMetadataStore) metadataStore;
-        return verStore.retrieve(id.getNumberAsInteger());
-    }
-
-    /**
-     * Retrieves stored metadata xml as IFS2 metadata object.
-     *
-     * @param mcrid the MCRObjectID
-     */
-    private MCRStoredMetadata retrieveStoredMetadata(MCRObjectID mcrid) throws IOException {
-        return getStore(mcrid, true).retrieve(mcrid.getNumberAsInteger());
-    }
+    public abstract MCRVersionedMetadata getVersionedMetaData(MCRObjectID id) throws IOException;
 
     /**
      * This method returns the highest stored ID number for a given MCRObjectID
@@ -628,64 +257,19 @@ public class MCRXMLMetadataManager {
      *                if a persistence problem is occurred
      * @return the highest stored ID number as a String
      */
-    public int getHighestStoredID(String project, String type) {
-        MCRMetadataStore store;
-        try {
-            store = getStore(project, type, true);
-        } catch (MCRPersistenceException persistenceException) {
-            // store does not exists -> return 0
-            return 0;
-        }
-        int highestStoredID = store.getHighestStoredID();
-        //fixes MCR-1534 (IDs once deleted should never be used again)
-        return Math.max(highestStoredID, MCRMetadataHistoryManager.getHighestStoredID(project, type)
-            .map(MCRObjectID::getNumberAsInteger)
-            .orElse(0));
-    }
+    public abstract int getHighestStoredID(String project, String type);
 
     /**
      * Checks if an object with the given MCRObjectID exists in the store.
      */
-    public boolean exists(MCRObjectID mcrid) throws MCRPersistenceException {
-        try {
-            if (mcrid == null) {
-                return false;
-            }
-            MCRMetadataStore store;
-            try {
-                store = getStore(mcrid, true);
-            } catch (MCRPersistenceException persistenceException) {
-                // the store couldn't be retrieved, the object does not exists
-                return false;
-            }
-            return store.exists(mcrid.getNumberAsInteger());
-        } catch (Exception exc) {
-            throw new MCRPersistenceException("Unable to check if object exists " + mcrid, exc);
-        }
-    }
+    public abstract boolean exists(MCRObjectID mcrid) throws MCRPersistenceException;
 
     /**
      * Lists all MCRObjectIDs stored for the given base, which is {project}_{type}
      *
      * @param base the MCRObjectID base, e.g. DocPortal_document
      */
-    public List<String> listIDsForBase(String base) {
-        MCRMetadataStore store;
-        try {
-            store = getStore(base, true);
-        } catch (MCRPersistenceException e) {
-            LOGGER.warn("Store for '{}' does not exist.", base);
-            return Collections.emptyList();
-        }
-
-        List<String> list = new ArrayList<>();
-        Iterator<Integer> it = store.listIDs(MCRStore.ASCENDING);
-        String[] idParts = MCRObjectID.getIDParts(base);
-        while (it.hasNext()) {
-            list.add(MCRObjectID.formatID(idParts[0], idParts[1], it.next()));
-        }
-        return list;
-    }
+    public abstract List<String> listIDsForBase(String base);
 
     /**
      * Lists all MCRObjectIDs stored for the given object type, for all projects
@@ -693,38 +277,14 @@ public class MCRXMLMetadataManager {
      * @param type the MCRObject type, e.g. document
      * @return list of all mycore identifiers found in the metadata store for the given type
      */
-    public List<String> listIDsOfType(String type) {
-        try (Stream<Path> streamBasePath = list(basePath)) {
-            return streamBasePath.flatMap(projectPath -> {
-                final String project = projectPath.getFileName().toString();
-                return list(projectPath).flatMap(typePath -> {
-                    if (type.equals(typePath.getFileName().toString())) {
-                        final String base = getStoryKey(project, type);
-                        return listIDsForBase(base).stream();
-                    }
-                    return Stream.empty();
-                });
-            }).collect(Collectors.toList());
-        }
-    }
+    public abstract List<String> listIDsOfType(String type);
 
     /**
      * Lists all MCRObjectIDs of all types and projects stored in any metadata store
      *
      * @return list of all mycore identifiers found in the metadata store
      */
-    public List<String> listIDs() {
-        try (Stream<Path> streamBasePath = list(basePath)) {
-            return streamBasePath.flatMap(projectPath -> {
-                final String project = projectPath.getFileName().toString();
-                return list(projectPath).flatMap(typePath -> {
-                    final String type = typePath.getFileName().toString();
-                    final String base = getStoryKey(project, type);
-                    return listIDsForBase(base).stream();
-                });
-            }).collect(Collectors.toList());
-        }
-    }
+    public abstract List<String> listIDs();
 
     /**
      * Returns all stored object types of MCRObjects/MCRDerivates.
@@ -732,16 +292,7 @@ public class MCRXMLMetadataManager {
      * @return collection of object types
      * @see MCRObjectID#getTypeId()
      */
-    public Collection<String> getObjectTypes() {
-        try (Stream<Path> streamBasePath = list(basePath)) {
-            return streamBasePath.flatMap(this::list)
-                .map(Path::getFileName)
-                .map(Path::toString)
-                .filter(MCRObjectID::isValidType)
-                .distinct()
-                .collect(Collectors.toSet());
-        }
-    }
+    public abstract Collection<String> getObjectTypes();
 
     /**
      * Returns all used base ids of MCRObjects/MCRDerivates.
@@ -749,28 +300,7 @@ public class MCRXMLMetadataManager {
      * @return collection of object types
      * @see MCRObjectID#getBase()
      */
-    public Collection<String> getObjectBaseIds() {
-        try (Stream<Path> streamBasePath = list(basePath)) {
-            return streamBasePath.flatMap(this::list)
-                .filter(p -> MCRObjectID.isValidType(p.getFileName().toString()))
-                .map(p -> p.getParent().getFileName() + "_" + p.getFileName())
-                .collect(Collectors.toSet());
-        }
-    }
-
-    /**
-     * Returns the entries of the given path. Throws a MCRException if an I/O-Exceptions occur.
-     *
-     * @return stream of project directories
-     */
-    private Stream<Path> list(Path path) {
-        try {
-            return Files.list(path);
-        } catch (IOException ioException) {
-            throw new MCRPersistenceException(
-                "unable to list files of IFS2 metadata directory " + path.toAbsolutePath(), ioException);
-        }
-    }
+    public abstract Collection<String> getObjectBaseIds();
 
     /**
      * lists objects and their last modified date.
@@ -792,14 +322,7 @@ public class MCRXMLMetadataManager {
      * @param ids MCRObject ids
      * @throws IOException thrown by {@link MCRObjectIDFileSystemDate}
      */
-    public List<MCRObjectIDDate> retrieveObjectDates(List<String> ids) throws IOException {
-        List<MCRObjectIDDate> objidlist = new ArrayList<>(ids.size());
-        for (String id : ids) {
-            MCRStoredMetadata sm = this.retrieveStoredMetadata(MCRObjectID.getInstance(id));
-            objidlist.add(new MCRObjectIDFileSystemDate(sm, id));
-        }
-        return objidlist;
-    }
+    public abstract List<MCRObjectIDDate> retrieveObjectDates(List<String> ids) throws IOException;
 
     /**
      * Returns the time the store's content was last modified
@@ -813,37 +336,7 @@ public class MCRXMLMetadataManager {
      * @return output of {@link MCRStoredMetadata#getLastModified()}
      * @throws IOException thrown by {@link MCRMetadataStore#retrieve(int)}
      */
-    public long getLastModified(MCRObjectID id) throws IOException {
-        MCRMetadataStore store = getStore(id, true);
-        MCRStoredMetadata metadata = store.retrieve(id.getNumberAsInteger());
-        if (metadata != null) {
-            return metadata.getLastModified().getTime();
-        }
-        return -1;
-    }
+    public abstract long getLastModified(MCRObjectID id) throws IOException;
 
-    public MCRCache.ModifiedHandle getLastModifiedHandle(final MCRObjectID id, final long expire, TimeUnit unit) {
-        return new StoreModifiedHandle(id, expire, unit);
-    }
-
-    private static final class StoreModifiedHandle implements MCRCache.ModifiedHandle {
-        private final long expire;
-
-        private final MCRObjectID id;
-
-        private StoreModifiedHandle(MCRObjectID id, long time, TimeUnit unit) {
-            this.expire = unit.toMillis(time);
-            this.id = id;
-        }
-
-        @Override
-        public long getCheckPeriod() {
-            return expire;
-        }
-
-        @Override
-        public long getLastModified() throws IOException {
-            return MCRXMLMetadataManager.instance().getLastModified(id);
-        }
-    }
+    public abstract MCRCache.ModifiedHandle getLastModifiedHandle(MCRObjectID id, long expire, TimeUnit unit);
 }

--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRXMLMetadataManagerAdapter.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRXMLMetadataManagerAdapter.java
@@ -1,0 +1,262 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.datamodel.common;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.mycore.common.MCRCache;
+import org.mycore.common.MCRPersistenceException;
+import org.mycore.common.content.MCRContent;
+import org.mycore.datamodel.ifs2.MCRMetadataVersion;
+import org.mycore.datamodel.ifs2.MCRStoredMetadata;
+import org.mycore.datamodel.ifs2.MCRVersionedMetadata;
+import org.mycore.datamodel.metadata.MCRObject;
+import org.mycore.datamodel.metadata.MCRObjectID;
+
+/**
+ * Provides an abstract class for persistence managers of MCRObject and MCRDerivate xml
+ * metadata to extend, with methods to perform CRUD operations on object metadata.
+ *
+ * The default xml metadata manager is {@link MCRDefaultXMLMetadataManager}. If you wish to use
+ * another manager implementation instead, change the following property accordingly:
+ *
+ * MCR.Metadata.Manager.Class=org.mycore.datamodel.common.MCRDefaultXMLMetadataManager
+ *
+ * Xml metadata managers have a default class they will instantiate for every store.
+ * If you wish to use a different default class, change the following property
+ * accordingly. For example, when using the MCRDefaultXMLMetadataManager:
+ *
+ * MCR.Metadata.Store.DefaultClass=org.mycore.datamodel.ifs2.MCRVersioningMetadataStore
+ *
+ * The following directory will be used by xml metadata managers to keep up-to-date
+ * store contents in. This directory will be created if it does not exist yet.
+ *
+ * MCR.Metadata.Store.BaseDir=/path/to/metadata/dir
+ *
+ * For each project and type, subdirectories will be created below this path,
+ * for example %MCR.Metadata.Store.BaseDir%/DocPortal/document/.
+ *
+ * If an SVN-based store is configured, then the following property will be used to
+ * store and manage local SVN repositories:
+ *
+ * MCR.Metadata.Store.SVNBase=file:///path/to/local/svndir/
+ *
+ * It is also possible to change individual properties per project and object type
+ * and overwrite the defaults, for example
+ *
+ * MCR.IFS2.Store.Class=org.mycore.datamodel.ifs2.MCRVersioningMetadataStore
+ * MCR.IFS2.Store.SVNRepositoryURL=file:///use/other/location/for/document/versions/
+ * MCR.IFS2.Store.SlotLayout=2-2-2-2
+ *
+ * See documentation of MCRStore, MCRMetadataStore and the MCRXMLMetadataManager
+ * extensions (e.g. MCRDefaultXMLMetadataManager) for details.
+ *
+ * @author Christoph Neidahl (OPNA2608)
+ */
+public interface MCRXMLMetadataManagerAdapter {
+
+    /**
+     * Reads configuration properties, checks and creates base directories and builds the singleton.
+     */
+    void reload();
+
+    /**
+     * Try to validate a store.
+     *
+     * @param base The base ID of a to-be-validated store
+     */
+    void verifyStore(String base);
+
+    /**
+     * Stores metadata of a new MCRObject in the persistent store.
+     *
+     * @param mcrid the MCRObjectID
+     * @param xml the xml metadata of the MCRObject
+     * @param lastModified the date of last modification to set
+     * @return the stored metadata as IFS2 object
+     * @throws MCRPersistenceException the object couldn't be created due persistence problems
+     */
+    MCRStoredMetadata create(MCRObjectID mcrid, MCRContent xml, Date lastModified)
+        throws MCRPersistenceException;
+
+    /**
+     * Delete metadata in store.
+     * 
+     * @param mcrid the MCRObjectID
+     * @throws MCRPersistenceException if an error occurs during the deletion
+     */
+    void delete(MCRObjectID mcrid) throws MCRPersistenceException;
+
+    /**
+     * Updates metadata of existing MCRObject in the persistent store.
+     *
+     * @param mcrid the MCRObjectID
+     * @param xml the xml metadata of the MCRObject
+     * @param lastModified the date of last modification to set
+     * @return the stored metadata as IFS2 object
+     */
+    MCRStoredMetadata update(MCRObjectID mcrid, MCRContent xml, Date lastModified)
+        throws MCRPersistenceException;
+
+    /**
+     * Retrieves the (latest) content of a metadata object.
+     *
+     * @param mcrid
+     *            the id of the object to be retrieved
+     * @return a {@link MCRContent} representing the {@link MCRObject} or
+     *         <code>null</code> if there is no such object
+     * @throws IOException
+     */
+    MCRContent retrieveContent(MCRObjectID mcrid) throws IOException;
+
+    /**
+     * Retrieves the content of a specific revision of a metadata object.
+     *
+     * @param mcrid
+     *            the id of the object to be retrieved
+     * @param revision
+     *            the revision to be returned, specify -1 if you want to
+     *            retrieve the latest revision (includes deleted objects also)
+     * @return a {@link MCRContent} representing the {@link MCRObject} of the
+     *         given revision or <code>null</code> if there is no such object
+     *         with the given revision
+     * @throws IOException
+     */
+    MCRContent retrieveContent(MCRObjectID mcrid, long revision) throws IOException;
+
+    /**
+     * Lists all versions of this metadata object available in the
+     * subversion repository.
+     *
+     * @param id
+     *            the id of the object to be retrieved
+     * @return {@link List} with all {@link MCRMetadataVersion} of
+     *         the given object or null if the id is null or the metadata
+     *         store doesn't support versioning
+     */
+    List<MCRMetadataVersion> listRevisions(MCRObjectID id) throws IOException;
+
+    /**
+     * Attempts to retrieve a versioned metadata object for a given ID.
+     *
+     * @param id
+     *            the id of the object to be retrieved
+     * @return {@link MCRVersionedMetadata} object for the given ID, or null if the ID is null
+     *         or the store for the ID does not do versioning.
+     * @throws IOException
+     */
+    MCRVersionedMetadata getVersionedMetaData(MCRObjectID id) throws IOException;
+
+    /**
+     * This method returns the highest stored ID number for a given MCRObjectID
+     * base, or 0 if no object is stored for this type and project.
+     *
+     * @param project
+     *            the project ID part of the MCRObjectID base
+     * @param type
+     *            the type ID part of the MCRObjectID base
+     * @exception MCRPersistenceException
+     *                if a persistence problem is occurred
+     * @return the highest stored ID number as a String
+     */
+    int getHighestStoredID(String project, String type);
+
+    /**
+     * Checks if an object with the given MCRObjectID exists in the store.
+     *
+     * @param mcrid
+     *            the MCRObjectID to check
+     * @return true if the ID exists, or false if it doesn't
+     * @throws MCRPersistenceException if an error occurred in the store
+     */
+    boolean exists(MCRObjectID mcrid) throws MCRPersistenceException;
+
+    /**
+     * Lists all MCRObjectIDs stored for the given base, which is {project}_{type}
+     *
+     * @param base
+     *            the MCRObjectID base, e.g. DocPortal_document
+     * @return List of Strings with all MyCoRe identifiers found in the metadata stores for the given base
+     */
+    List<String> listIDsForBase(String base);
+
+    /**
+     * Lists all MCRObjectIDs stored for the given object type, for all projects
+     *
+     * @param type
+     *            the MCRObject type, e.g. document
+     * @return List of Strings with all MyCoRe identifiers found in the metadata store for the given type
+     */
+    List<String> listIDsOfType(String type);
+
+    /**
+     * Lists all MCRObjectIDs of all types and projects stored in any metadata store
+     *
+     * @return List of Strings with all MyCoRe identifiers found in the metadata store
+     */
+    List<String> listIDs();
+
+    /**
+     * Returns all stored object types of MCRObjects/MCRDerivates.
+     *
+     * @return Collection of Strings with all object types
+     * @see MCRObjectID#getTypeId()
+     */
+    Collection<String> getObjectTypes();
+
+    /**
+     * Returns all used base ids of MCRObjects/MCRDerivates.
+     *
+     * @return Collection of Strings with all object base identifier
+     * @see MCRObjectID#getBase()
+     */
+    Collection<String> getObjectBaseIds();
+
+    /**
+     * Returns an enhanced list of object ids and their last modified date
+     *
+     * @param ids MCRObject ids
+     * @throws IOException
+     */
+    List<MCRObjectIDDate> retrieveObjectDates(List<String> ids) throws IOException;
+
+    /**
+     * Returns the time when the xml data of a MCRObject was last modified.
+     *
+     * @param id
+     *            the MCRObjectID of an object
+     * @return the last modification data of the object
+     * @throws IOException thrown while retrieving the object from the store
+     */
+    long getLastModified(MCRObjectID id) throws IOException;
+
+    /**
+     *
+     *
+     * @param id
+     * @param expire
+     * @param unit
+     * @return
+     */
+    MCRCache.ModifiedHandle getLastModifiedHandle(MCRObjectID id, long expire, TimeUnit unit);
+}

--- a/mycore-base/src/main/resources/config/mycore.properties
+++ b/mycore-base/src/main/resources/config/mycore.properties
@@ -173,6 +173,9 @@ MCR.Access.Strategy.CreatorPermissions=writedb
 # Set last modified date of the metadata file in the store to the exactly same timestamp as the SVN commit
   MCR.IFS2.SyncLastModifiedOnSVNCommit=true
 
+# Which metadata manager to use (dictates the available stores)
+  MCR.Metadata.Manager.Class=org.mycore.datamodel.common.MCRDefaultXMLMetadataManager
+
 # Metadata store for derivate XML
   MCR.IFS2.Store.derivate.Class=org.mycore.datamodel.ifs2.MCRVersioningMetadataStore
   MCR.IFS2.Store.derivate.SlotLayout=4-2-2

--- a/mycore-base/src/test/java/org/mycore/datamodel/common/MCRXMLMetadataManagerTest.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/common/MCRXMLMetadataManagerTest.java
@@ -215,6 +215,7 @@ public class MCRXMLMetadataManagerTest extends MCRStoreTestCase {
     @Override
     protected Map<String, String> getTestProperties() {
         Map<String, String> testProperties = super.getTestProperties();
+        testProperties.put("MCR.Metadata.Manager.Class", MCRDefaultXMLMetadataManager.class.getCanonicalName());
         testProperties.put("MCR.Metadata.Type.document", "true");
         testProperties.put("MCR.Metadata.ObjectID.NumberPattern", "00000000");
         return testProperties;


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-2398).

~~Still need to test & find a good solution for code calling `MCRXMLMetadataManager.instance()` directly vs `MCRAbstractXMLMetadataManager.getManager()` reading the configured XML Metadata Manager class and instantiating it via its `instance()` method.~~

Fixed by moving MCRXMLMetadataManager -> MCRDefaultXMLMetadataManager & MCRAbstractXMLMetadataManager -> MCRXMLMetadataManager.