### PR TITLE
MCR-2631 Make DataCite client use systemwide proxy

### DIFF
--- a/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteClient.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteClient.java
@@ -433,7 +433,8 @@ public class MCRDataciteClient {
     }
 
     private CloseableHttpClient getHttpClient() {
-        return HttpClientBuilder.create().setDefaultCredentialsProvider(getCredentialsProvider()).build();
+        return HttpClientBuilder.create().useSystemProperties().setDefaultCredentialsProvider(getCredentialsProvider())
+            .build();
     }
 
     private BasicCredentialsProvider getCredentialsProvider() {


### PR DESCRIPTION
The DataCite client ignores the systemwide proxy Java properties
(https.proxyHost etc.), so it cannot be used when a proxy is mandatory.
This is due to the usage of the Apache HTTP library, where these
properties have to be explicitly enabled (in contrast to the HTTP
classes in Java's standard library).
This commit configures the HttpClientBuilder of the DataCite client to
respect the same properties as the standard Java implementation, making
it behave like the rest of MyCoRe.

[Link to jira](https://mycore.atlassian.net/browse/MCR-2631).
