### PR TITLE
MCR-2688 RestAPIv2 - new PATCH methods to update derivate metadata

### DIFF
--- a/mycore-restapi/src/main/java/org/mycore/restapi/v2/MCRErrorCodeConstants.java
+++ b/mycore-restapi/src/main/java/org/mycore/restapi/v2/MCRErrorCodeConstants.java
@@ -44,6 +44,8 @@ final class MCRErrorCodeConstants {
 
     //MCRDerivate
     public static final String MCRDERIVATE_NO_PERMISSION = "MCRDERIVATE_NO_PERMISSION";
+    
+    public static final String MCRDERIVATE_INVALID_JSON_PATCH_SYNTAX = "MCRDERIVATE_INVALID_JSON_PATCH_SYNTAX";
 
     public static final String MCRDERIVATE_NOT_FOUND = "MCRDERIVATE_NOT_FOUND";
 

--- a/mycore-restapi/src/main/java/org/mycore/restapi/v2/access/MCRRestAPIACLPermission.java
+++ b/mycore-restapi/src/main/java/org/mycore/restapi/v2/access/MCRRestAPIACLPermission.java
@@ -58,6 +58,7 @@ public enum MCRRestAPIACLPermission {
                 return DELETE;
             case HttpMethod.POST:
             case HttpMethod.PUT:
+            case HttpMethod.PATCH:
                 return WRITE;
             default:
                 return null;


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-2688).

Before you can use / test this new feature , you need to enable it via property:
`MCR.RestApi.Draft.PartialMetadataUpdates=true`
