### PR TITLE
MCR-2452 Add libraries neccesary to render JPEG 2000 images in PDF fi…

### DIFF
--- a/mycore-iview2/pom.xml
+++ b/mycore-iview2/pom.xml
@@ -51,7 +51,17 @@
       <artifactId>log4j-api</artifactId>
     </dependency>
     <dependency>
-      <!-- needed for some PDF documents -->
+      <!-- needed for PDF documents with JPEG2000 images-->
+      <groupId>com.github.jai-imageio</groupId>
+      <artifactId>jai-imageio-core</artifactId>
+    </dependency>
+    <dependency>
+      <!-- needed for PDF documents with JPEG2000 images-->
+      <groupId>com.github.jai-imageio</groupId>
+      <artifactId>jai-imageio-jpeg2000</artifactId>
+    </dependency>
+    <dependency>
+      <!-- needed for PDF documents with JBIG2 images-->
       <groupId>org.apache.pdfbox</groupId>
       <artifactId>jbig2-imageio</artifactId>
     </dependency>

--- a/mycore-media/pom.xml
+++ b/mycore-media/pom.xml
@@ -37,6 +37,17 @@
       <artifactId>fontbox</artifactId>
     </dependency>
     <dependency>
+      <!-- needed for PDF documents with JPEG2000 images-->
+      <groupId>com.github.jai-imageio</groupId>
+      <artifactId>jai-imageio-core</artifactId>
+    </dependency>
+    <dependency>
+      <!-- needed for PDF documents with JPEG2000 images-->
+      <groupId>com.github.jai-imageio</groupId>
+      <artifactId>jai-imageio-jpeg2000</artifactId>
+    </dependency>
+    <dependency>
+      <!-- needed for PDF documents with JBIG2 images-->
       <groupId>org.apache.pdfbox</groupId>
       <artifactId>jbig2-imageio</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1573,6 +1573,18 @@ Applications based on MyCoRe use a common core, which provides the functionality
         <scope>runtime</scope>
       </dependency>
       <dependency>
+        <groupId>com.github.jai-imageio</groupId>
+        <artifactId>jai-imageio-core</artifactId>
+        <version>1.4.0</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.github.jai-imageio</groupId>
+        <artifactId>jai-imageio-jpeg2000</artifactId>
+        <version>1.4.0</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
         <groupId>org.apache.pdfbox</groupId>
         <artifactId>jbig2-imageio</artifactId>
         <version>3.0.3</version>


### PR DESCRIPTION
MCR-2452: JPEG 2000 images in PDF files aren't rendered during thumbnail generation

[Link to jira](https://mycore.atlassian.net/browse/MCR-2452).
