### PR TITLE
MCR-2566 invalid encoded key should not produce exception when decrypting with uri resolver

### DIFF
--- a/mycore-base/src/main/java/org/mycore/crypt/MCRAESCipher.java
+++ b/mycore-base/src/main/java/org/mycore/crypt/MCRAESCipher.java
@@ -81,6 +81,8 @@ public class MCRAESCipher extends MCRCipher {
                     "Keyfile " + keyFile 
                     + " not found. Generate new one with cli command or copy file to path."
                     ) ;
+        } catch (IllegalArgumentException e) {
+           throw new InvalidKeyException("Error while decoding key from keyFile " + keyFile + "!", e);
         } catch (IOException e) {
             throw new MCRException ("Can't read keyFile " + keyFile + ".",e) ; 
         } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-2566).
