### PR TITLE
MCR-2440 update image-tiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1466,7 +1466,7 @@ Applications based on MyCoRe use a common core, which provides the functionality
       <dependency>
         <groupId>org.mycore.iview2</groupId>
         <artifactId>image-tiler</artifactId>
-        <version>2.2</version>
+        <version>2.3</version>
       </dependency>
       <dependency>
         <groupId>org.mycore.mets</groupId>


### PR DESCRIPTION
adds support for 16 bit grayscale images

[Link to jira](https://mycore.atlassian.net/browse/MCR-2440).
