### PR TITLE
MCR-2609 remove double slashes from IIIF Manifest, if Impl not set

### DIFF
--- a/mycore-iiif/src/main/java/org/mycore/iiif/presentation/MCRIIIFPresentationUtil.java
+++ b/mycore-iiif/src/main/java/org/mycore/iiif/presentation/MCRIIIFPresentationUtil.java
@@ -93,7 +93,8 @@ public class MCRIIIFPresentationUtil {
     }
 
     private static String getImplBaseURL(String impl, String identifier) {
-        return MCRFrontendUtil.getBaseURL() + "api/iiif/presentation/v2/" + impl + "/" + identifier + "/";
+        String impAndSlash = "".equals(impl) ? "" : impl + "/";
+        return MCRFrontendUtil.getBaseURL() + "api/iiif/presentation/v2/" + impAndSlash + identifier + "/";
     }
 
     private static String encodeUTF8(String c) {


### PR DESCRIPTION
fixed double slashes in IIIF Manifest

[Link to jira](https://mycore.atlassian.net/browse/MCR-2609).
