### PR TITLE
MCR-2607 MetsMods2IIIFConverter has issues with filenames and empty m…

### DIFF
--- a/mycore-mets/src/main/java/org/mycore/mets/iiif/MCRMetsMods2IIIFConverter.java
+++ b/mycore-mets/src/main/java/org/mycore/mets/iiif/MCRMetsMods2IIIFConverter.java
@@ -18,7 +18,6 @@
 
 package org.mycore.mets.iiif;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;

--- a/mycore-mets/src/main/java/org/mycore/mets/iiif/MCRMetsMods2IIIFConverter.java
+++ b/mycore-mets/src/main/java/org/mycore/mets/iiif/MCRMetsMods2IIIFConverter.java
@@ -163,7 +163,7 @@ public class MCRMetsMods2IIIFConverter {
             String identifier = this.physicalIdentifierMap.get(physicalSubDiv);
             try {
                 MCRIIIFImageInformation information = imageImpl
-                    .getInformation(URLDecoder.decode(identifier, StandardCharsets.UTF_8.toString()));
+                    .getInformation(URLDecoder.decode(identifier, StandardCharsets.UTF_8));
                 MCRIIIFCanvas canvas = new MCRIIIFCanvas(identifier, label, information.width, information.height);
 
                 MCRIIIFAnnotation annotation = new MCRIIIFAnnotation(identifier, canvas);
@@ -180,7 +180,7 @@ public class MCRMetsMods2IIIFConverter {
                 annotation.setResource(resource);
 
                 return canvas;
-            } catch (MCRIIIFImageNotFoundException | MCRIIIFImageProvidingException | UnsupportedEncodingException e) {
+            } catch (MCRIIIFImageNotFoundException | MCRIIIFImageProvidingException e) {
                 throw new MCRException("Error while providing ImageInfo for " + identifier, e);
             } catch (MCRAccessException e) {
                 LOGGER.warn("User has no access to {}", identifier);

--- a/mycore-mets/src/main/java/org/mycore/mets/iiif/MCRMetsMods2IIIFConverter.java
+++ b/mycore-mets/src/main/java/org/mycore/mets/iiif/MCRMetsMods2IIIFConverter.java
@@ -18,6 +18,9 @@
 
 package org.mycore.mets.iiif;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -159,7 +162,8 @@ public class MCRMetsMods2IIIFConverter {
 
             String identifier = this.physicalIdentifierMap.get(physicalSubDiv);
             try {
-                MCRIIIFImageInformation information = imageImpl.getInformation(identifier);
+                MCRIIIFImageInformation information = imageImpl
+                    .getInformation(URLDecoder.decode(identifier, StandardCharsets.UTF_8.toString()));
                 MCRIIIFCanvas canvas = new MCRIIIFCanvas(identifier, label, information.width, information.height);
 
                 MCRIIIFAnnotation annotation = new MCRIIIFAnnotation(identifier, canvas);
@@ -176,7 +180,7 @@ public class MCRMetsMods2IIIFConverter {
                 annotation.setResource(resource);
 
                 return canvas;
-            } catch (MCRIIIFImageNotFoundException | MCRIIIFImageProvidingException e) {
+            } catch (MCRIIIFImageNotFoundException | MCRIIIFImageProvidingException | UnsupportedEncodingException e) {
                 throw new MCRException("Error while providing ImageInfo for " + identifier, e);
             } catch (MCRAccessException e) {
                 LOGGER.warn("User has no access to {}", identifier);
@@ -205,8 +209,7 @@ public class MCRMetsMods2IIIFConverter {
         complete.add(range);
         range.setLabel(divContainer.getLabel());
 
-        this.logicalIdIdentifiersMap.get(divContainer.getId()).stream().map(refId -> refId)
-            .forEach(canvasRef -> range.canvases.add(canvasRef));
+        range.canvases.addAll(this.logicalIdIdentifiersMap.getOrDefault(divContainer.getId(), Collections.emptyList()));
 
         divContainer.getChildren()
             .forEach(div -> {

--- a/mycore-mets/src/main/java/org/mycore/mets/iiif/MCRMetsMods2IIIFConverter.java
+++ b/mycore-mets/src/main/java/org/mycore/mets/iiif/MCRMetsMods2IIIFConverter.java
@@ -18,8 +18,8 @@
 
 package org.mycore.mets.iiif;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -161,8 +161,7 @@ public class MCRMetsMods2IIIFConverter {
 
             String identifier = this.physicalIdentifierMap.get(physicalSubDiv);
             try {
-                MCRIIIFImageInformation information = imageImpl
-                    .getInformation(URLDecoder.decode(identifier, StandardCharsets.UTF_8));
+                MCRIIIFImageInformation information = imageImpl.getInformation(new URI(identifier).getPath());
                 MCRIIIFCanvas canvas = new MCRIIIFCanvas(identifier, label, information.width, information.height);
 
                 MCRIIIFAnnotation annotation = new MCRIIIFAnnotation(identifier, canvas);
@@ -179,7 +178,7 @@ public class MCRMetsMods2IIIFConverter {
                 annotation.setResource(resource);
 
                 return canvas;
-            } catch (MCRIIIFImageNotFoundException | MCRIIIFImageProvidingException e) {
+            } catch (MCRIIIFImageNotFoundException | MCRIIIFImageProvidingException | URISyntaxException e) {
                 throw new MCRException("Error while providing ImageInfo for " + identifier, e);
             } catch (MCRAccessException e) {
                 LOGGER.warn("User has no access to {}", identifier);


### PR DESCRIPTION
…ets:divs

fixed MetsMods2IIIFConverter can not handle Umlaute and Spaces in filenames

fixed MetsMods2IIIFConverter can not handle empty mets:divs that are not linked to images

[Link to jira](https://mycore.atlassian.net/browse/MCR-2607).
