### PR TITLE
MCR-2562 MyCoRe Storage Layout Derivate Implementation in the OCFLXMLMetadataManager

### DIFF
--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/MCROCFLXMLMetadataManager.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/MCROCFLXMLMetadataManager.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -77,6 +78,8 @@ public class MCROCFLXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
         Map.entry(MESSAGE_DELETED, MCROCFLMetadataVersion.DELETED)));
 
     public static final String MCR_OBJECT_ID_PREFIX = "mcrobject:";
+
+    public static final String MCR_DERIVATE_ID_PREFIX = "mcrderivate:";
 
     private String repositoryKey = "Default";
 
@@ -175,7 +178,8 @@ public class MCROCFLXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
     }
 
     private String getObjName(String mcrid) {
-        return MCR_OBJECT_ID_PREFIX + mcrid;
+        String objectType = MCRObjectID.getIDParts(mcrid.trim())[1].toLowerCase(Locale.ROOT).intern();
+        return "derivate".equals(objectType) ? MCR_DERIVATE_ID_PREFIX + mcrid : MCR_OBJECT_ID_PREFIX + mcrid;
     }
 
     private String buildFilePath(MCRObjectID objName) {

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/MCROCFLXMLMetadataManager.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/MCROCFLXMLMetadataManager.java
@@ -268,10 +268,19 @@ public class MCROCFLXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
         }).collect(Collectors.toList());
     }
 
+    private boolean isMetadata(String id) {
+        return id.startsWith(MCR_OBJECT_ID_PREFIX) || id.startsWith(MCR_DERIVATE_ID_PREFIX);
+    }
+
+    private String substrPrefix(String id) {
+        return id.startsWith(MCR_DERIVATE_ID_PREFIX) ? id.substring(MCR_DERIVATE_ID_PREFIX.length())
+            : id.substring(MCR_OBJECT_ID_PREFIX.length());
+    }
+
     public IntStream getStoredIDs(String project, String type) throws MCRPersistenceException {
         return getRepository().listObjectIds()
-            .filter(id -> id.startsWith(MCR_OBJECT_ID_PREFIX))
-            .map(id -> id.substring(MCR_OBJECT_ID_PREFIX.length()))
+            .filter(this::isMetadata)
+            .map(this::substrPrefix)
             .filter(id -> id.startsWith(project + "_" + type))
             .mapToInt((fullId) -> Integer.parseInt(fullId.substring(project.length() + type.length() + 2))).sorted();
     }
@@ -290,9 +299,9 @@ public class MCROCFLXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
     @Override
     public List<String> listIDsForBase(String base) {
         return getRepository().listObjectIds()
-            .filter(id -> id.startsWith(MCR_OBJECT_ID_PREFIX))
+            .filter(this::isMetadata)
             .filter(this::isNotDeleted)
-            .map(id -> id.substring(MCR_OBJECT_ID_PREFIX.length()))
+            .map(this::substrPrefix)
             .filter(s -> s.startsWith(base))
             .collect(Collectors.toList());
 
@@ -301,9 +310,9 @@ public class MCROCFLXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
     @Override
     public List<String> listIDsOfType(String type) {
         return getRepository().listObjectIds()
-            .filter(id -> id.startsWith(MCR_OBJECT_ID_PREFIX))
+            .filter(this::isMetadata)
             .filter(this::isNotDeleted)
-            .map(id -> id.substring(MCR_OBJECT_ID_PREFIX.length()))
+            .map(this::substrPrefix)
             .filter(s -> type.equals(s.split("_")[1]))
             .collect(Collectors.toList());
     }
@@ -313,9 +322,9 @@ public class MCROCFLXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
         OcflRepository repo = getRepository();
         return repo
             .listObjectIds()
-            .filter(id -> id.startsWith(MCR_OBJECT_ID_PREFIX))
+            .filter(this::isMetadata)
             .filter(this::isNotDeleted)
-            .map(id -> id.substring(MCR_OBJECT_ID_PREFIX.length()))
+            .map(this::substrPrefix)
             .collect(Collectors.toList());
     }
 
@@ -328,8 +337,8 @@ public class MCROCFLXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
     public Collection<String> getObjectTypes() {
         return getRepository()
             .listObjectIds()
-            .filter(id -> id.startsWith(MCR_OBJECT_ID_PREFIX))
-            .map(id -> id.substring(MCR_OBJECT_ID_PREFIX.length()))
+            .filter(this::isMetadata)
+            .map(this::substrPrefix)
             .map(s -> s.split("_")[1])
             .distinct()
             .collect(Collectors.toList());
@@ -339,8 +348,8 @@ public class MCROCFLXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
     public Collection<String> getObjectBaseIds() {
         return getRepository()
             .listObjectIds()
-            .filter(id -> id.startsWith(MCR_OBJECT_ID_PREFIX))
-            .map(s -> s.substring(MCR_OBJECT_ID_PREFIX.length()))
+            .filter(this::isMetadata)
+            .map(this::substrPrefix)
             .map(s -> s.substring(0, s.lastIndexOf("_")))
             .distinct()
             .collect(Collectors.toList());
@@ -349,9 +358,9 @@ public class MCROCFLXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
     @Override
     public List<MCRObjectIDDate> retrieveObjectDates(List<String> ids) throws IOException {
         return ids.stream()
-            .filter(id -> id.startsWith(MCR_OBJECT_ID_PREFIX))
+            .filter(this::isMetadata)
             .filter(this::isNotDeleted)
-            .map(id -> id.substring(MCR_OBJECT_ID_PREFIX.length()))
+            .map(this::substrPrefix)
             .map(id -> new MCRObjectIDDateImpl(new Date(getLastModified(getObjName(id))), id))
             .collect(Collectors.toList());
     }

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/MCROCFLXMLMetadataManager.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/MCROCFLXMLMetadataManager.java
@@ -63,7 +63,7 @@ import edu.wisc.library.ocfl.api.model.VersionNum;
 /**
  * Manages persistence of MCRObject and MCRDerivate xml metadata. Provides
  * methods to create, retrieve, update and delete object metadata using OCFL
- **/
+ */
 public class MCROCFLXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
 
     private static final String MESSAGE_CREATED = "Created";

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/MCROCFLXMLMetadataManager.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/MCROCFLXMLMetadataManager.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -178,7 +177,7 @@ public class MCROCFLXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
     }
 
     private String getObjName(String mcrid) {
-        String objectType = MCRObjectID.getIDParts(mcrid.trim())[1].toLowerCase(Locale.ROOT).intern();
+        String objectType = MCRObjectID.getInstance(mcrid).getTypeId();
         return "derivate".equals(objectType) ? MCR_DERIVATE_ID_PREFIX + mcrid : MCR_OBJECT_ID_PREFIX + mcrid;
     }
 


### PR DESCRIPTION
Make the OCFLXMLMetadataManager use the ID Prefix on Derivates `mcrderivate` instead of always using `mcrobject`.

~Also adds new throws declaration for `NotFoundException`~ *moved to #1434*

# This brings BREAKING changes to old OCFL Repositories
### That is because derivates are now stored as `mcrderivate:project_type_id` instead of `mcrobject:project_type_id`

[Link to jira](https://mycore.atlassian.net/browse/MCR-2562).
