### PR TITLE
MCR-2448 activated trace listener causes ClassCastException in saxon transformations

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/content/transformer/MCRXSLTransformer.java
+++ b/mycore-base/src/main/java/org/mycore/common/content/transformer/MCRXSLTransformer.java
@@ -304,7 +304,8 @@ public class MCRXSLTransformer extends MCRParameterizedTransformer {
             TransformerHandler handler = tFactory.newTransformerHandler(template);
             parameterCollector.setParametersTo(handler.getTransformer());
             handler.getTransformer().setErrorListener(errorListener);
-            if (TRACE_LISTENER_ENABLED) {
+            // trace listener only works with xalan
+            if (TRACE_LISTENER_ENABLED && handler.getTransformer() instanceof TransformerImpl) {
                 TransformerImpl transformer = (TransformerImpl) handler.getTransformer();
                 TraceManager traceManager = transformer.getTraceManager();
                 try {


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-2448).
