### PR TITLE
MCR-604 cleanup MCRCalendar class from redundant code and add support for missing calendars

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/MCRCalendar.java
+++ b/mycore-base/src/main/java/org/mycore/common/MCRCalendar.java
@@ -18,12 +18,12 @@
 
 package org.mycore.common;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -36,6 +36,7 @@ import com.ibm.icu.util.GregorianCalendar;
 import com.ibm.icu.util.HebrewCalendar;
 import com.ibm.icu.util.IslamicCalendar;
 import com.ibm.icu.util.JapaneseCalendar;
+import com.ibm.icu.util.ULocale;
 
 /**
  * This class implements all methods for handling calendars in MyCoRe objects
@@ -48,92 +49,124 @@ import com.ibm.icu.util.JapaneseCalendar;
  */
 public class MCRCalendar {
 
-    /** Logger */
-    static Logger LOGGER = LogManager.getLogger(MCRCalendar.class.getName());
-
-    /** Tag for Buddhistic calendar */
-    public static final String TAG_BUDDHIST = "buddhist";
-
-    /** Tag for Chinese calendar */
-    public static final String TAG_CHINESE = "chinese";
-
-    /** Tag for Coptic calendar */
-    public static final String TAG_COPTIC = "coptic";
-
-    /** Tag for Ethiopic calendar */
-    public static final String TAG_ETHIOPIC = "ethiopic";
-
-    /** Tag for Gregorian calendar */
-    public static final String TAG_GREGORIAN = "gregorian";
-
-    /** Tag for Hebrew calendar */
-    public static final String TAG_HEBREW = "hebrew";
-
-    /** Tag for Islamic calendar */
-    public static final String TAG_ISLAMIC = "islamic";
-
-    /** Tag for Japanese calendar */
-    public static final String TAG_JAPANESE = "japanese";
-
-    /** Tag for Julian calendar */
-    public static final String TAG_JULIAN = "julian";
-
-    /** Tag for Persic calendar */
-    public static final String TAG_PERSIC = "persic";
-
-    /** Tag for Armenian calendar */
-    public static final String TAG_ARMENIAN = "armenian";
-
-    /** Tag for Egyptian calendar */
-    public static final String TAG_EGYPTIAN = "egyptian";
-
-    /** Minimum Julian Day number is 0 = 01.01.4713 BC */
-    public static final int MIN_JULIAN_DAY_NUMBER = 0;
-
-    /** Maximum Julian Day number is 3182057 = 28.01.4000 */
-    public static final int MAX_JULIAN_DAY_NUMBER = 3182057;
-
-    /** all available calendars of ICU as String area */
-    public static final String[] CALENDARS_ICU = { TAG_BUDDHIST, TAG_CHINESE, TAG_COPTIC, TAG_ETHIOPIC, TAG_GREGORIAN,
-        TAG_HEBREW, TAG_ISLAMIC, TAG_JAPANESE };
-
-    /** a list of calendar tags they are supported in this class */
-    public static final List<String> CALENDARS_LIST = Collections
-        .unmodifiableList(new ArrayList<>(
-            Arrays.asList(TAG_GREGORIAN, TAG_JULIAN, TAG_ISLAMIC, TAG_BUDDHIST, TAG_COPTIC, TAG_ETHIOPIC, TAG_PERSIC,
-                TAG_JAPANESE, TAG_ARMENIAN, TAG_EGYPTIAN)));
+    /**
+     * Logger
+     */
+    private static final Logger LOGGER = LogManager.getLogger(MCRCalendar.class.getName());
 
     /**
-     * This method check a ancient date string for the given calendar. For
-     * syntax of the date string see javadocs of calendar methods.
-     *
-     * @param dateString
-     *            the date as string.
-     * @param last
-     *            the value is true if the date should be filled with the
-     *            highest value of month or day like 12 or 31 else it fill the
-     *            date with the lowest value 1 for month and day.
-     * @param calendarString
-     *            the calendar name as String, kind of the calendars are
-     *            ('gregorian', 'julian', 'islamic', 'buddhist', 'coptic',
-     *            'ethiopic', 'persic', 'japanese', 'armenian' or 'egyptian' )
-     *
-     * @return the ICU Calendar instance of the concrete calendar type or null if an error was occurred.
-     * @exception MCRException if parsing has an error
+     * Tag for Buddhistic calendar
      */
-    public static Calendar getHistoryDateAsCalendar(String dateString, boolean last, String calendarString)
-        throws MCRException {
-        Calendar out = null;
+    public static final String TAG_BUDDHIST = "buddhist";
+
+    /**
+     * Tag for Chinese calendar
+     */
+    public static final String TAG_CHINESE = "chinese";
+
+    /**
+     * Tag for Coptic calendar
+     */
+    public static final String TAG_COPTIC = "coptic";
+
+    /**
+     * Tag for Ethiopic calendar
+     */
+    public static final String TAG_ETHIOPIC = "ethiopic";
+
+    /**
+     * Tag for Gregorian calendar
+     */
+    public static final String TAG_GREGORIAN = "gregorian";
+
+    /**
+     * Tag for Hebrew calendar
+     */
+    public static final String TAG_HEBREW = "hebrew";
+
+    /**
+     * Tag for Islamic calendar
+     */
+    public static final String TAG_ISLAMIC = "islamic";
+
+    /**
+     * Tag for Japanese calendar
+     */
+    public static final String TAG_JAPANESE = "japanese";
+
+    /**
+     * Tag for Julian calendar
+     */
+    public static final String TAG_JULIAN = "julian";
+
+    /**
+     * Tag for Persic calendar
+     */
+    public static final String TAG_PERSIC = "persic";
+
+    /**
+     * Tag for Armenian calendar
+     */
+    public static final String TAG_ARMENIAN = "armenian";
+
+    /**
+     * Tag for Egyptian calendar
+     */
+    public static final String TAG_EGYPTIAN = "egyptian";
+
+    /**
+     * Minimum Julian Day number is 0 = 01.01.4713 BC
+     */
+    public static final int MIN_JULIAN_DAY_NUMBER = 0;
+
+    /**
+     * Maximum Julian Day number is 3182057 = 28.01.4000
+     */
+    public static final int MAX_JULIAN_DAY_NUMBER = 3182057;
+
+    /**
+     * a list of calendar tags they are supported in this class
+     */
+    public static final List<String> CALENDARS_LIST = List.of(
+        TAG_GREGORIAN, TAG_JULIAN, TAG_ISLAMIC, TAG_BUDDHIST, TAG_COPTIC, TAG_ETHIOPIC, TAG_PERSIC, TAG_JAPANESE,
+        TAG_ARMENIAN, TAG_EGYPTIAN, TAG_HEBREW);
+
+    /**
+     * the Julian day of the first day in the armenian calendar, 1.1.1 arm = 13.7.552 greg
+     */
+    public static final int FIRST_ARMENIAN_DAY;
+
+    /**
+     * the Julian day of the first day in the egyptian calendar, 1.1.1 eg = 18.2.747 BC greg
+     */
+    public static final int FIRST_EGYPTIAN_DAY;
+
+    static {
+        final Calendar firstArmenian = GregorianCalendar.getInstance();
+        firstArmenian.set(552, GregorianCalendar.JULY, 13);
+        FIRST_ARMENIAN_DAY = firstArmenian.get(Calendar.JULIAN_DAY);
+
+        final Calendar firstEgypt = GregorianCalendar.getInstance();
+        firstEgypt.set(747, GregorianCalendar.FEBRUARY, 18);
+        firstEgypt.set(Calendar.ERA, GregorianCalendar.BC);
+        FIRST_EGYPTIAN_DAY = firstEgypt.get(Calendar.JULIAN_DAY);
+    }
+
+    private static final String MSG_CALENDAR_UNSUPPORTED = "Calendar %s is not supported!";
+
+    /**
+     * @see #getHistoryDateAsCalendar(String, boolean, String)
+     */
+    public static Calendar getHistoryDateAsCalendar(String input, boolean last, CalendarType calendarType) {
+        LOGGER.debug("Input of getHistoryDateAsCalendar: {}  {}  {}", input, calendarType, Boolean.toString(last));
+
+        final String dateString = StringUtils.trim(input);
         // check dateString
-        LOGGER.debug("Input of getHistoryDateAsCalendar: {}  {}  {}", dateString, calendarString,
-            Boolean.toString(last));
-        if (dateString == null || dateString.trim().length() == 0) {
+        if (StringUtils.isBlank(dateString)) {
             throw new MCRException("The ancient date string is null or empty");
         }
-        dateString = dateString.trim();
-        if (calendarString == null || calendarString.trim().length() == 0) {
-            throw new MCRException("The calendar string is null or empty");
-        }
+
+        final Calendar out;
         if (dateString.equals("4713-01-01 BC")) {
             LOGGER.debug("Date string contains MIN_JULIAN_DAY_NUMBER");
             out = new GregorianCalendar();
@@ -146,196 +179,117 @@ public class MCRCalendar {
             out.set(Calendar.JULIAN_DAY, MCRCalendar.MAX_JULIAN_DAY_NUMBER);
             return out;
         }
-        // Check calendar string
-        if (!CALENDARS_LIST.contains(calendarString)) {
-            throw new MCRException("The calendar string " + calendarString + " is not supported");
+
+        switch (calendarType) {
+            case Armenian: {
+                out = getCalendarFromArmenianDate(dateString, last);
+                break;
+            }
+            case Buddhist: {
+                out = getCalendarFromBuddhistDate(dateString, last);
+                break;
+            }
+            case Coptic: {
+                out = getCalendarFromCopticDate(dateString, last);
+                break;
+            }
+            case Egyptian: {
+                out = getCalendarFromEgyptianDate(dateString, last);
+                break;
+            }
+            case Ethiopic: {
+                out = getCalendarFromEthiopicDate(dateString, last);
+                break;
+            }
+            case Gregorian: {
+                out = getCalendarFromGregorianDate(dateString, last);
+                break;
+            }
+            case Hebrew: {
+                out = getCalendarFromHebrewDate(dateString, last);
+                break;
+            }
+            case Islamic: {
+                out = getCalendarFromIslamicDate(dateString, last);
+                break;
+            }
+            case Japanese: {
+                out = getCalendarFromJapaneseDate(dateString, last);
+                break;
+            }
+            case Julian: {
+                out = getCalendarFromJulianDate(dateString, last);
+                break;
+            }
+            case Persic: {
+                out = getCalendarFromPersicDate(dateString, last);
+                break;
+            }
+            default: {
+                throw new MCRException("Calendar type " + calendarType + " not supported!");
+            }
         }
-        // select for calendar
-        if (calendarString.equals(TAG_GREGORIAN)) {
-            out = getCalendarFromGregorianDate(dateString, last);
-        }
-        if (calendarString.equals(TAG_JULIAN)) {
-            out = getCalendarFromJulianDate(dateString, last);
-        }
-        if (calendarString.equals(TAG_ISLAMIC)) {
-            out = getCalendarFromIslamicDate(dateString, last);
-        }
-        if (calendarString.equals(TAG_COPTIC)) {
-            out = getCalendarFromCopticDate(dateString, last);
-        }
-        if (calendarString.equals(TAG_ETHIOPIC)) {
-            out = getCalendarFromEthiopicDate(dateString, last);
-        }
-        if (calendarString.equals(TAG_BUDDHIST)) {
-            out = getCalendarFromBuddhistDate(dateString, last);
-        }
-        if (calendarString.equals(TAG_PERSIC)) {
-            out = getCalendarFromPersicDate(dateString, last);
-        }
-        if (calendarString.equals(TAG_ARMENIAN)) {
-            out = getCalendarFromArmenianDate(dateString, last);
-        }
-        if (calendarString.equals(TAG_EGYPTIAN)) {
-            out = getCalendarFromEgyptianDate(dateString, last);
-        }
-        if (calendarString.equals(TAG_JAPANESE)) {
-            out = getCalendarFromJapaneseDate(dateString, last);
-        }
-        if (calendarString.equals(TAG_HEBREW)) {
-            out = getCalendarFromHebrewDate(dateString, last);
-        }
+
         LOGGER.debug("Output of getHistoryDateAsCalendar: {}", getCalendarDateToFormattedString(out));
         return out;
+    }
+
+    /**
+     * This method check an ancient date string for the given calendar. For
+     * syntax of the date string see javadocs of calendar methods.
+     *
+     * @param dateString     the date as string.
+     * @param last           the value is true if the date should be filled with the
+     *                       highest value of month or day like 12 or 31 else it fill the
+     *                       date with the lowest value 1 for month and day.
+     * @param calendarString the calendar name as String, kind of the calendars are
+     *                       ('gregorian', 'julian', 'islamic', 'buddhist', 'coptic',
+     *                       'ethiopic', 'persic', 'japanese', 'armenian' or 'egyptian' )
+     * @return the ICU Calendar instance of the concrete calendar type or null if an error was occurred.
+     * @throws MCRException if parsing has an error
+     */
+    public static Calendar getHistoryDateAsCalendar(String dateString, boolean last, String calendarString)
+        throws MCRException {
+        return getHistoryDateAsCalendar(dateString, last, CalendarType.of(calendarString));
     }
 
     /**
      * Check the date string for julian or gregorian calendar
      *
      * @param dateString the date string
-     * @param last the flag for first / last day
+     * @param last       the flag for first / last day
      * @return an integer array with [0] = year; [1] = month; [2] = day; [3] = era : -1 = BC : +1 = AC
-     * @throws Exception
      */
-    private static int[] checkDateStringForJulianCalendar(String dateString, boolean last) throws Exception {
-        int[] fields = new int[4];
+    private static int[] checkDateStringForJulianCalendar(String dateString, boolean last, CalendarType calendarType) {
         // look for BC
-        dateString = dateString.toUpperCase(Locale.ROOT);
-        boolean bc = false;
-        int start = 0;
-        int ende = dateString.length();
-        if (dateString.substring(0, 1).equals("-")) {
-            bc = true;
-            start = 1;
-        } else {
-            if (dateString.length() > 2) {
-                int i = dateString.indexOf("AD");
-                if (i != -1) {
-                    if (i == 0) {
-                        bc = false;
-                        start = 2;
-                    } else {
-                        bc = false;
-                        start = 0;
-                        ende = i - 1;
-                    }
-                }
-                i = dateString.indexOf("BC");
-                if (i != -1) {
-                    if (i == 0) {
-                        bc = true;
-                        start = 2;
-                    } else {
-                        bc = true;
-                        start = 0;
-                        ende = i - 1;
-                    }
-                }
-            }
-            if (dateString.length() > 7) {
-                int i = dateString.indexOf("N. CHR");
-                if (i != -1) {
-                    if (i == 0) {
-                        bc = false;
-                        start = 7;
-                    } else {
-                        bc = false;
-                        start = 0;
-                        ende = i - 1;
-                    }
-                }
-                i = dateString.indexOf("V. CHR");
-                if (i != -1) {
-                    if (i == 0) {
-                        bc = true;
-                        start = 7;
-                    } else {
-                        bc = true;
-                        start = 0;
-                        ende = i - 1;
-                    }
-                }
-            }
-        }
-        dateString = dateString.substring(start, ende).trim();
+        final String dateTrimmed = StringUtils.trim(StringUtils.upperCase(dateString, Locale.ROOT));
 
-        // German, English or ISO?
-        start = 0;
-        boolean iso = false;
-        String token = ".";
-        if (dateString.indexOf("-", start + 1) != -1) {
-            iso = true;
-            token = "-";
-        }
-        if (dateString.indexOf("/", start + 1) != -1) {
-            token = "/";
-        }
-
-        // only a year?
-        int firstdot = dateString.indexOf(token, start + 1);
-        int secdot = -1;
-        if (firstdot != -1) {
-            secdot = dateString.indexOf(token, firstdot + 1);
-        }
-        int day = 1;
-        int mon = 0;
-        int year = 0;
-        if (secdot != -1) {
-            if (iso) {
-                year = Integer.parseInt(dateString.substring(start, firstdot));
-                mon = Integer.parseInt(dateString.substring(firstdot + 1, secdot)) - 1;
-                day = Integer.parseInt(dateString.substring(secdot + 1));
-            } else {
-                day = Integer.parseInt(dateString.substring(start, firstdot));
-                mon = Integer.parseInt(dateString.substring(firstdot + 1, secdot)) - 1;
-                year = Integer.parseInt(dateString.substring(secdot + 1));
-            }
-        } else {
-            if (firstdot != -1) {
-                if (iso) {
-                    year = Integer.parseInt(dateString.substring(start, firstdot));
-                    mon = Integer.parseInt(dateString.substring(firstdot + 1)) - 1;
-                } else {
-                    mon = Integer.parseInt(dateString.substring(start, firstdot)) - 1;
-                    year = Integer.parseInt(dateString.substring(firstdot + 1));
-                }
-                if (last) {
-                    if (mon == 0 || mon == 2 || mon == 4 || mon == 6 || mon == 7 || mon == 9 || mon == 11) {
-                        day = 31;
-                    }
-                    if (mon == 1) {
-                        day = 28;
-                    }
-
-                    if (mon == 3 || mon == 5 || mon == 8 || mon == 10) {
-                        day = 30;
-                    }
-
-                }
-            } else {
-                year = Integer.parseInt(dateString.substring(start));
-                if (last) {
-                    mon = 11;
-                    day = 31;
-                }
-            }
-        }
+        final boolean bc = beforeZero(dateTrimmed, calendarType);
+        final String cleanDate = cleanDate(dateTrimmed, calendarType);
+        final int[] fields = parseDateString(cleanDate, last, calendarType);
+        final int year = fields[0];
+        final int mon = fields[1];
+        final int day = fields[2];
+        final int era = bc ? -1 : 1;
 
         // test of the monthly
-        if (mon > 11 || mon < 0) {
+        if (mon > GregorianCalendar.DECEMBER || mon < GregorianCalendar.JANUARY) {
             throw new MCRException("The month of the date is inadmissible.");
         }
 
         // Test of the daily
-        if ((mon == 0 || mon == 2 || mon == 4 || mon == 6 || mon == 7 || mon == 9 || mon == 11) && day > 31
-            || (mon == 3 || mon == 5 || mon == 8 || mon == 10) && day > 30 || mon == 1 && day > 29 && year % 4 == 0
-            || mon == 1 && day > 28 && year % 4 > 0 || day < 1) {
+        if (day > 31) {
+            throw new MCRException("The day of the date is inadmissible.");
+        } else if ((day > 30) && (mon == GregorianCalendar.APRIL || mon == GregorianCalendar.JUNE ||
+            mon == GregorianCalendar.SEPTEMBER || mon == GregorianCalendar.NOVEMBER)) {
+            throw new MCRException("The day of the date is inadmissible.");
+        } else if ((day > 29) && (mon == GregorianCalendar.FEBRUARY)) {
+            throw new MCRException("The day of the date is inadmissible.");
+        } else if ((day > 28) && (mon == GregorianCalendar.FEBRUARY) && !isLeapYear(year, calendarType)) {
             throw new MCRException("The day of the date is inadmissible.");
         }
-        fields[0] = year;
-        fields[1] = mon;
-        fields[2] = day;
-        fields[3] = bc ? -1 : 1;
-        return fields;
+
+        return new int[] { year, mon, day, era };
     }
 
     /**
@@ -366,7 +320,7 @@ public class MCRCalendar {
     protected static GregorianCalendar getCalendarFromGregorianDate(String dateString, boolean last)
         throws MCRException {
         try {
-            int[] fields = checkDateStringForJulianCalendar(dateString, last);
+            int[] fields = checkDateStringForJulianCalendar(dateString, last, CalendarType.Gregorian);
             GregorianCalendar calendar = new GregorianCalendar();
             calendar.set(fields[0], fields[1], fields[2]);
             if (fields[3] == -1) {
@@ -407,64 +361,16 @@ public class MCRCalendar {
      */
     protected static Calendar getCalendarFromJulianDate(String dateString, boolean last) throws MCRException {
         try {
-            int[] fields = checkDateStringForJulianCalendar(dateString, last);
-            Calendar calendar = new GregorianCalendar();
+            int[] fields = checkDateStringForJulianCalendar(dateString, last, CalendarType.Julian);
+            final Calendar calendar = Calendar.getInstance(CalendarType.Julian.getLocale());
+            ((GregorianCalendar) calendar).setGregorianChange(new Date(Long.MAX_VALUE));
             calendar.set(fields[0], fields[1], fields[2]);
             if (fields[3] == -1) {
                 calendar.set(Calendar.ERA, GregorianCalendar.BC);
             } else {
                 calendar.set(Calendar.ERA, GregorianCalendar.AD);
             }
-            // correct data
-            int julianDay = calendar.get(Calendar.JULIAN_DAY);
-            if (fields[0] == 1582 && fields[1] == 9 && fields[2] == 6 && fields[3] == 1) {
-                julianDay = 2299162;
-            }
-            if (fields[0] == 1582 && fields[1] == 9 && fields[2] == 7 && fields[3] == 1) {
-                julianDay = 2299163;
-            }
-            if (fields[0] == 1582 && fields[1] == 9 && fields[2] == 8 && fields[3] == 1) {
-                julianDay = 2299164;
-            }
-            if (fields[0] == 1582 && fields[1] == 9 && fields[2] == 9 && fields[3] == 1) {
-                julianDay = 2299165;
-            }
-            if (fields[0] == 1582 && fields[1] == 9 && fields[2] == 10 && fields[3] == 1) {
-                julianDay = 2299166;
-            }
-            if (fields[0] == 1582 && fields[1] == 9 && fields[2] == 11 && fields[3] == 1) {
-                julianDay = 2299167;
-            }
-            if (fields[0] == 1582 && fields[1] == 9 && fields[2] == 12 && fields[3] == 1) {
-                julianDay = 2299168;
-            }
-            if (fields[0] == 1582 && fields[1] == 9 && fields[2] == 13 && fields[3] == 1) {
-                julianDay = 2299169;
-            }
-            if (fields[0] == 1582 && fields[1] == 9 && fields[2] == 14 && fields[3] == 1) {
-                julianDay = 2299170;
-            }
-            if (fields[0] == 1582 && fields[1] == 9 && fields[2] == 15 && fields[3] == 1) {
-                julianDay = 2299171;
-            }
-            if ((fields[0] > 1582 || (fields[0] == 1582 && fields[1] > 9)
-                || (fields[0] == 1582 && fields[1] == 9 && fields[2] > 15))
-                && fields[3] == 1) {
-                julianDay += 10;
-            }
-            if ((fields[0] > 1700 || (fields[0] == 1700 && fields[1] >= 2)) && fields[3] == 1) {
-                julianDay += 1;
-            }
-            if ((fields[0] > 1800 || (fields[0] == 1800 && fields[1] >= 2)) && fields[3] == 1) {
-                julianDay += 1;
-            }
-            if ((fields[0] > 1900 || (fields[0] == 1900 && fields[1] >= 2)) && fields[3] == 1) {
-                julianDay += 1;
-            }
-            if ((fields[0] > 2100 || (fields[0] == 2100 && fields[1] >= 2)) && fields[3] == 1) {
-                julianDay += 1;
-            }
-            calendar.set(Calendar.JULIAN_DAY, julianDay);
+
             return calendar;
         } catch (Exception e) {
             throw new MCRException("The ancient julian date is false.", e);
@@ -472,7 +378,7 @@ public class MCRCalendar {
     }
 
     /**
-     * This method convert a islamic calendar date to a IslamicCalendar valuei civil mode.
+     * This method converts an islamic calendar date to a IslamicCalendar value civil mode.
      * The syntax for the islamic input is: <br>
      * <ul>
      * <li> [[[t]t.][m]m.][yyy]y [H.|h.]</li>
@@ -491,102 +397,33 @@ public class MCRCalendar {
      * @exception MCRException if parsing has an error
      */
     protected static IslamicCalendar getCalendarFromIslamicDate(String dateString, boolean last) {
-        try {
-            dateString = dateString.toUpperCase(Locale.ROOT);
-            int start = 0;
-            int ende = dateString.length();
-            int i = dateString.indexOf("H.");
-            if (i != -1) {
-                ende = i;
-            }
-            if (dateString.length() > 10) {
-                i = dateString.indexOf(".\u0647.\u0642");
-                if (i != -1) {
-                    start = 3;
-                } else {
-                    i = dateString.indexOf(".\u0647");
-                    if (i != -1) {
-                        start = 2;
-                    }
-                }
-            }
+        final String dateTrimmed = StringUtils.trim(StringUtils.upperCase(dateString, Locale.ROOT));
 
-            dateString = dateString.substring(start, ende).trim();
+        final boolean before = beforeZero(dateTrimmed, CalendarType.Islamic);
+        final String cleanDate = cleanDate(dateTrimmed, CalendarType.Islamic);
+        final int[] fields = parseDateString(cleanDate, last, CalendarType.Islamic);
+        int year = fields[0];
+        final int mon = fields[1];
+        final int day = fields[2];
 
-            // german or ISO?
-            start = 0;
-            boolean iso = false;
-            String token = ".";
-
-            if (dateString.indexOf("-", start + 1) != -1) {
-                iso = true;
-                token = "-";
-            }
-            //
-            int firstdot = dateString.indexOf(token, start + 1);
-            int secdot = -1;
-
-            if (firstdot != -1) {
-                secdot = dateString.indexOf(token, firstdot + 1);
-            }
-
-            int day = 1;
-            int mon = 0;
-            int year = 0;
-            if (secdot != -1) { // day month year
-                if (iso) {
-                    year = Integer.parseInt(dateString.substring(start, firstdot));
-                    mon = Integer.parseInt(dateString.substring(firstdot + 1, secdot)) - 1;
-                    day = Integer.parseInt(dateString.substring(secdot + 1));
-                } else {
-                    day = Integer.parseInt(dateString.substring(start, firstdot));
-                    mon = Integer.parseInt(dateString.substring(firstdot + 1, secdot)) - 1;
-                    year = Integer.parseInt(dateString.substring(secdot + 1));
-                }
-            } else {
-                if (firstdot != -1) { // month year
-                    if (iso) {
-                        year = Integer.parseInt(dateString.substring(start, firstdot));
-                        mon = Integer.parseInt(dateString.substring(firstdot + 1)) - 1;
-                    } else {
-                        mon = Integer.parseInt(dateString.substring(start, firstdot)) - 1;
-                        year = Integer.parseInt(dateString.substring(firstdot + 1));
-                    }
-
-                    if (last) {
-                        if (mon % 2 == 0) {
-                            day = 30;
-                        }
-                        if (mon % 2 == 1) {
-                            day = 29;
-                        }
-
-                    }
-                } else { // year
-                    year = Integer.parseInt(dateString.substring(start));
-
-                    if (last) {
-                        mon = 11;
-                        day = 29;
-                    }
-                }
-            }
-            // test of the monthly
-            if (mon > 11 || mon < 0) {
-                throw new MCRException("The month of the date is inadmissible.");
-            }
-            // Test of the daily
-            if (day > 30 || mon % 2 == 1 && mon < 11 && day > 29 || day < 1) {
-                throw new MCRException("The day of the date is inadmissible.");
-            }
-            IslamicCalendar calendar = new IslamicCalendar();
-            calendar.setCivil(true);
-            calendar.set(year, mon, day);
-            return calendar;
-        } catch (Exception e) {
-            throw new MCRException("The ancient islamic date is false.", e);
+        if (before) {
+            year = -year + 1;
         }
 
+        // test of the monthly
+        if (mon > 11 || mon < 0) {
+            throw new MCRException("The month of the date is inadmissible.");
+        }
+        // Test of the daily
+        if (day > 30 || mon % 2 == 1 && mon < 11 && day > 29 || day < 1) {
+            throw new MCRException("The day of the date is inadmissible.");
+        }
+
+        IslamicCalendar calendar = new IslamicCalendar();
+        calendar.setCivil(true);
+        calendar.set(year, mon, day);
+
+        return calendar;
     }
 
     /**
@@ -601,176 +438,52 @@ public class MCRCalendar {
      *            highest value of month or day like 13 or 30 else it fill the
      *            date with the lowest value 1 for month and day.
      *
-     * @return the HebewCalendar date value or null if an error was occurred.
+     * @return the HebrewCalendar date value or null if an error was occurred.
      * @exception MCRException if parsing has an error
      */
 
     protected static HebrewCalendar getCalendarFromHebrewDate(String datestr, boolean last) {
-        try {
-            int start = 0;
-            datestr = datestr.trim();
+        final String dateTrimmed = StringUtils.trim(StringUtils.upperCase(datestr, Locale.ROOT));
 
-            // german or ISO?
-            start = 0;
-            boolean iso = false;
-            String token = ".";
-
-            if (datestr.indexOf("-", start + 1) != -1) {
-                iso = true;
-                token = "-";
-            }
-            //
-            int firstdot = datestr.indexOf(token, start + 1);
-            int secdot = -1;
-
-            if (firstdot != -1) {
-                secdot = datestr.indexOf(token, firstdot + 1);
-            }
-
-            int day = 0;
-            int mon = 0;
-            int year = 0;
-
-            if (secdot != -1) {
-                if (iso) {
-                    year = Integer.parseInt(datestr.substring(start, firstdot));
-                    mon = Integer.parseInt(datestr.substring(firstdot + 1, secdot)) - 1;
-                    day = Integer.parseInt(datestr.substring(secdot + 1));
-                } else {
-                    day = Integer.parseInt(datestr.substring(start, firstdot));
-                    mon = Integer.parseInt(datestr.substring(firstdot + 1, secdot)) - 1;
-                    year = Integer.parseInt(datestr.substring(secdot + 1));
-                }
-            } else {
-                if (firstdot != -1) {
-                    if (iso) {
-                        year = Integer.parseInt(datestr.substring(start, firstdot));
-                        mon = Integer.parseInt(datestr.substring(firstdot + 1)) - 1;
-                    } else {
-                        mon = Integer.parseInt(datestr.substring(start, firstdot)) - 1;
-                        year = Integer.parseInt(datestr.substring(firstdot + 1));
-                    }
-
-                    if (last) {
-                        if (mon == 0 || mon == 4 || mon == 7 || mon == 9 || mon == 11) {
-                            day = 30;
-                        } else {
-                            day = 29;
-                        }
-                    } else {
-                        day = 1;
-                    }
-                } else {
-                    year = Integer.parseInt(datestr.substring(start));
-
-                    if (last) {
-                        mon = 11;
-                        day = 29;
-                    } else {
-                        mon = 0;
-                        day = 1;
-                    }
-                }
-            }
-            HebrewCalendar hcal = new HebrewCalendar();
-            hcal.set(year, mon, day);
-            return hcal;
-
-        } catch (Exception e) {
-            throw new MCRException("The ancient hebrew date is false.", e);
+        final boolean before = beforeZero(dateTrimmed, CalendarType.Hebrew);
+        if (before) {
+            throw new MCRException("Dates before 1 not supported in Hebrew calendar!");
         }
+
+        final String cleanDate = cleanDate(dateTrimmed, CalendarType.Hebrew);
+        final int[] fields = parseDateString(cleanDate, last, CalendarType.Hebrew);
+        final int year = fields[0];
+        final int mon = fields[1];
+        final int day = fields[2];
+
+        HebrewCalendar hcal = new HebrewCalendar();
+        hcal.set(year, mon, day);
+
+        return hcal;
     }
 
     /**
      * Check the date string for ethiopic or coptic calendar
      *
      * @param dateString the date string
-     * @param last the flag for first / last day
+     * @param last       the flag for first / last day
      * @return an integer array with [0] = year; [1] = month; [2] = day; [3] = era : -1 = B.M.: +1 = A.M.
-     * @throws Exception
      */
-    private static int[] checkDateStringForCopticCalendar(String dateString, boolean last) {
-        int[] fields = new int[4];
-        dateString = dateString.trim();
-        // test before Martyrium
-        boolean bm = false;
-        int start = 0;
-        int ende = dateString.length();
-        ende = dateString.length();
-        if (dateString.length() > 4) {
-            int i = dateString.indexOf("A.M.");
-            if (i != -1) {
-                start = 0;
-                ende = i - 1;
-            }
-            i = dateString.indexOf("a.M.");
-            if (i != -1) {
-                start = 0;
-                ende = i - 1;
-            }
-            i = dateString.indexOf("E.E.");
-            if (i != -1) {
-                start = 0;
-                ende = i - 1;
-            }
+    private static int[] checkDateStringForCopticCalendar(String dateString, boolean last, CalendarType calendarType) {
+        final String dateTrimmed = StringUtils.trim(StringUtils.upperCase(dateString, Locale.ROOT));
+
+        final boolean bm = beforeZero(dateTrimmed, calendarType);
+        final String cleanDate = cleanDate(dateTrimmed, calendarType);
+        final int[] fields = parseDateString(cleanDate, last, calendarType);
+        int year = fields[0];
+        final int mon = fields[1];
+        final int day = fields[2];
+        final int era = bm ? -1 : 1;
+
+        if (bm) {
+            year = -year + 1;
         }
-        dateString = dateString.substring(start, ende).trim();
 
-        // german or ISO?
-        start = 0;
-        boolean iso = false;
-        String token = ".";
-
-        if (dateString.indexOf("-", start + 1) != -1) {
-            iso = true;
-            token = "-";
-        }
-        //
-        int firstdot = dateString.indexOf(token, start + 1);
-        int secdot = -1;
-
-        if (firstdot != -1) {
-            secdot = dateString.indexOf(token, firstdot + 1);
-        }
-        int day = 1;
-        int mon = 0;
-        int year = 0;
-        if (secdot != -1) { // day, mon, year
-            if (iso) {
-                year = Integer.parseInt(dateString.substring(start, firstdot));
-                mon = Integer.parseInt(dateString.substring(firstdot + 1, secdot)) - 1;
-                day = Integer.parseInt(dateString.substring(secdot + 1));
-            } else {
-                day = Integer.parseInt(dateString.substring(start, firstdot));
-                mon = Integer.parseInt(dateString.substring(firstdot + 1, secdot)) - 1;
-                year = Integer.parseInt(dateString.substring(secdot + 1));
-            }
-        } else {
-            if (firstdot != -1) { // mon, year
-                if (iso) {
-                    year = Integer.parseInt(dateString.substring(start, firstdot));
-                    mon = Integer.parseInt(dateString.substring(firstdot + 1)) - 1;
-                } else {
-                    mon = Integer.parseInt(dateString.substring(start, firstdot)) - 1;
-                    year = Integer.parseInt(dateString.substring(firstdot + 1));
-                }
-
-                if (last) {
-                    if (mon <= 11) {
-                        day = 30;
-                    } else {
-                        day = 5;
-                    }
-                }
-            } else { // year
-                year = Integer.parseInt(dateString.substring(start));
-
-                if (last) {
-                    mon = 12;
-                    day = 5;
-                }
-            }
-        }
         // test of the monthly
         if (mon > 12 || mon < 0) {
             throw new MCRException("The month of the date is inadmissible.");
@@ -779,13 +492,8 @@ public class MCRCalendar {
         if (day > 30 || day < 1 || day > 6 && mon == 12) {
             throw new MCRException("The day of the date is inadmissible.");
         }
-        if (bm) {
-            year = -year + 1; // if before Matyrium
-        }
-        fields[0] = year;
-        fields[1] = mon;
-        fields[2] = day;
-        return fields;
+
+        return new int[] { year, mon, day, era };
     }
 
     /**
@@ -808,7 +516,7 @@ public class MCRCalendar {
      */
     protected static CopticCalendar getCalendarFromCopticDate(String dateString, boolean last) {
         try {
-            int[] fields = checkDateStringForCopticCalendar(dateString, last);
+            final int[] fields = checkDateStringForCopticCalendar(dateString, last, CalendarType.Coptic);
             CopticCalendar calendar = new CopticCalendar();
             calendar.set(fields[0], fields[1], fields[2]);
             return calendar;
@@ -837,7 +545,7 @@ public class MCRCalendar {
      */
     protected static EthiopicCalendar getCalendarFromEthiopicDate(String dateString, boolean last) {
         try {
-            int[] fields = checkDateStringForCopticCalendar(dateString, last);
+            final int[] fields = checkDateStringForCopticCalendar(dateString, last, CalendarType.Ethiopic);
             EthiopicCalendar calendar = new EthiopicCalendar();
             calendar.set(fields[0], fields[1], fields[2]);
             return calendar;
@@ -850,10 +558,10 @@ public class MCRCalendar {
      * This method convert a JapaneseCalendar date to a JapaneseCalendar value.
      * The syntax for the japanese input is: <br>
      * <ul>
-     * <li> [[[t]t.][m]m.][H|M|S|T][yyy]y <br>
-     * H: Heisei; M: Meiji, S: Showa, T: Taiso
+     * <li> [[[t]t.][m]m.][H|M|S|T|R][yyy]y <br>
+     * H: Heisei; M: Meiji, S: Showa, T: Taiso, R: Reiwa
      * </li>
-     * <li> [H|M|S|T]y[yyy][-m[m][-t[t]]]</li>
+     * <li> [H|M|S|T|R]y[yyy][-m[m][-t[t]]]</li>
      * </ul>
      *
      * @param datestr
@@ -867,115 +575,45 @@ public class MCRCalendar {
      * @exception MCRException if parsing has an error
      */
     protected static JapaneseCalendar getCalendarFromJapaneseDate(String datestr, boolean last) {
-        try {
-            datestr = datestr.trim();
+        final String dateTrimmed = StringUtils.trim(StringUtils.upperCase(datestr, Locale.ROOT));
+        final String cleanDate = cleanDate(dateTrimmed, CalendarType.Japanese);
 
-            // boolean bm = false;
-            int start = 0;
-
-            // german or ISO?
-            start = 0;
-            boolean iso = false;
-            String token = ".";
-
-            if (datestr.indexOf("-", start + 1) != -1) {
-                iso = true;
-                token = "-";
-            }
-            //
-            int firstdot = datestr.indexOf(token, start + 1);
-            int secdot = -1;
-
-            if (firstdot != -1) {
-                secdot = datestr.indexOf(token, firstdot + 1);
-            }
-
-            int day = 0;
-            int mon = 0;
-            int year = 0;
-            String syear = "";
-            if (secdot != -1) { // day, mon, year
-                if (iso) {
-                    syear = datestr.substring(start, firstdot);
-                    mon = Integer.parseInt(datestr.substring(firstdot + 1, secdot)) - 1;
-                    day = Integer.parseInt(datestr.substring(secdot + 1));
-                } else {
-                    day = Integer.parseInt(datestr.substring(start, firstdot));
-                    mon = Integer.parseInt(datestr.substring(firstdot + 1, secdot)) - 1;
-                    syear = datestr.substring(secdot + 1);
-                }
-            } else {
-                if (firstdot != -1) { // mon, year
-                    if (iso) {
-                        syear = datestr.substring(start, firstdot);
-                        mon = Integer.parseInt(datestr.substring(firstdot + 1)) - 1;
-                    } else {
-                        mon = Integer.parseInt(datestr.substring(start, firstdot)) - 1;
-                        syear = datestr.substring(firstdot + 1);
-                    }
-
-                    if (last) {
-                        if (mon <= 11) {
-                            day = 30;
-                        } else {
-                            day = 5;
-                        }
-                    } else {
-                        day = 1;
-                    }
-                } else { // year
-                    syear = datestr.substring(start);
-
-                    if (last) {
-                        mon = 12;
-                        day = 5;
-                    } else {
-                        mon = 0;
-                        day = 1;
-                    }
-                }
-            }
-
-            int era;
-            switch (syear.substring(0, 1)) {
-                case "H":
-                    era = 235;
-                    break;
-                case "S":
-                    era = 234;
-                    break;
-                case "T":
-                    era = 233;
-                    break;
-                case "M":
-                    era = 232;
-                    break;
-                default:
-                    era = 0;
-            }
-            year = Integer.parseInt(syear.substring(1).trim());
-            // test of the monthly
-            if (mon > 12 || mon < 0) {
-                throw new MCRException("The month of the date is inadmissible.");
-            }
-            // Test of the daily
-            if (day > 30 || day < 1 || day > 6 && mon == 12) {
-                throw new MCRException("The day of the date is inadmissible.");
-            }
-
-            JapaneseCalendar jcal = new JapaneseCalendar();
-            // GregorianCalendar jcal = new GregorianCalendar();
-            jcal.set(year, mon, day);
-            jcal.set(Calendar.ERA, era);
-            jcal.add(Calendar.DATE, 0); // Calendar correction
-            GregorianCalendar xcal = new GregorianCalendar();
-            xcal.setTime(jcal.getTime());
-
-            return jcal;
-
-        } catch (Exception e) {
-            throw new MCRException("The ancient jacanese date is false.", e);
+        // japanese dates contain the era statement directly in the year e.g. 1.1.H2
+        // before parsing we have to remove this
+        final String eraToken;
+        final int era;
+        if (StringUtils.contains(cleanDate, "M")) {
+            eraToken = "M";
+            era = JapaneseCalendar.MEIJI;
+        } else if (StringUtils.contains(cleanDate, "T")) {
+            eraToken = "T";
+            era = JapaneseCalendar.TAISHO;
+        } else if (StringUtils.contains(cleanDate, "S")) {
+            eraToken = "S";
+            era = JapaneseCalendar.SHOWA;
+        } else if (StringUtils.contains(cleanDate, "H")) {
+            eraToken = "H";
+            era = JapaneseCalendar.HEISEI;
+        } else if (StringUtils.contains(cleanDate, "R")) {
+            eraToken = "R";
+            era = JapaneseCalendar.REIWA;
+        } else {
+            throw new MCRException("Japanese date " + datestr + " does not contain era statement!");
         }
+
+        final String firstPart = StringUtils.substringBefore(cleanDate, eraToken);
+        final String secondPart = StringUtils.substringAfter(cleanDate, eraToken);
+
+        final int[] fields = parseDateString(firstPart + secondPart, last, CalendarType.Japanese);
+        final int year = fields[0];
+        final int mon = fields[1];
+        final int day = fields[2];
+
+        JapaneseCalendar jcal = new JapaneseCalendar();
+        jcal.set(year, mon, day);
+        jcal.set(Calendar.ERA, era);
+
+        return jcal;
     }
 
     /**
@@ -998,127 +636,34 @@ public class MCRCalendar {
      * @return the BuddhistCalendar date value or null if an error was occurred.
      * @exception MCRException if parsing has an error
      */
-
     protected static BuddhistCalendar getCalendarFromBuddhistDate(String datestr, boolean last) {
-        try {
-            datestr = datestr.trim();
-            // test before Buddhas
-            boolean bb = false;
-            int start = 0;
-            int ende = datestr.length();
-            if (datestr.substring(0, 1).equals("-")) {
-                bb = true;
-                start = 1;
-                datestr = datestr.substring(start).trim();
-                ende = datestr.length();
-            }
-            start = 0;
-            if (datestr.length() > 4) {
-                int i = datestr.indexOf("B.E.");
-                if (i != -1) {
-                    start = 0;
-                    ende = i;
-                }
-            }
-            datestr = datestr.substring(start, ende).trim();
+        // test before Buddhas
+        final String dateTrimmed = StringUtils.trim(StringUtils.upperCase(datestr, Locale.ROOT));
 
-            // german oder ISO?
-            start = 0;
-            boolean iso = false;
-            String token = ".";
+        final boolean bb = beforeZero(dateTrimmed, CalendarType.Buddhist);
+        final String cleanDate = cleanDate(dateTrimmed, CalendarType.Buddhist);
+        final int[] fields = parseDateString(cleanDate, last, CalendarType.Buddhist);
+        int year = fields[0];
+        int mon = fields[1];
+        int day = fields[2];
 
-            if (datestr.indexOf("-", start + 1) != -1) {
-                iso = true;
-                token = "-";
-            }
-            //
-            int firstdot = datestr.indexOf(token, start + 1);
-            int secdot = -1;
-
-            if (firstdot != -1) {
-                secdot = datestr.indexOf(token, firstdot + 1);
-            }
-
-            int day = 0;
-            int mon = 0;
-            int year = 0;
-
-            if (secdot != -1) { // day, month, year
-                if (iso) {
-                    year = Integer.parseInt(datestr.substring(start, firstdot));
-                    mon = Integer.parseInt(datestr.substring(firstdot + 1, secdot)) - 1;
-                    day = Integer.parseInt(datestr.substring(secdot + 1));
-                } else {
-                    day = Integer.parseInt(datestr.substring(start, firstdot));
-                    mon = Integer.parseInt(datestr.substring(firstdot + 1, secdot)) - 1;
-                    year = Integer.parseInt(datestr.substring(secdot + 1));
-                }
-            } else {
-                if (firstdot != -1) { // month, year
-                    if (iso) {
-                        year = Integer.parseInt(datestr.substring(start, firstdot));
-                        mon = Integer.parseInt(datestr.substring(firstdot + 1)) - 1;
-                    } else {
-                        mon = Integer.parseInt(datestr.substring(start, firstdot)) - 1;
-                        year = Integer.parseInt(datestr.substring(firstdot + 1));
-                    }
-
-                    if (last) {
-                        if (mon == 0 || mon == 2 || mon == 4 || mon == 6 || mon == 7 || mon == 9 || mon == 11) {
-                            day = 31;
-                        }
-                        if (mon == 1) {
-                            day = 28;
-                        }
-                        if (mon == 3 || mon == 5 || mon == 8 || mon == 10) {
-                            day = 30;
-                        }
-                    } else {
-                        day = 1;
-                    }
-                } else { // year
-                    year = Integer.parseInt(datestr.substring(start));
-
-                    if (last) {
-                        mon = 11;
-                        day = 29;
-                    } else {
-                        mon = 0;
-                        day = 1;
-                    }
-                }
-            }
-            BuddhistCalendar budcal = new BuddhistCalendar();
-            // test of the monthly
-            if (mon > 11 || mon < 0) {
-                throw new MCRException("The month of the date is inadmissible.");
-            }
-
-            // Test of the daily
-            if ((mon == 0 || mon == 2 || mon == 4 || mon == 6 || mon == 7 || mon == 9 || mon == 11) && day > 31
-                || (mon == 3 || mon == 5 || mon == 8 || mon == 10) && day > 30 || mon == 1 && day > 29
-                    && year % 4 == 0
-                || mon == 1 && day > 28 && year % 4 > 0 || day < 1) {
-                throw new MCRException("The day of the date is inadmissible.");
-            }
-            if (bb) {
-                year = -year + 1; // if before Buddha
-            }
-
-            if (year == 2125 && mon == 9 && day >= 5 && day < 15) {
-                day = 15;
-            }
-
-            budcal.set(year, mon, day);
-            return budcal;
-        } catch (Exception e) {
-            throw new MCRException("The ancient buddhist date is false.", e);
+        if (bb) {
+            year = -year + 1; // if before Buddha
         }
+
+        if (year == 2125 && mon == 9 && day >= 5 && day < 15) {
+            day = 15;
+        }
+
+        BuddhistCalendar budcal = new BuddhistCalendar();
+        budcal.set(year, mon, day);
+
+        return budcal;
     }
 
     /**
      * This method convert a PersicCalendar date to a GregorianCalendar value.
-     * The The syntax for the persian input is: <br>
+     * The syntax for the persian input is: <br>
      * <ul>
      * <li> [-] [[[t]t.][m]m.][yyy]y</li>
      * <li> [-] y[yyy][-m[m][-t[t]]]</li>
@@ -1137,91 +682,26 @@ public class MCRCalendar {
      */
     protected static GregorianCalendar getCalendarFromPersicDate(String datestr, boolean last) {
         try {
-            datestr = datestr.trim();
-            // test before
-            boolean bb = false;
-            int start = 0;
-            if (datestr.substring(0, 1).equals("-")) {
-                bb = true;
-                start = 1;
-                datestr = datestr.substring(start).trim();
-            }
+            final String dateTrimmed = StringUtils.trim(StringUtils.upperCase(datestr, Locale.ROOT));
 
-            // german or ISO?
-            start = 0;
-            boolean iso = false;
-            String token = ".";
+            final boolean bb = beforeZero(dateTrimmed, CalendarType.Persic);
+            final String cleanDate = cleanDate(dateTrimmed, CalendarType.Persic);
+            final int[] fields = parseDateString(cleanDate, last, CalendarType.Persic);
+            final int year = fields[0];
+            final int mon = fields[1];
+            final int day = fields[2];
 
-            if (datestr.indexOf("-", start + 1) != -1) {
-                iso = true;
-                token = "-";
-            }
-
-            int firstdot = datestr.indexOf(token, start + 1);
-            int secdot = -1;
-
-            if (firstdot != -1) {
-                secdot = datestr.indexOf(token, firstdot + 1);
-            }
-
-            int day = 0;
-            int mon = 0;
-            int year = 0;
-
-            if (secdot != -1) { // year, month, day
-                if (iso) {
-                    year = Integer.parseInt(datestr.substring(start, firstdot));
-                    mon = Integer.parseInt(datestr.substring(firstdot + 1, secdot)) - 1;
-                    day = Integer.parseInt(datestr.substring(secdot + 1));
-                } else {
-                    day = Integer.parseInt(datestr.substring(start, firstdot));
-                    mon = Integer.parseInt(datestr.substring(firstdot + 1, secdot)) - 1;
-                    year = Integer.parseInt(datestr.substring(secdot + 1));
-                }
-            } else {
-                if (firstdot != -1) { // year, month
-                    if (iso) {
-                        year = Integer.parseInt(datestr.substring(start, firstdot));
-                        mon = Integer.parseInt(datestr.substring(firstdot + 1)) - 1;
-                    } else {
-                        mon = Integer.parseInt(datestr.substring(start, firstdot)) - 1;
-                        year = Integer.parseInt(datestr.substring(firstdot + 1));
-                    }
-
-                    if (last) {
-                        if (mon == 0 || mon == 1 || mon == 2 || mon == 3 || mon == 4 || mon == 5) {
-                            day = 31;
-                        }
-                        if (mon == 6 || mon == 7 || mon == 8 || mon == 9 || mon == 10) {
-                            day = 30;
-                        }
-                        if (mon == 11) {
-                            day = 29;
-                        }
-
-                    } else {
-                        day = 1;
-                    }
-                } else { // year
-                    year = Integer.parseInt(datestr.substring(start));
-
-                    if (last) {
-                        mon = 11;
-                        day = 29;
-                    } else {
-                        mon = 0;
-                        day = 1;
-                    }
-                }
-            }
-            int njahr = 0;
+            final int njahr;
             if (bb) {
-                year = -year + 1;
+                njahr = -year + 1 + 621;
+            } else {
+                njahr = year + 621;
             }
-            njahr = year + 621;
 
             GregorianCalendar newdate = new GregorianCalendar();
-            newdate.set(njahr, 2, 20); // yearly beginning to 20.3.
+            newdate.clear();
+            newdate.set(njahr, Calendar.MARCH, 20); // yearly beginning to 20.3.
+
             // beginning of the month (day to year)
             int begday = 0;
             if (mon == 1) {
@@ -1264,26 +744,16 @@ public class MCRCalendar {
             int c = njahr % 100; // year of the century
             int d = c / 4; // count leap year of the century
 
-            int min;
+            final int min = b * 360 + 350 * c - d * 1440 + 720;
             if (njahr >= 0) {
-                min = b * 360 + 350 * c - d * 1440 + 720; // minute
                 newdate.add(Calendar.MINUTE, min); // minute of day
                 newdate.add(Calendar.DATE, begday); // day of the year
             } else {
-                min = b * 360 + 350 * c - d * 1440 + 720; // minute
                 newdate.add(Calendar.DATE, begday + 2); // day of the year
                 newdate.add(Calendar.MINUTE, min); // minute of day
             }
 
-            // problem 1582
-            year = newdate.get(Calendar.YEAR);
-            mon = newdate.get(Calendar.MONTH) + 1;
-            if (year == 1582 && mon == 10 && day >= 5 && day < 15) {
-                newdate.set(1582, 9, 15);
-            }
-
             return newdate;
-
         } catch (Exception e) {
             throw new MCRException("The ancient persian date is false.", e);
         }
@@ -1311,328 +781,80 @@ public class MCRCalendar {
      * @exception MCRException if parsing has an error
      */
     protected static GregorianCalendar getCalendarFromArmenianDate(String datestr, boolean last) {
-        try {
-            datestr = datestr.trim();
-            // test before
-            boolean ba = false;
-            int start = 0;
-            if (datestr.substring(0, 1).equals("-")) {
-                ba = true;
-                start = 1;
-                datestr = datestr.substring(start).trim();
-            }
+        final String dateTrimmed = StringUtils.trim(StringUtils.upperCase(datestr, Locale.ROOT));
 
-            // german or ISO?
-            start = 0;
-            boolean iso = false;
-            String token = ".";
+        final boolean before = beforeZero(dateTrimmed, CalendarType.Armenian);
+        final String cleanDate = cleanDate(dateTrimmed, CalendarType.Armenian);
+        final int[] fields = parseDateString(cleanDate, last, CalendarType.Armenian);
+        int year = fields[0];
+        int mon = fields[1];
+        int day = fields[2];
 
-            if (datestr.indexOf("-", start + 1) != -1) {
-                iso = true;
-                token = "-";
-            }
-
-            int firstdot = datestr.indexOf(token, start + 1);
-            int secdot = -1;
-
-            if (firstdot != -1) {
-                secdot = datestr.indexOf(token, firstdot + 1);
-            }
-            int day = 0;
-            int mon = 0;
-            int year = 0;
-
-            if (secdot != -1) { // year, month, day
-                if (iso) {
-                    year = Integer.parseInt(datestr.substring(start, firstdot));
-                    mon = Integer.parseInt(datestr.substring(firstdot + 1, secdot));
-                    day = Integer.parseInt(datestr.substring(secdot + 1));
-                } else {
-                    day = Integer.parseInt(datestr.substring(start, firstdot));
-                    mon = Integer.parseInt(datestr.substring(firstdot + 1, secdot));
-                    year = Integer.parseInt(datestr.substring(secdot + 1));
-                }
-            } else {
-                if (firstdot != -1) { // year, month
-                    if (iso) {
-                        year = Integer.parseInt(datestr.substring(start, firstdot));
-                        mon = Integer.parseInt(datestr.substring(firstdot + 1));
-                    } else {
-                        mon = Integer.parseInt(datestr.substring(start, firstdot));
-                        year = Integer.parseInt(datestr.substring(firstdot + 1));
-                    }
-
-                    if (last) {
-                        if (mon <= 12) {
-                            day = 30;
-                        }
-                        if (mon == 13) {
-                            day = 5;
-                        }
-                    } else {
-                        mon = 1;
-                        day = 1;
-                    }
-                } else { // year
-                    year = Integer.parseInt(datestr.substring(start));
-
-                    if (last) {
-                        mon = 13;
-                        day = 5;
-                    } else {
-                        mon = 1;
-                        day = 1;
-                    }
-                }
-            }
-            // test of the monthly
-            if (mon > 13 || mon < 1) {
-                throw new MCRException("The month of the date is inadmissible.");
-            }
-            // Test of the daily
-            if (day > 30 || day < 1 || day > 5 && mon == 13) {
-                throw new MCRException("The day of the date is inadmissible.");
-            }
-            int difyear;
-            int difday;
-            int jhd = 1600;
-            int ndifday = 0;
-            if (ba) {
-                year = -year + 1;
-            }
-            GregorianCalendar ecal = new GregorianCalendar();
-            if (year * 10000 + mon * 100 + day >= 10311214) {// Jahr >
-                // 14.12.1031
-                difyear = year - 1031;
-                difday = difyear * 365 + (mon - 1) * 30 + day - 344;
-                ecal.set(1582, 9, 15);
-                ecal.add(Calendar.DATE, difday);
-            }
-            if (year * 10000 + mon * 100 + day < 10311214 && year * 10000 + mon * 100 + day > 10311204) { //
-                ecal.set(1582, 9, 15);
-            }
-            if (year * 10000 + mon * 100 + day <= 10311204) {// Jahr <
-                // 5.10.1592
-                ecal.set(1582, 9, 15);
-                difyear = year - 1031;
-                int daysyear = 36525;
-                difday = difyear * 365 + (mon - 1) * 30 + day - 334;
-
-                if (difday <= -30168) {
-                    ndifday = ndifday - 30168;
-                    jhd = 1500;
-                    difday = difday + 30167;
-                    while (difday < 0) {
-                        if (difday < -daysyear) { // 36525
-                            ndifday = ndifday - daysyear;
-                            jhd = jhd - 100;
-                            if (jhd == 0) {
-                                jhd = -1;
-                            }
-                            if (jhd == -1) {
-                                jhd = 0;
-                            } else {
-                                daysyear = 36525;
-                            }
-                            if (jhd % 400 == 0) {
-                                difday = difday + daysyear;
-                            } else {
-                                difday = difday + daysyear - 1;
-                            }
-                        } else {
-                            ndifday = ndifday + difday;
-                            difday = 0;
-                        }
-                    }
-                    ecal.add(Calendar.DATE, ndifday);
-                } else {
-                    ecal.add(Calendar.DATE, difday);
-                }
-            }
-            return ecal;
-
-        } catch (Exception e) {
-            throw new MCRException("The ancient armenian date is false.", e);
+        if (before) {
+            year = -year + 1;
         }
+
+        // Armenian calendar has every year an invariant of 365 days - these are added to the beginning of the
+        // calendar defined in FIRST_ARMENIAN_DAY (13.7.552)
+        int addedDays = (year - 1) * 365;
+        if (mon == 12) {
+            addedDays += 12 * 30;
+        } else {
+            addedDays += mon * 30;
+        }
+        addedDays += day - 1;
+
+        final GregorianCalendar result = new GregorianCalendar();
+        result.set(Calendar.JULIAN_DAY, (FIRST_ARMENIAN_DAY + addedDays));
+
+        return result;
     }
 
     /**
      * This method convert a EgyptianCalendar date to a GregorianCalendar value.
-     * The The syntax for the egyptian (Nabonassar) input is: <br>
+     * The syntax for the egyptian (Nabonassar) input is: <br>
      * <ul>
      * <li> [-][[[t]t.][m]m.][yyy]y [A.N.]</li>
      * <li> [-] [[[t]t.][m]m.][yyy]y</li>
      * <li> [-] y[yyy][-m[m][-t[t]]] [A.N.]</li>
      * <li> [-] y[yyy][-m[m][-t[t]]]</li>
      * </ul>
+     * <p>
+     * For calculating the resulting Gregorian date, February, 18 747 BC is used as initial date for Egyptian calendar.
      *
-     * @param datestr
-     *            the date as string.
-     * @param last
-     *            the value is true if the date should be filled with the
-     *            highest value of month or day like 13 or 30 else it fill the
-     *            date with the lowest value 1 for month and day.
-     *
+     * @param datestr the date as string.
+     * @param last    the value is true if the date should be filled with the
+     *                highest value of month or day like 13 or 30 else it fill the
+     *                date with the lowest value 1 for month and day.
      * @return the GregorianCalendar date value or null if an error was
-     *         occurred.
-     * @exception MCRException if parsing has an error
+     * occurred.
      */
     protected static GregorianCalendar getCalendarFromEgyptianDate(String datestr, boolean last) {
-        try {
-            datestr = datestr.trim();
-            // test before
-            boolean ba = false;
-            int start = 0;
-            int ende = datestr.length();
-            if (datestr.substring(0, 1).equals("-")) {
-                ba = true;
-                start = 1;
-                datestr = datestr.substring(start).trim();
-                ende = datestr.length();
-            }
-            start = 0;
-            if (datestr.length() > 4) {
-                int i = datestr.indexOf("A.N.");
-                if (i != -1) {
-                    start = 0;
-                    ende = i;
-                }
-            }
-            datestr = datestr.substring(start, ende).trim();
-            // german or ISO?
-            start = 0;
-            boolean iso = false;
-            String token = ".";
+        final String dateTrimmed = StringUtils.trim(StringUtils.upperCase(datestr, Locale.ROOT));
 
-            if (datestr.indexOf("-", start + 1) != -1) {
-                iso = true;
-                token = "-";
-            }
+        final boolean ba = beforeZero(dateTrimmed, CalendarType.Egyptian);
+        final String cleanDate = cleanDate(dateTrimmed, CalendarType.Egyptian);
+        final int[] fields = parseDateString(cleanDate, last, CalendarType.Egyptian);
+        int year = fields[0];
+        final int mon = fields[1];
+        final int day = fields[2];
 
-            int firstdot = datestr.indexOf(token, start + 1);
-            int secdot = -1;
-
-            if (firstdot != -1) {
-                secdot = datestr.indexOf(token, firstdot + 1);
-            }
-
-            int day = 0;
-            int mon = 0;
-            int year = 0;
-
-            if (secdot != -1) { // year, month, day
-                if (iso) {
-                    year = Integer.parseInt(datestr.substring(start, firstdot));
-                    mon = Integer.parseInt(datestr.substring(firstdot + 1, secdot));
-                    day = Integer.parseInt(datestr.substring(secdot + 1));
-                } else {
-                    day = Integer.parseInt(datestr.substring(start, firstdot));
-                    mon = Integer.parseInt(datestr.substring(firstdot + 1, secdot));
-                    year = Integer.parseInt(datestr.substring(secdot + 1));
-                }
-            } else {
-                if (firstdot != -1) { // year, month
-                    if (iso) {
-                        year = Integer.parseInt(datestr.substring(start, firstdot));
-                        mon = Integer.parseInt(datestr.substring(firstdot + 1));
-                    } else {
-                        mon = Integer.parseInt(datestr.substring(start, firstdot));
-                        year = Integer.parseInt(datestr.substring(firstdot + 1));
-                    }
-
-                    if (last) {
-                        if (mon <= 12) {
-                            day = 30;
-                        }
-                        if (mon == 13) {
-                            day = 5;
-                        }
-                    } else {
-                        mon = 1;
-                        day = 1;
-                    }
-                } else { // year
-                    year = Integer.parseInt(datestr.substring(start));
-
-                    if (last) {
-                        mon = 13;
-                        day = 5;
-                    } else {
-                        mon = 1;
-                        day = 1;
-                    }
-                }
-            }
-            // test of the monthly
-            if (mon > 13 || mon < 1) {
-                throw new MCRException("The month of the date is inadmissible.");
-            }
-            // Test of the daily
-            if (day > 30 || day < 1 || day > 5 && mon == 13) {
-                throw new MCRException("The day of the date is inadmissible.");
-            }
-            int difyear;
-            int difday;
-            int jhd = 1600;
-            int ndifday = 0;
-            if (ba) {
-                year = -year + 1;
-            }
-            GregorianCalendar ecal = new GregorianCalendar();
-            if (year * 10000 + mon * 100 + day >= 23310314) {// Jahr >
-                // 15.10.1592
-                difyear = year - 2331;
-                difday = difyear * 365 + (mon - 1) * 30 + day - 74;
-                ecal.set(1582, 9, 15);
-                ecal.add(Calendar.DATE, difday);
-            }
-
-            if (year * 10000 + mon * 100 + day < 23310314 && year * 10000 + mon * 100 + day >= 23310304) { //
-                ecal.set(1582, 9, 15);
-            }
-            if (year * 10000 + mon * 100 + day < 23310304) {// Jahr <
-                // 5.10.1592
-                ecal.set(1582, 9, 15);
-                difyear = year - 2331;
-                int daysyear = 36525;
-                difday = difyear * 365 + (mon - 1) * 30 + day - 64;
-
-                if (difday <= -30168) {
-                    ndifday = ndifday - 30168;
-                    jhd = 1500;
-                    difday = difday + 30167;
-                    while (difday < 0) {
-                        if (difday < -daysyear) { // days of 100 years 36525
-                            ndifday = ndifday - daysyear;
-                            jhd = jhd - 100;
-                            if (jhd == 0) {
-                                jhd = -1;
-                            }
-                            if (jhd == -1) {
-                                jhd = 0;
-                            }
-                            // else {daysyear=36525;
-                            // }
-                            if (jhd % 400 == 0) {
-                                difday = difday + daysyear;
-                            } else {
-                                difday = difday + daysyear - 1;
-                            }
-                        } else {
-                            ndifday = ndifday + difday;
-                            difday = 0;
-                        }
-                    }
-                    ecal.add(Calendar.DATE, ndifday);
-                } else {
-                    ecal.add(Calendar.DATE, difday);
-                }
-            }
-            return ecal;
-
-        } catch (Exception e) {
-            throw new MCRException("The ancient egyptian date is false.", e);
+        if (ba) {
+            year = -year + 1;
         }
+
+        int addedDays = (year - 1) * 365;
+        if (mon == 12) {
+            addedDays += 12 * 30;
+        } else {
+            addedDays += mon * 30;
+        }
+        addedDays += day - 1;
+
+        final GregorianCalendar result = new GregorianCalendar();
+        result.set(Calendar.JULIAN_DAY, (FIRST_EGYPTIAN_DAY + addedDays));
+
+        return result;
     }
 
     /**
@@ -1729,9 +951,9 @@ public class MCRCalendar {
     /**
      * The method get a date String in format yyyy-MM-ddThh:mm:ssZ for ancient date values.
      *
-     * @param date the date string
-     * @param useLastValue as boolean 
-     *   - true if incomplete dates should be filled up with last month or last day
+     * @param date         the date string
+     * @param useLastValue as boolean
+     *                     - true if incomplete dates should be filled up with last month or last day
      * @param calendarName the name if the calendar defined in MCRCalendar
      * @return the date in format yyyy-MM-ddThh:mm:ssZ
      */
@@ -1760,9 +982,8 @@ public class MCRCalendar {
     /**
      * This method returns the calendar type as string.
      *
-     * @param calendar
-     *            the Calendar date
-     * @return The clendar type as string. If Calendar is empty an empty string will be returned.
+     * @param calendar the Calendar date
+     * @return The calendar type as string. If Calendar is empty an empty string will be returned.
      */
     public static String getCalendarTypeString(Calendar calendar) {
         if (calendar == null) {
@@ -1770,14 +991,603 @@ public class MCRCalendar {
         }
         if (calendar instanceof IslamicCalendar) {
             return TAG_ISLAMIC;
+        } else if (calendar instanceof BuddhistCalendar) {
+            return TAG_BUDDHIST;
         } else if (calendar instanceof CopticCalendar) {
             return TAG_COPTIC;
         } else if (calendar instanceof EthiopicCalendar) {
             return TAG_ETHIOPIC;
+        } else if (calendar instanceof HebrewCalendar) {
+            return TAG_HEBREW;
+        } else if (calendar instanceof JapaneseCalendar) {
+            return TAG_JAPANESE;
         } else if (calendar instanceof GregorianCalendar) {
             return TAG_GREGORIAN;
         } else {
             return TAG_JULIAN;
+        }
+    }
+
+    /**
+     * Parses a clean date string in German (d.m.y), English (d/m/y) or ISO (y-m-d) form and returns the year, month
+     * and day as an array.
+     *
+     * @param dateString   the date to parse
+     * @param last         flag to determine if the last month or day of a month is to be used when no month
+     *                     or day is given
+     * @param calendarType the calendar type to parse the date string for
+     * @return a field containing year, month and day statements
+     */
+    public static int[] parseDateString(String dateString, boolean last, CalendarType calendarType) {
+        // German, English or ISO?
+        final boolean iso = isoFormat(dateString);
+        final String delimiter = delimiter(dateString);
+
+        // check for positions of year and month delimiters
+        final int firstdot = StringUtils.indexOf(dateString, delimiter, 1);
+        final int secdot = StringUtils.indexOf(dateString, delimiter, firstdot + 1);
+
+        final int day;
+        final int mon;
+        final int year;
+        if (secdot != -1) {
+            // we have a date in the form of d.m.yy or y/m/d
+            final int firstPart = Integer.parseInt(StringUtils.substring(dateString, 0, firstdot));
+            final int secondPart = Integer.parseInt(StringUtils.substring(dateString, firstdot + 1, secdot));
+            final int thirdPart = Integer.parseInt(StringUtils.substring(dateString, secdot + 1));
+            if (iso) {
+                year = firstPart;
+                mon = secondPart - 1;
+                day = thirdPart;
+            } else {
+                day = firstPart;
+                mon = secondPart - 1;
+                year = thirdPart;
+            }
+        } else {
+            if (firstdot != -1) {
+                // we have a date in form of m.y or y/m
+                final int firstPart = Integer.parseInt(StringUtils.substring(dateString, 0, firstdot));
+                final int secondPart = Integer.parseInt(StringUtils.substring(dateString, firstdot + 1));
+                if (iso) {
+                    year = firstPart;
+                    mon = secondPart - 1;
+                } else {
+                    mon = firstPart - 1;
+                    year = secondPart;
+                }
+
+                if (last) {
+                    day = getLastDayOfMonth(mon, year, calendarType);
+                } else {
+                    day = 1;
+                }
+            } else {
+                // we have just a year statement
+                year = Integer.parseInt(dateString);
+                if (last) {
+                    mon = getLastMonth(year, calendarType);
+                    day = getLastDayOfMonth(mon, year, calendarType);
+                } else {
+                    mon = getFirstMonth(calendarType);
+                    day = 1;
+                }
+            }
+        }
+
+        return new int[] { year, mon, day };
+    }
+
+    /**
+     * Returns true if the given input date is in ISO format (xx-xx-xx), otherwise false.
+     *
+     * @param input the input date to check
+     * @return true if the given input date is in ISO format (xx-xx-xx), otherwise false
+     */
+    public static boolean isoFormat(String input) {
+        return -1 != StringUtils.indexOf(input, "-", 1);
+    }
+
+    /**
+     * Cleans a given date by removing era statements like -, AD, B.E. etc.
+     *
+     * @param input        the date to clean
+     * @param calendarType the calendar type of the given date
+     * @return the cleaned date containing only day, month and year statements
+     */
+    public static String cleanDate(String input, CalendarType calendarType) {
+        final String date = StringUtils.trim(StringUtils.upperCase(input, Locale.ROOT));
+        final int start;
+        final int end;
+        final int length = StringUtils.length(date);
+
+        if (StringUtils.startsWith(date, "-")) {
+            start = 1;
+            end = length;
+        } else {
+            final int[] borders;
+            switch (calendarType) {
+                case Armenian: {
+                    borders = calculateArmenianDateBorders(date);
+                    break;
+                }
+                case Buddhist: {
+                    borders = calculateBuddhistDateBorders(date);
+                    break;
+                }
+                case Coptic:
+                case Ethiopic: {
+                    borders = calculateCopticDateBorders(date);
+                    break;
+                }
+                case Egyptian: {
+                    borders = calculateEgyptianDateBorders(date);
+                    break;
+                }
+                case Gregorian:
+                case Julian: {
+                    borders = calculateGregorianDateBorders(date);
+                    break;
+                }
+                case Hebrew: {
+                    borders = calculateHebrewDateBorders(date);
+                    break;
+                }
+                case Islamic: {
+                    borders = calculateIslamicDateBorders(date);
+                    break;
+                }
+                case Japanese: {
+                    borders = calculateJapaneseDateBorders(date);
+                    break;
+                }
+                case Persic: {
+                    borders = calculatePersianDateBorders(date);
+                    break;
+                }
+                default: {
+                    throw new MCRException(String.format(Locale.ROOT, MSG_CALENDAR_UNSUPPORTED, calendarType));
+                }
+            }
+
+            start = borders[0];
+            end = borders[1];
+        }
+
+        return StringUtils.trim(StringUtils.substring(date, start, end));
+    }
+
+    /**
+     * Calculates the borders of an egyptian date.
+     *
+     * @param datestr the egyptian date contain era statements like -, A.N.
+     * @return the indexes of the date string containing the date without era statements
+     */
+    public static int[] calculateEgyptianDateBorders(String datestr) {
+        final int start;
+        final int ende;
+        final int length = StringUtils.length(datestr);
+
+        if (StringUtils.startsWith(datestr, "-")) {
+            start = 1;
+        } else {
+            start = 0;
+        }
+
+        if (StringUtils.contains(datestr, "A.N.")) {
+            ende = StringUtils.indexOf(datestr, "A.N.");
+        } else {
+            ende = length;
+        }
+
+        return new int[] { start, ende };
+    }
+
+    /**
+     * Calculates the borders of an armenian date.
+     *
+     * @param input the armenian date contain era statements like -
+     * @return the indexes of the date string containing the date without era statements
+     */
+    public static int[] calculateArmenianDateBorders(String input) {
+        final int start;
+        if (StringUtils.startsWith(input, "-")) {
+            start = 1;
+        } else {
+            start = 0;
+        }
+
+        return new int[] { start, StringUtils.length(input) };
+    }
+
+    /**
+     * Calculates the borders of a japanese date.
+     *
+     * @param input the japanese date contain era statements like -
+     * @return the indexes of the date string containing the date without era statements
+     */
+    public static int[] calculateJapaneseDateBorders(String input) {
+        final int start;
+        if (StringUtils.startsWith(input, "-")) {
+            start = 1;
+        } else {
+            start = 0;
+        }
+
+        return new int[] { start, StringUtils.length(input) };
+    }
+
+    /**
+     * Calculates the borders of a persian date.
+     *
+     * @param dateStr the persina date contain era statements like -
+     * @return the indexes of the date string containing the date without era statements
+     */
+    public static int[] calculatePersianDateBorders(String dateStr) {
+        final int start;
+        if (StringUtils.startsWith(dateStr, "-")) {
+            start = 1;
+        } else {
+            start = 0;
+        }
+
+        return new int[] { start, StringUtils.length(dateStr) };
+    }
+
+    /**
+     * Calculates the borders of a coptic/ethiopian date.
+     *
+     * @param input the coptic/ethiopian date contain era statements like -, A.M, A.E.
+     * @return the indexes of the date string containing the date without era statements
+     */
+    public static int[] calculateCopticDateBorders(String input) {
+        final int start;
+        final int end;
+        final int length = StringUtils.length(input);
+
+        if (StringUtils.startsWith(input, "-")) {
+            start = 1;
+            end = length;
+        } else {
+            start = 0;
+
+            if (StringUtils.contains(input, "A.M")) {
+                end = StringUtils.indexOf(input, "A.M.");
+            } else if (StringUtils.contains(input, "E.E.")) {
+                end = StringUtils.indexOf(input, "E.E.");
+            } else {
+                end = length;
+            }
+        }
+
+        return new int[] { start, end };
+    }
+
+    /**
+     * Calculates the borders of a hebrew date.
+     *
+     * @param input the hebrew date contain era statements like -
+     * @return the indexes of the date string containing the date without era statements
+     */
+    public static int[] calculateHebrewDateBorders(String input) {
+        return new int[] { 0, StringUtils.length(input) };
+    }
+
+    /**
+     * Calculates the borders of an islamic date.
+     *
+     * @param dateString the islamic date contain era statements like -
+     * @return the indexes of the date string containing the date without era statements
+     */
+    public static int[] calculateIslamicDateBorders(String dateString) {
+        int start = 0;
+        int ende = dateString.length();
+        int i = dateString.indexOf("H.");
+        if (i != -1) {
+            ende = i;
+        }
+        if (dateString.length() > 10) {
+            i = dateString.indexOf(".\u0647.\u0642");
+            if (i != -1) {
+                start = 3;
+            } else {
+                i = dateString.indexOf(".\u0647");
+                if (i != -1) {
+                    start = 2;
+                }
+            }
+        }
+
+        return new int[] { start, ende };
+    }
+
+    /**
+     * Calculates the date borders for a Gregorian date in the form d.m.y [N. CHR|V.CHR|AD|BC]
+     *
+     * @param dateString the date string to parse
+     * @return a field containing the start position of the date string in index 0 and the end position in index 1
+     */
+    public static int[] calculateGregorianDateBorders(String dateString) {
+        final int start;
+        final int end;
+        final int length = StringUtils.length(dateString);
+
+        if (StringUtils.contains(dateString, "N. CHR") || StringUtils.contains(dateString, "V. CHR")) {
+            final int positionNChr = StringUtils.indexOf(dateString, "N. CHR");
+            final int positionVChr = StringUtils.indexOf(dateString, "V. CHR");
+            if (-1 != positionNChr) {
+                if (0 == positionNChr) {
+                    start = 7;
+                    end = length;
+                } else {
+                    start = 0;
+                    end = positionNChr - 1;
+                }
+            } else if (-1 != positionVChr) {
+                if (0 == positionVChr) {
+                    start = 7;
+                    end = length;
+                } else {
+                    start = 0;
+                    end = positionVChr - 1;
+                }
+            } else {
+                start = 0;
+                end = length;
+            }
+        } else if (StringUtils.contains(dateString, "AD") || StringUtils.contains(dateString, "BC")) {
+            final int positionAD = StringUtils.indexOf(dateString, "AD");
+            final int positionBC = StringUtils.indexOf(dateString, "BC");
+            if (-1 != positionAD) {
+                if (0 == positionAD) {
+                    start = 2;
+                    end = length;
+                } else {
+                    start = 0;
+                    end = positionAD - 1;
+                }
+            } else if (-1 != positionBC) {
+                if (0 == positionBC) {
+                    start = 2;
+                    end = length;
+                } else {
+                    start = 0;
+                    end = positionBC - 1;
+                }
+            } else {
+                start = 0;
+                end = length;
+            }
+        } else {
+            start = 0;
+            end = length;
+        }
+
+        return new int[] { start, end };
+    }
+
+    /**
+     * Calculates the date borders for a Buddhist date in the form d.m.y [B.E.]
+     *
+     * @param datestr the date string to parse
+     * @return a field containing the start position of the date string in index 0 and the end position in index 1
+     */
+    public static int[] calculateBuddhistDateBorders(String datestr) {
+        final int start;
+        final int end;
+        final int length = StringUtils.length(datestr);
+
+        if (StringUtils.startsWith(datestr, "-")) {
+            start = 1;
+            end = length;
+        } else {
+            start = 0;
+
+            if (StringUtils.contains(datestr, "B.E.")) {
+                end = StringUtils.indexOf(datestr, "B.E.");
+            } else {
+                end = length;
+            }
+        }
+
+        return new int[] { start, end };
+    }
+
+    /**
+     * Returns the delimiter for the given date input: ., - or /.
+     *
+     * @param input the date input to check
+     * @return the delimiter for the given date input
+     */
+    public static String delimiter(String input) {
+        if (-1 != StringUtils.indexOf(input, "-", 1)) {
+            return "-";
+        } else if (-1 != StringUtils.indexOf(input, "/", 1)) {
+            return "/";
+        } else {
+            return ".";
+        }
+    }
+
+    /**
+     * Returns true if the given date input is before the year zero of the given calendar type.
+     * <p>
+     * Examples:
+     * <ul>
+     * <li>1 BC is before zero for gregorian/julian calendars</li>
+     * <li>-1 is before zero for all calendar types</li>
+     * <li>1 AD is after zero for gregorian/julian calendars</li>
+     * <li>1 is after zero for all calendar types</li>
+     * </ul>
+     *
+     * @param input        the input date to check
+     * @param calendarType the calendar type
+     * @return true if the given input date is for the calendars zero date
+     */
+    public static boolean beforeZero(String input, CalendarType calendarType) {
+        if (StringUtils.startsWith(input, "-")) {
+            return true;
+        }
+
+        switch (calendarType) {
+            case Buddhist: {
+                return StringUtils.contains(input, "B.E.");
+            }
+            case Gregorian:
+            case Julian: {
+                return StringUtils.contains(input, "BC") || StringUtils.contains(input, "V. CHR");
+            }
+            case Coptic:
+            case Hebrew:
+            case Ethiopic:
+            case Persic:
+            case Chinese:
+            case Islamic:
+            case Armenian:
+            case Egyptian:
+            case Japanese: {
+                // these calendars do not allow for an era statement other than -
+                return false;
+            }
+            default: {
+                throw new MCRException(String.format(Locale.ROOT, MSG_CALENDAR_UNSUPPORTED, calendarType));
+            }
+        }
+    }
+
+    /**
+     * Returns the last day number for the given month, e.g. {@link GregorianCalendar#FEBRUARY} has 28 in normal years
+     * and 29 days in leap years.
+     *
+     * @param month        the month number
+     * @param year         the year
+     * @param calendarType the calendar type to evaluate the last day for
+     * @return the last day number for the given month
+     */
+    public static int getLastDayOfMonth(int month, int year, CalendarType calendarType) {
+        final Calendar cal = Calendar.getInstance(calendarType.getLocale());
+
+        if (calendarType == CalendarType.Julian) {
+            ((GregorianCalendar) cal).setGregorianChange(new Date(Long.MAX_VALUE));
+        }
+
+        cal.set(Calendar.MONTH, month);
+        cal.set(Calendar.YEAR, year);
+
+        return cal.getActualMaximum(Calendar.DAY_OF_MONTH);
+    }
+
+    /**
+     * Returns the first month of a year for the given calendar type, e.g. January for gregorian calendars.
+     *
+     * @param calendarType the calendar type to evaluate the first month for
+     * @return the first month of a year for the given calendar type
+     */
+    public static int getFirstMonth(CalendarType calendarType) {
+        switch (calendarType) {
+            case Buddhist:
+            case Gregorian:
+            case Julian: {
+                return GregorianCalendar.JANUARY;
+            }
+            case Coptic:
+            case Egyptian: {
+                return CopticCalendar.TOUT;
+            }
+            case Ethiopic: {
+                return EthiopicCalendar.MESKEREM;
+            }
+            case Hebrew: {
+                return HebrewCalendar.TISHRI;
+            }
+            case Islamic: {
+                return IslamicCalendar.MUHARRAM;
+            }
+            case Armenian:
+            case Persic: {
+                return 0;
+            }
+            default: {
+                throw new MCRException(String.format(Locale.ROOT, MSG_CALENDAR_UNSUPPORTED, calendarType));
+            }
+        }
+    }
+
+    /**
+     * Returns the last month number of the given year for the given calendar type.
+     *
+     * @param year         the year to calculate last month number for
+     * @param calendarType the calendar type
+     * @return the last month number of the given year for the given calendar type
+     */
+    public static int getLastMonth(int year, CalendarType calendarType) {
+        final Calendar cal = Calendar.getInstance(calendarType.getLocale());
+        cal.set(Calendar.YEAR, year);
+
+        return cal.getActualMaximum(Calendar.MONTH);
+    }
+
+    /**
+     * Returns true, if the given year is a leap year in the given calendar type.
+     *
+     * @param year         the year to analyse
+     * @param calendarType the calendar type
+     * @return true, if the given year is a leap year in the given calendar type; otherwise false
+     */
+    public static boolean isLeapYear(int year, CalendarType calendarType) {
+        switch (calendarType) {
+            case Gregorian: {
+                final GregorianCalendar cal = new GregorianCalendar();
+                return cal.isLeapYear(year);
+            }
+            case Julian: {
+                final GregorianCalendar cal = new GregorianCalendar();
+                cal.setGregorianChange(new Date(Long.MAX_VALUE));
+                return cal.isLeapYear(year);
+            }
+            default: {
+                throw new MCRException(String.format(Locale.ROOT, MSG_CALENDAR_UNSUPPORTED, calendarType));
+            }
+        }
+    }
+
+    public enum CalendarType {
+        Buddhist(TAG_BUDDHIST, new ULocale("@calendar=buddhist")),
+        Chinese(TAG_CHINESE, new ULocale("@calendar=chinese")),
+        Coptic(TAG_COPTIC, new ULocale("@calendar=coptic")),
+        Ethiopic(TAG_ETHIOPIC, new ULocale("@calendar=ethiopic")),
+        Gregorian(TAG_GREGORIAN, new ULocale("@calendar=gregorian")),
+        Hebrew(TAG_HEBREW, new ULocale("@calendar=hebrew")),
+        Islamic(TAG_ISLAMIC, new ULocale("@calendar=islamic-civil")),
+        Japanese(TAG_JAPANESE, new ULocale("@calendar=japanese")),
+        Julian(TAG_JULIAN, new ULocale("@calendar=gregorian")),
+        Persic(TAG_PERSIC, new ULocale("@calendar=persian")),
+        // Armenian calendar uses coptic calendar as a base, since both have 12 months + 5 days
+        Armenian(TAG_ARMENIAN, new ULocale("@calendar=coptic")),
+        // Egyptian calendar uses coptic calendar as a base, since both have 12 months + 5 days
+        Egyptian(TAG_EGYPTIAN, new ULocale("@calendar=coptic"));
+
+        private final String type;
+
+        private final ULocale locale;
+
+        CalendarType(String type, ULocale locale) {
+            this.type = type;
+            this.locale = locale;
+        }
+
+        public ULocale getLocale() {
+            return locale;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public static CalendarType of(String type) {
+            return Arrays.stream(CalendarType.values())
+                .filter(current -> StringUtils.equals(current.getType(), type))
+                .findFirst().orElseThrow();
         }
     }
 }

--- a/mycore-base/src/test/java/org/mycore/common/MCRCalendarTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/MCRCalendarTest.java
@@ -19,18 +19,26 @@
 package org.mycore.common;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import com.ibm.icu.util.BuddhistCalendar;
 import com.ibm.icu.util.Calendar;
+import com.ibm.icu.util.CopticCalendar;
+import com.ibm.icu.util.EthiopicCalendar;
 import com.ibm.icu.util.GregorianCalendar;
+import com.ibm.icu.util.HebrewCalendar;
+import com.ibm.icu.util.IslamicCalendar;
+import com.ibm.icu.util.JapaneseCalendar;
 
 /**
  * This class is a JUnit test case for org.mycore.common.MCRCalendar.
- * 
+ *
  * @author Jens Kupferschmidt
  * @version $Revision: 1.3 $ $Date: 2008/06/02 10:10:05 $
- * 
  */
 public class MCRCalendarTest extends MCRTestCase {
 
@@ -57,6 +65,1140 @@ public class MCRCalendarTest extends MCRTestCase {
         assertEquals("gregorian with format yyyy-MM-dd", "1964-02-24", dstring);
     }
 
+    @Test
+    public void testParseGregorianDate() {
+        Calendar cal;
+
+        // 04.10.1582 AD (gregorian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("04.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 4);
+        assertEquals(cal.get(Calendar.MONTH), Calendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 1582);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.AD);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 2299160);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "2299160");
+
+        // 05.10.1582 AD (gregorian) -> 15.10.1582 (https://en.wikipedia.org/wiki/Inter_gravissimas)
+        cal = MCRCalendar.getHistoryDateAsCalendar("05.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 15);
+        assertEquals(cal.get(Calendar.MONTH), Calendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 1582);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.AD);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 2299161);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "2299161");
+
+        // 06.10.1582 AD (gregorian) -> 16.10.1582 in the ICU implementation
+        cal = MCRCalendar.getHistoryDateAsCalendar("06.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 16);
+        assertEquals(cal.get(Calendar.MONTH), Calendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 1582);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.AD);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 2299162);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "2299162");
+
+        // 15.10.1582 AD (gregorian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("15.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 15);
+        assertEquals(cal.get(Calendar.MONTH), Calendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 1582);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.AD);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 2299161);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "2299161");
+
+        // 16.10.1582 AD (gregorian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("16.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 16);
+        assertEquals(cal.get(Calendar.MONTH), Calendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 1582);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.AD);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 2299162);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "2299162");
+
+        // 01.01.1800 AD (gregorian) with missing day and last=false
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.1800", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), Calendar.JANUARY);
+        assertEquals(cal.get(Calendar.YEAR), 1800);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.AD);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 2378497);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "2378497");
+
+        // 31.01.1800 AD (gregorian) with missing day and last=true
+        cal = MCRCalendar.getHistoryDateAsCalendar("1/1800", true, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 31);
+        assertEquals(cal.get(Calendar.MONTH), Calendar.JANUARY);
+        assertEquals(cal.get(Calendar.YEAR), 1800);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.AD);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 2378527);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "2378527");
+
+        // 09.01.1800 AD (gregorian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("9/1/1800", true, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 9);
+        assertEquals(cal.get(Calendar.MONTH), Calendar.JANUARY);
+        assertEquals(cal.get(Calendar.YEAR), 1800);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.AD);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 2378505);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "2378505");
+
+        // 24.02.1964 AD (gregorian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("1964-02-24", true, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 24);
+        assertEquals(cal.get(Calendar.MONTH), Calendar.FEBRUARY);
+        assertEquals(cal.get(Calendar.YEAR), 1964);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.AD);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 2438450);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "2438450");
+
+        // 1 BC with last=true (gregorian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("1 BC", true, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 31);
+        assertEquals(cal.get(Calendar.MONTH), Calendar.DECEMBER);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 1721423);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "1721423");
+    }
+
+    @Test
+    public void testParseJulianDate() {
+        Calendar cal;
+
+        // 02.01.4713 BC (julian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("02.01.4713 bc", false, MCRCalendar.TAG_JULIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 2);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.JANUARY);
+        assertEquals(cal.get(Calendar.YEAR), 4713);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 1);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "1");
+
+        // 01.01.0814 BC (julian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("-814", false, MCRCalendar.TAG_JULIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.JANUARY);
+        assertEquals(cal.get(Calendar.YEAR), 814);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 1424110);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "1424110");
+
+        // 01.01.0814 BC (julian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("-01.01.814", false, MCRCalendar.TAG_JULIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.JANUARY);
+        assertEquals(cal.get(Calendar.YEAR), 814);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 1424110);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "1424110");
+
+        // 15.03.0044 BC (julian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("BC 15.03.44", false, MCRCalendar.TAG_JULIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 15);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.MARCH);
+        assertEquals(cal.get(Calendar.YEAR), 44);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 1705426);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "1705426");
+
+        // 01.01.0001 BC (julian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("01.01.0001 BC", false, MCRCalendar.TAG_JULIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.JANUARY);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 1721058);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "1721058");
+
+        // 31.12.0001 BC (julian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("31.12.0001 v. Chr", false, MCRCalendar.TAG_JULIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 31);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.DECEMBER);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 1721423);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "1721423");
+
+        // 01.01.0000 -> 1.1.1 BC (julian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("01.01.0000", false, MCRCalendar.TAG_JULIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.JANUARY);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 1721058);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "1721058");
+
+        // 01.01.0001 AD (julian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("01.01.01 AD", false, MCRCalendar.TAG_JULIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.JANUARY);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.AD);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 1721424);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "1721424");
+
+        // 04.10.1582 AD (julian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("04.10.1582 N. Chr", false, MCRCalendar.TAG_JULIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 4);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 1582);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.AD);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 2299160);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "2299160");
+
+        // 05.10.1582 AD (julian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("05.10.1582", false, MCRCalendar.TAG_JULIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 5);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 1582);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.AD);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 2299161);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "2299161");
+
+        // 06.10.1582 AD (julian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("06.10.1582", false, MCRCalendar.TAG_JULIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 6);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 1582);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.AD);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 2299162);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "2299162");
+
+        // 15.10.1582 AD (julian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("15.10.1582", false, MCRCalendar.TAG_JULIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 15);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 1582);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.AD);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 2299171);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "2299171");
+
+        // 16.10.1582 AD (julian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("16.10.1582", false, MCRCalendar.TAG_JULIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 16);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 1582);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.AD);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 2299172);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "2299172");
+
+        // 28.02.1700 AD (julian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("28.02.1700", false, MCRCalendar.TAG_JULIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 28);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.FEBRUARY);
+        assertEquals(cal.get(Calendar.YEAR), 1700);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.AD);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 2342041);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "2342041");
+
+        // 29.02.1700 AD (julian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("29.02.1700", false, MCRCalendar.TAG_JULIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 29);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.FEBRUARY);
+        assertEquals(cal.get(Calendar.YEAR), 1700);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.AD);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 2342042);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "2342042");
+
+        // 1 BC with last=true (jul)
+        cal = MCRCalendar.getHistoryDateAsCalendar("1 BC", true, MCRCalendar.TAG_JULIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 31);
+        assertEquals(cal.get(Calendar.MONTH), Calendar.DECEMBER);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 1721423);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "1721423");
+    }
+
+    @Test
+    public void testParseIslamicDate() {
+        Calendar cal;
+
+        // 01.01.0001 h. (islamic)
+        cal = MCRCalendar.getHistoryDateAsCalendar("01.01.0001 h.", false, MCRCalendar.TAG_ISLAMIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), IslamicCalendar.MUHARRAM);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+
+        // first day of Islamic calendar is 16.7.622 in Gregorian/Julian calendar
+        Calendar greg = MCRCalendar.getHistoryDateAsCalendar("16.7.622", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(greg), MCRCalendar.getJulianDayNumber(cal));
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 1948440);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "1948440");
+
+        // 01.01.800 H. (islamic) -> 24.09.1397 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.800 H.", false, MCRCalendar.TAG_ISLAMIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), IslamicCalendar.MUHARRAM);
+        assertEquals(cal.get(Calendar.YEAR), 800);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("24.09.1397", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 30.01.800 H. (islamic) -> 23.10.1397 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.800 H.", true, MCRCalendar.TAG_ISLAMIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 30);
+        assertEquals(cal.get(Calendar.MONTH), IslamicCalendar.MUHARRAM);
+        assertEquals(cal.get(Calendar.YEAR), 800);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("23.10.1397", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 29.12.800 H. (islamic) -> 12.09.1398 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("800", true, MCRCalendar.TAG_ISLAMIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 29);
+        assertEquals(cal.get(Calendar.MONTH), IslamicCalendar.DHU_AL_HIJJAH);
+        assertEquals(cal.get(Calendar.YEAR), 800);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("12.09.1398", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // -1 (isl) -> 15.07.622 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("-1", true, MCRCalendar.TAG_ISLAMIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 29);
+        assertEquals(cal.get(Calendar.MONTH), IslamicCalendar.DHU_AL_HIJJAH);
+        assertEquals(cal.get(Calendar.YEAR), 0);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("15.7.622", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+    }
+
+    @Test
+    public void testParseCopticDate() {
+        Calendar cal;
+
+        // 01.01.0001 A.M. (coptic)
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.1.1 a.M.", false, MCRCalendar.TAG_COPTIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), CopticCalendar.TOUT);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+
+        // first day of Coptic calendar is 29.8.284 in Gregorian/Julian calendar
+        Calendar greg = MCRCalendar.getHistoryDateAsCalendar("29.8.284", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(greg), MCRCalendar.getJulianDayNumber(cal));
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 1825030);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "1825030");
+
+        // 01.01.1724 A.M. (coptic) -> 12.09.2007
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.1.1724 A.M.", false, MCRCalendar.TAG_COPTIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), CopticCalendar.TOUT);
+        assertEquals(cal.get(Calendar.YEAR), 1724);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("12.09.2007", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 05.13.1724 E.E. (coptic) -> 10.09.2008
+        cal = MCRCalendar.getHistoryDateAsCalendar("1724 a.M.", true, MCRCalendar.TAG_COPTIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 5);
+        assertEquals(cal.get(Calendar.MONTH), CopticCalendar.NASIE);
+        assertEquals(cal.get(Calendar.YEAR), 1724);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("10.09.2008", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // -5.13.1 (cop) -> 28.8.284
+        cal = MCRCalendar.getHistoryDateAsCalendar("-1", true, MCRCalendar.TAG_COPTIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 5);
+        assertEquals(cal.get(Calendar.MONTH), CopticCalendar.NASIE);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("28.8.284", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+    }
+
+    @Test
+    public void testParseEthiopianDate() {
+        Calendar cal;
+
+        // 01.01.0001 E.E. (ethiopic)
+        cal = MCRCalendar.getHistoryDateAsCalendar("1 E.E.", false, MCRCalendar.TAG_ETHIOPIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), EthiopicCalendar.MESKEREM);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+
+        // first day of Ehtiopian calendar is 29.8.8 in Gregorian/Julian calendar
+        Calendar greg = MCRCalendar.getHistoryDateAsCalendar("29.8.8", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(greg), MCRCalendar.getJulianDayNumber(cal));
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 1724221);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "1724221");
+
+        // 05.13.2000 E.E. (ethiopic) -> 10.09.2008 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("2000 E.E.", true, MCRCalendar.TAG_ETHIOPIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 5);
+        assertEquals(cal.get(Calendar.MONTH), EthiopicCalendar.PAGUMEN);
+        assertEquals(cal.get(Calendar.YEAR), 2000);
+        assertEquals(cal.get(Calendar.ERA), 1);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("10.09.2008", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // years before 0 are represented in Amete Alem format (starting with count from 5500 BC)
+        cal = MCRCalendar.getHistoryDateAsCalendar("-1", true, MCRCalendar.TAG_ETHIOPIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 5);
+        assertEquals(cal.get(Calendar.MONTH), EthiopicCalendar.PAGUMEN);
+        assertEquals(cal.get(Calendar.YEAR), 5500);
+        assertEquals(cal.get(Calendar.ERA), 0);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("28.8.8", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+    }
+
+    @Test
+    public void testParseHebrewDate() {
+        Calendar cal;
+
+        // 1.1.1 (hebrew)
+        cal = MCRCalendar.getHistoryDateAsCalendar("1", false, MCRCalendar.TAG_HEBREW);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), HebrewCalendar.TISHRI);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+
+        // first day of Hebrew calendar is 7.10.3761 BC in Gregorian/Julian calendar
+        Calendar greg = MCRCalendar.getHistoryDateAsCalendar("7.10.3761 BC", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 347998);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "347998");
+
+        // 04.10.1582 (hebrew) - 29.04.2178 BC
+        cal = MCRCalendar.getHistoryDateAsCalendar("04.10.1582", false, MCRCalendar.TAG_HEBREW);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 4);
+        assertEquals(cal.get(Calendar.MONTH), HebrewCalendar.SIVAN);
+        assertEquals(cal.get(Calendar.YEAR), 1582);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("17.05.2179 BC", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 18.01.5343 (hebrew) -> 04.10.1582 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("18.01.5343", false, MCRCalendar.TAG_HEBREW);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 18);
+        assertEquals(cal.get(Calendar.MONTH), HebrewCalendar.TISHRI);
+        assertEquals(cal.get(Calendar.YEAR), 5343);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("04.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 19.01.5343 (hebrew) -> 15.10.1582 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("19.01.5343", false, MCRCalendar.TAG_HEBREW);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 19);
+        assertEquals(cal.get(Calendar.MONTH), HebrewCalendar.TISHRI);
+        assertEquals(cal.get(Calendar.YEAR), 5343);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("15.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 19.01.5343 (hebrew) -> 16.10.1582 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("20.01.5343", false, MCRCalendar.TAG_HEBREW);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 20);
+        assertEquals(cal.get(Calendar.MONTH), HebrewCalendar.TISHRI);
+        assertEquals(cal.get(Calendar.YEAR), 5343);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("16.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 01.01.1800 (hebrew) with missing day and last=false
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.1800", false, MCRCalendar.TAG_HEBREW);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), HebrewCalendar.TISHRI);
+        assertEquals(cal.get(Calendar.YEAR), 1800);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("09.09.1962 BC", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // -1 (hebrew) not supported
+        assertThrows(MCRException.class,
+                () -> MCRCalendar.getHistoryDateAsCalendar("-1", true, MCRCalendar.TAG_HEBREW));
+    }
+
+    @Test
+    public void testParseBuddhistDate() {
+        Calendar cal;
+
+        // 1.1.1 (buddhist)
+        cal = MCRCalendar.getHistoryDateAsCalendar("1", false, MCRCalendar.TAG_BUDDHIST);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), BuddhistCalendar.JANUARY);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+
+        // first day of Buddhist calendar is 1.1.543 BC in Gregorian/Julian calendar
+        Calendar greg = MCRCalendar.getHistoryDateAsCalendar("1.1.543 BC", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 1523093);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "1523093");
+
+        // year 0
+        cal = MCRCalendar.getHistoryDateAsCalendar("0", false, MCRCalendar.TAG_BUDDHIST);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), BuddhistCalendar.JANUARY);
+        assertEquals(cal.get(Calendar.YEAR), 0);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("1.1.544 BC", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // year -1
+        cal = MCRCalendar.getHistoryDateAsCalendar("-1.1.1", false, MCRCalendar.TAG_BUDDHIST);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), BuddhistCalendar.JANUARY);
+        assertEquals(cal.get(Calendar.YEAR), 0);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("1.1.544 BC", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // year -100
+        cal = MCRCalendar.getHistoryDateAsCalendar("-100", false, MCRCalendar.TAG_BUDDHIST);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), BuddhistCalendar.JANUARY);
+        assertEquals(cal.get(Calendar.YEAR), -99);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("1.1.643 BC", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 04.10.2125 (buddhist) -> year 1582 in gregorian calendar
+        cal = MCRCalendar.getHistoryDateAsCalendar("04.10.2125", false, MCRCalendar.TAG_BUDDHIST);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 4);
+        assertEquals(cal.get(Calendar.MONTH), BuddhistCalendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 2125);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("04.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 05.10.2125 (buddhist) -> 15.10.1582 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("05.10.2125", false, MCRCalendar.TAG_BUDDHIST);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 15);
+        assertEquals(cal.get(Calendar.MONTH), BuddhistCalendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 2125);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("05.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 06.10.2125 (buddhist) -> 15.10.1582 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("06.10.2125", false, MCRCalendar.TAG_BUDDHIST);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 15);
+        assertEquals(cal.get(Calendar.MONTH), BuddhistCalendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 2125);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("15.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 15.10.2125 (buddhist) -> 15.10.1582 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("15.10.2125", false, MCRCalendar.TAG_BUDDHIST);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 15);
+        assertEquals(cal.get(Calendar.MONTH), BuddhistCalendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 2125);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("15.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 16.10.2125 (buddhist) -> 15.10.1582 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("16.10.2125", false, MCRCalendar.TAG_BUDDHIST);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 16);
+        assertEquals(cal.get(Calendar.MONTH), BuddhistCalendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 2125);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("16.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 01.01.1800 (buddhist) with missing day and last=false -> 01.01.257 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.1800", false, MCRCalendar.TAG_BUDDHIST);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), BuddhistCalendar.JANUARY);
+        assertEquals(cal.get(Calendar.YEAR), 1800);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("01.01.1257", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 24.02.1964 (buddhist) -> 24.04142 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("1964-02-24", true, MCRCalendar.TAG_BUDDHIST);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 24);
+        assertEquals(cal.get(Calendar.MONTH), BuddhistCalendar.FEBRUARY);
+        assertEquals(cal.get(Calendar.YEAR), 1964);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("24.02.1421", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 24.02.1964 BE (buddhist) -> 24.02.2507 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("1964-02-24 B.E.", true, MCRCalendar.TAG_BUDDHIST);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 24);
+        assertEquals(cal.get(Calendar.MONTH), BuddhistCalendar.FEBRUARY);
+        assertEquals(cal.get(Calendar.YEAR), -1963);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("24.02.2507 BC", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // -1 (buddhist) -> 24.02.2507 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("-1", true, MCRCalendar.TAG_BUDDHIST);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 31);
+        assertEquals(cal.get(Calendar.MONTH), BuddhistCalendar.DECEMBER);
+        assertEquals(cal.get(Calendar.YEAR), 0);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("31.12.544 BC", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+    }
+
+    @Test
+    public void testParsePersianDate() {
+        Calendar cal;
+
+        // 01.01.0001  (persian) -> 22.3.622 greg
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_PERSIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 21);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.MARCH);
+        assertEquals(cal.get(Calendar.YEAR), 622);
+
+        // first day of Persian calendar is 21.3.622 in Gregorian/Julian calendar
+        Calendar greg = MCRCalendar.getHistoryDateAsCalendar("21.3.622", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 1948323);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "1948323");
+
+        // 01.01.800 (persian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.800", false, MCRCalendar.TAG_PERSIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 21);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.MARCH);
+        assertEquals(cal.get(Calendar.YEAR), 1421);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("21.03.1421", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 31.01.800 (persian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.800", true, MCRCalendar.TAG_PERSIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 20);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.APRIL);
+        assertEquals(cal.get(Calendar.YEAR), 1421);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("20.04.1421", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 29.12.800 (persian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("800", true, MCRCalendar.TAG_PERSIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 20);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.MARCH);
+        assertEquals(cal.get(Calendar.YEAR), 1422);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("20.03.1422", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // gregorian calendar reform on October, 5th 1582 -> skip days between 5 and 15
+        cal = MCRCalendar.getHistoryDateAsCalendar("12.7.961", false, MCRCalendar.TAG_PERSIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 4);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 1582);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("04.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("13.7.961", false, MCRCalendar.TAG_PERSIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 15);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 1582);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("15.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("14.7.961", false, MCRCalendar.TAG_PERSIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 16);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 1582);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("16.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // -1.1.1 (pers) -> 22.03.621 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("-1", false, MCRCalendar.TAG_PERSIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 21);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.MARCH);
+        assertEquals(cal.get(Calendar.YEAR), 621);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("21.03.621", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // -29.12.1 (pers) -> 21.03.621 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("-1", true, MCRCalendar.TAG_PERSIC);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 21);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.MARCH);
+        assertEquals(cal.get(Calendar.YEAR), 622);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("21.03.622", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+    }
+
+    @Test
+    public void testParseArmenianDate() {
+        Calendar cal;
+
+        // 01.01.0001  (armenian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_ARMENIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 13);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.JULY);
+        assertEquals(cal.get(Calendar.YEAR), 552);
+
+        // first day of Armenian calendar is 13.7.552 in Gregorian/11.7.552 in Julian calendar
+        Calendar greg = MCRCalendar.getHistoryDateAsCalendar("13.7.552", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 1922870);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "1922870");
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.2.1", false, MCRCalendar.TAG_ARMENIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 12);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.AUGUST);
+        assertEquals(cal.get(Calendar.YEAR), 552);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("12.08.552", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("5.13.1", false, MCRCalendar.TAG_ARMENIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 12);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.JULY);
+        assertEquals(cal.get(Calendar.YEAR), 553);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("12.07.553", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("2.9.48", false, MCRCalendar.TAG_ARMENIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 28);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.FEBRUARY);
+        assertEquals(cal.get(Calendar.YEAR), 600);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("28.02.600", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("3.9.48", false, MCRCalendar.TAG_ARMENIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 29);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.FEBRUARY);
+        assertEquals(cal.get(Calendar.YEAR), 600);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("29.02.600", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("4.9.48", false, MCRCalendar.TAG_ARMENIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.MARCH);
+        assertEquals(cal.get(Calendar.YEAR), 600);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("01.03.600", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.1.1462", false, MCRCalendar.TAG_ARMENIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 26);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.JULY);
+        assertEquals(cal.get(Calendar.YEAR), 2012);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("26.07.2012", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.1.101", false, MCRCalendar.TAG_ARMENIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 18);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.JUNE);
+        assertEquals(cal.get(Calendar.YEAR), 652);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("18.06.652", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.1.1031", false, MCRCalendar.TAG_ARMENIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 29);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 1581);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("29.10.1581", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // checks for gregorian calendar switch in 1582
+        // 11.12.1031 arm -> 4.10.1582 greg
+        cal = MCRCalendar.getHistoryDateAsCalendar("11.12.1031", false, MCRCalendar.TAG_ARMENIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 4);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 1582);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("04.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 12.12.1031 arm -> 15.10.1582 greg
+        cal = MCRCalendar.getHistoryDateAsCalendar("12.12.1031", false, MCRCalendar.TAG_ARMENIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 15);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 1582);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("15.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 13.12.1031 arm -> 16.10.1582 greg
+        cal = MCRCalendar.getHistoryDateAsCalendar("13.12.1031", false, MCRCalendar.TAG_ARMENIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 16);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.OCTOBER);
+        assertEquals(cal.get(Calendar.YEAR), 1582);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("16.10.1582", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 12.500 (last=false) -> 1.12.500 -> 8.2.1052 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("12.500", false, MCRCalendar.TAG_ARMENIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 4);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.FEBRUARY);
+        assertEquals(cal.get(Calendar.YEAR), 1052);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("04.02.1052", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 12.500 (last=true) -> 30.12.500 -> 8.3.1052 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("12.500", true, MCRCalendar.TAG_ARMENIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 4);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.MARCH);
+        assertEquals(cal.get(Calendar.YEAR), 1052);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("04.03.1052", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 500 (last=false) -> 1.1.500 -> 15.3.1051 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("500", false, MCRCalendar.TAG_ARMENIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 11);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.MARCH);
+        assertEquals(cal.get(Calendar.YEAR), 1051);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("11.03.1051", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 500 (last=true) -> 5.13.500 -> 13.3.1052 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("500", true, MCRCalendar.TAG_ARMENIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 9);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.MARCH);
+        assertEquals(cal.get(Calendar.YEAR), 1052);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("09.03.1052", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // -1 (last=true) -> 5.13.-1 -> 12.07.552 (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("-1", true, MCRCalendar.TAG_ARMENIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 12);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.JULY);
+        assertEquals(cal.get(Calendar.YEAR), 552);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("12.07.552", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+    }
+
+    @Test
+    public void testParseEgyptianDate() {
+        Calendar cal;
+
+        // 01.01.0001  (egyptian)
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_EGYPTIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 18);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.FEBRUARY);
+        assertEquals(cal.get(Calendar.YEAR), 747);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        // first day of Egyptian calendar is 18.2.747 BC in Gregorian/Julian calendar
+        Calendar greg = MCRCalendar.getHistoryDateAsCalendar("18.2.747 BC", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), 1448630);
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), "1448630");
+
+        // 1.1 -> 30.1.1 in Gregorian date: 19.3.747 BC
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.1 A.N.", true, MCRCalendar.TAG_EGYPTIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 19);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.MARCH);
+        assertEquals(cal.get(Calendar.YEAR), 747);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("19.03.747 BC", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 10.1 (last=false) -> 1.10.1 in Gregorian date: 14.12.747 BC
+        cal = MCRCalendar.getHistoryDateAsCalendar("10.1 A.N.", false, MCRCalendar.TAG_EGYPTIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 15);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.NOVEMBER);
+        assertEquals(cal.get(Calendar.YEAR), 747);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("15.11.747 BC", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 10.1 (last=true) -> 30.10.1 in Gregorian date: 14.12.747 BC
+        cal = MCRCalendar.getHistoryDateAsCalendar("10.1 A.N.", true, MCRCalendar.TAG_EGYPTIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 14);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.DECEMBER);
+        assertEquals(cal.get(Calendar.YEAR), 747);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("14.12.747 BC", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 1.2.1 -> in Gregorian date: 20.3.747 BC
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.2.1 A.N.", false, MCRCalendar.TAG_EGYPTIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 20);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.MARCH);
+        assertEquals(cal.get(Calendar.YEAR), 747);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("20.03.747 BC", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 13.1 (last=false) -> 1.13.1 (in Gregorian date: 17.2.746)
+        cal = MCRCalendar.getHistoryDateAsCalendar("13.1 A.N.", false, MCRCalendar.TAG_EGYPTIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 13);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.FEBRUARY);
+        assertEquals(cal.get(Calendar.YEAR), 746);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("13.02.746 BC", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // 1 (last=true) -> 5.13.1 (in Gregorian date: 17.2.746)
+        cal = MCRCalendar.getHistoryDateAsCalendar("1 A.N.", true, MCRCalendar.TAG_EGYPTIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 17);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.FEBRUARY);
+        assertEquals(cal.get(Calendar.YEAR), 746);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("17.02.746 BC", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+
+        // -1 (last=true) -> 17.02.747 BC (greg)
+        cal = MCRCalendar.getHistoryDateAsCalendar("-1", true, MCRCalendar.TAG_EGYPTIAN);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 17);
+        assertEquals(cal.get(Calendar.MONTH), GregorianCalendar.FEBRUARY);
+        assertEquals(cal.get(Calendar.YEAR), 747);
+        assertEquals(cal.get(Calendar.ERA), GregorianCalendar.BC);
+
+        greg = MCRCalendar.getHistoryDateAsCalendar("17.02.747 BC", false, MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getJulianDayNumber(cal), MCRCalendar.getJulianDayNumber(greg));
+        assertEquals(MCRCalendar.getJulianDayNumberAsString(cal), MCRCalendar.getJulianDayNumberAsString(greg));
+    }
+
+    @Test
+    public void testParseJapaneseDate() {
+        Calendar cal;
+
+        // Meiji era: 8.9.1868 - 29.07.1912
+        cal = MCRCalendar.getHistoryDateAsCalendar("8.9.M1", true, MCRCalendar.TAG_JAPANESE);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 8);
+        assertEquals(cal.get(Calendar.MONTH), JapaneseCalendar.SEPTEMBER);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+        assertEquals(cal.get(Calendar.ERA), JapaneseCalendar.MEIJI);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal),
+                MCRCalendar.getJulianDayNumber(
+                        MCRCalendar.getHistoryDateAsCalendar("8.9.1868", false, MCRCalendar.TAG_GREGORIAN)));
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("29.7.M45", true, MCRCalendar.TAG_JAPANESE);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 29);
+        assertEquals(cal.get(Calendar.MONTH), JapaneseCalendar.JULY);
+        assertEquals(cal.get(Calendar.YEAR), 45);
+        assertEquals(cal.get(Calendar.ERA), JapaneseCalendar.MEIJI);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal),
+                MCRCalendar.getJulianDayNumber(
+                        MCRCalendar.getHistoryDateAsCalendar("29.7.1912", false, MCRCalendar.TAG_GREGORIAN)));
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("30.7.M45", true, MCRCalendar.TAG_JAPANESE);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 30);
+        assertEquals(cal.get(Calendar.MONTH), JapaneseCalendar.JULY);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+        assertEquals(cal.get(Calendar.ERA), JapaneseCalendar.TAISHO);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal),
+                MCRCalendar.getJulianDayNumber(
+                        MCRCalendar.getHistoryDateAsCalendar("30.7.1912", false, MCRCalendar.TAG_GREGORIAN)));
+
+        // Taisho era: 30.7.1912-24.12.1926
+        cal = MCRCalendar.getHistoryDateAsCalendar("30.7.T1", true, MCRCalendar.TAG_JAPANESE);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 30);
+        assertEquals(cal.get(Calendar.MONTH), JapaneseCalendar.JULY);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+        assertEquals(cal.get(Calendar.ERA), JapaneseCalendar.TAISHO);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal),
+                MCRCalendar.getJulianDayNumber(
+                        MCRCalendar.getHistoryDateAsCalendar("30.7.1912", false, MCRCalendar.TAG_GREGORIAN)));
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("24.12.T15", true, MCRCalendar.TAG_JAPANESE);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 24);
+        assertEquals(cal.get(Calendar.MONTH), JapaneseCalendar.DECEMBER);
+        assertEquals(cal.get(Calendar.YEAR), 15);
+        assertEquals(cal.get(Calendar.ERA), JapaneseCalendar.TAISHO);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal),
+                MCRCalendar.getJulianDayNumber(
+                        MCRCalendar.getHistoryDateAsCalendar("24.12.1926", false, MCRCalendar.TAG_GREGORIAN)));
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("25.12.T15", true, MCRCalendar.TAG_JAPANESE);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 25);
+        assertEquals(cal.get(Calendar.MONTH), JapaneseCalendar.DECEMBER);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+        assertEquals(cal.get(Calendar.ERA), JapaneseCalendar.SHOWA);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal),
+                MCRCalendar.getJulianDayNumber(
+                        MCRCalendar.getHistoryDateAsCalendar("25.12.1926", false, MCRCalendar.TAG_GREGORIAN)));
+
+        // Showa era: 25.12.1926-07.01.1989
+        cal = MCRCalendar.getHistoryDateAsCalendar("25.12.S1", true, MCRCalendar.TAG_JAPANESE);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 25);
+        assertEquals(cal.get(Calendar.MONTH), JapaneseCalendar.DECEMBER);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+        assertEquals(cal.get(Calendar.ERA), JapaneseCalendar.SHOWA);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal),
+                MCRCalendar.getJulianDayNumber(
+                        MCRCalendar.getHistoryDateAsCalendar("25.12.1926", false, MCRCalendar.TAG_GREGORIAN)));
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("7.1.S64", true, MCRCalendar.TAG_JAPANESE);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 7);
+        assertEquals(cal.get(Calendar.MONTH), JapaneseCalendar.JANUARY);
+        assertEquals(cal.get(Calendar.YEAR), 64);
+        assertEquals(cal.get(Calendar.ERA), JapaneseCalendar.SHOWA);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal),
+                MCRCalendar.getJulianDayNumber(
+                        MCRCalendar.getHistoryDateAsCalendar("7.1.1989", false, MCRCalendar.TAG_GREGORIAN)));
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("8.1.S64", true, MCRCalendar.TAG_JAPANESE);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 8);
+        assertEquals(cal.get(Calendar.MONTH), JapaneseCalendar.JANUARY);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+        assertEquals(cal.get(Calendar.ERA), JapaneseCalendar.HEISEI);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal),
+                MCRCalendar.getJulianDayNumber(
+                        MCRCalendar.getHistoryDateAsCalendar("8.1.1989", false, MCRCalendar.TAG_GREGORIAN)));
+
+        // Heisei era: 08.01.1989-30.04.2019
+        cal = MCRCalendar.getHistoryDateAsCalendar("8.1.H1", true, MCRCalendar.TAG_JAPANESE);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 8);
+        assertEquals(cal.get(Calendar.MONTH), JapaneseCalendar.JANUARY);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+        assertEquals(cal.get(Calendar.ERA), JapaneseCalendar.HEISEI);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal),
+                MCRCalendar.getJulianDayNumber(
+                        MCRCalendar.getHistoryDateAsCalendar("8.1.1989", false, MCRCalendar.TAG_GREGORIAN)));
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("30.4.H31", true, MCRCalendar.TAG_JAPANESE);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 30);
+        assertEquals(cal.get(Calendar.MONTH), JapaneseCalendar.APRIL);
+        assertEquals(cal.get(Calendar.YEAR), 31);
+        assertEquals(cal.get(Calendar.ERA), JapaneseCalendar.HEISEI);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal),
+                MCRCalendar.getJulianDayNumber(
+                        MCRCalendar.getHistoryDateAsCalendar("30.4.2019", false, MCRCalendar.TAG_GREGORIAN)));
+
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.5.H31", true, MCRCalendar.TAG_JAPANESE);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), JapaneseCalendar.MAY);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+        assertEquals(cal.get(Calendar.ERA), JapaneseCalendar.REIWA);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal),
+                MCRCalendar.getJulianDayNumber(
+                        MCRCalendar.getHistoryDateAsCalendar("1.5.2019", false, MCRCalendar.TAG_GREGORIAN)));
+
+        // Reiwa era: 01.05.2019 - present
+        cal = MCRCalendar.getHistoryDateAsCalendar("1.5.R1", true, MCRCalendar.TAG_JAPANESE);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), JapaneseCalendar.MAY);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+        assertEquals(cal.get(Calendar.ERA), JapaneseCalendar.REIWA);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal),
+                MCRCalendar.getJulianDayNumber(
+                        MCRCalendar.getHistoryDateAsCalendar("1.5.2019", false, MCRCalendar.TAG_GREGORIAN)));
+
+        // check ISO format
+        cal = MCRCalendar.getHistoryDateAsCalendar("R1-5-1", true, MCRCalendar.TAG_JAPANESE);
+        assertEquals(cal.get(Calendar.DAY_OF_MONTH), 1);
+        assertEquals(cal.get(Calendar.MONTH), JapaneseCalendar.MAY);
+        assertEquals(cal.get(Calendar.YEAR), 1);
+        assertEquals(cal.get(Calendar.ERA), JapaneseCalendar.REIWA);
+
+        assertEquals(MCRCalendar.getJulianDayNumber(cal),
+                MCRCalendar.getJulianDayNumber(
+                        MCRCalendar.getHistoryDateAsCalendar("1.5.2019", false, MCRCalendar.TAG_GREGORIAN)));
+    }
+
     /*
      * Test method for 'org.mycore.datamodel.metadata.MCRCalendar.getHistoryDateAsCalendar(String, boolean, String)'
      */
@@ -69,7 +1211,7 @@ public class MCRCalendarTest extends MCRTestCase {
         /* check julian calendar implementation */
         // all entries are empty
         try {
-            cal = MCRCalendar.getHistoryDateAsCalendar(null, false, null);
+            cal = MCRCalendar.getHistoryDateAsCalendar(null, false, MCRCalendar.CalendarType.Islamic);
         } catch (MCRException e) {
             cal = new GregorianCalendar();
         }
@@ -113,163 +1255,6 @@ public class MCRCalendarTest extends MCRTestCase {
         cal.set(Calendar.JULIAN_DAY, MCRCalendar.MAX_JULIAN_DAY_NUMBER);
         dstring = MCRCalendar.getJulianDayNumberAsString(cal);
         assertEquals("julian: 28.01.4000 AD", "3182057", dstring);
-
-        // 02.01.4713 BC (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("02.01.4713 bc", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 02.01.4713 BC", "1", dstring);
-        // 01.01.0814 BC (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("-814", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 01.01.0814 BC", "1424110", dstring);
-        // 01.01.0814 BC (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("-01.01.814", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 01.01.0814 BC", "1424110", dstring);
-        // 15.03.0044 BC (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("BC 15.03.44", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 15.03.0044 BC", "1705426", dstring);
-        // 01.01.0001 BC (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("01.01.0001 BC", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 01.01.0001 BC", "1721058", dstring);
-        // 31.12.0001 BC (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("31.12.0001 v. Chr", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 31.12.0001 BC", "1721423", dstring);
-        // 01.01.0000 AD (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("01.01.0000", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 01.01.0000 AD", "1721058", dstring);
-        // 01.01.0001 AD (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("01.01.01 AD", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian", "1721424", dstring);
-        // 04.10.1582 AD (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("04.10.1582 N. Chr", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 04.10.1582 AD", "2299160", dstring);
-        // 05.10.1582 AD (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("05.10.1582", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 05.10.1582 AD", "2299161", dstring);
-        // 06.10.1582 AD (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("06.10.1582", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 06.10.1582 AD", "2299162", dstring);
-        // 15.10.1582 AD (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("15.10.1582", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 15.10.1582 AD", "2299171", dstring);
-        // 16.10.1582 AD (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("16.10.1582", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 16.10.1582 AD", "2299172", dstring);
-        // 28.02.1700 AD (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("28.02.1700", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 28.02.1700 AD", "2342041", dstring);
-        // 29.02.1700 AD (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("29.02.1700", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 29.02.1700 AD", "2342042", dstring);
-        // 01.03.1700 AD (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("01.03.1700", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 01.03.1700 AD", "2342043", dstring);
-        // 28.02.1800 AD (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("28.02.1800", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 28.02.1800 AD", "2378566", dstring);
-        // 29.02.1800 AD (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("29.02.1800", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 29.02.1800 AD", "2378567", dstring);
-        // 01.03.1800 AD (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("01.03.1800", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 01.03.1800 AD", "2378568", dstring);
-        // 29.02.1900 AD (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("29.02.1900", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 29.02.1900 AD", "2415092", dstring);
-        // 29.02.2100 AD (julian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("29.02.2100", false, MCRCalendar.TAG_JULIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("julian: 29.02.2100 AD", "2488142", dstring);
-
-        /* gregorian date check */
-        // 04.10.1582 AD (gregorian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("04.10.1582", false, MCRCalendar.TAG_GREGORIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("gregorian: 04.10.1582 AD", "2299160", dstring);
-        // 05.10.1582 AD (gregorian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("05.10.1582", false, MCRCalendar.TAG_GREGORIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("gregorian: 05.10.1582 AD", "2299161", dstring);
-        // 15.10.1582 AD (gregorian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("15.10.1582", false, MCRCalendar.TAG_GREGORIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("gregorian: 15.10.1582 AD", "2299161", dstring);
-        // 06.10.1582 AD (gregorian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("16.10.1582", false, MCRCalendar.TAG_GREGORIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("gregorian: 06.10.1582 AD", "2299162", dstring);
-        // 31.01.1800 AD (gregorian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("1.1800", true, MCRCalendar.TAG_GREGORIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("gregorian: 31.01.1800 AD", "2378527", dstring);
-        // 31.01.1800 AD (gregorian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("1/1800", true, MCRCalendar.TAG_GREGORIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("gregorian: 31.01.1800 AD", "2378527", dstring);
-        // 01.31.1800 AD (gregorian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("9/1/1800", true, MCRCalendar.TAG_GREGORIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("gregorian: 01.31.1800 AD", "2378505", dstring);
-        // 24.02.1964 AD (gregorian)
-        cal = MCRCalendar.getHistoryDateAsCalendar("1964-02-24", true, MCRCalendar.TAG_GREGORIAN);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("gregorian: 1964-02-24 AD", "2438450", dstring);
-
-        // 01.01.0001 h. (islamic)
-        cal = MCRCalendar.getHistoryDateAsCalendar("01.01.0001 h.", false, MCRCalendar.TAG_ISLAMIC);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("islamic: 01.01.0001 H.", "1948440", dstring);
-        // 01.01.800 H. (islamic)
-        cal = MCRCalendar.getHistoryDateAsCalendar("1.800 H.", false, MCRCalendar.TAG_ISLAMIC);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("islamic: 01.01.800 H.", "2231579", dstring);
-        // 30.01.800 H. (islamic)
-        cal = MCRCalendar.getHistoryDateAsCalendar("1.800 H.", true, MCRCalendar.TAG_ISLAMIC);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("islamic: 30.01.800 H.", "2231608", dstring);
-        // 29.12.800 H. (islamic)
-        cal = MCRCalendar.getHistoryDateAsCalendar("800", true, MCRCalendar.TAG_ISLAMIC);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("islamic: 29.12.800 H.", "2231932", dstring);
-
-        // 01.01.0001 A.M. (coptioc)
-        cal = MCRCalendar.getHistoryDateAsCalendar("1.1.1 a.M.", false, MCRCalendar.TAG_COPTIC);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("coptic: 01.01.0001 A.M.", "1825030", dstring);
-        // 01.01.1724 A.M. (coptioc)
-        cal = MCRCalendar.getHistoryDateAsCalendar("1.1.1724 A.M.", false, MCRCalendar.TAG_COPTIC);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("coptic: 01.01.1724 A.M.", "2454356", dstring);
-        // 05.13.1724 E.E. (coptic)
-        cal = MCRCalendar.getHistoryDateAsCalendar("1724 a.M.", true, MCRCalendar.TAG_COPTIC);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("coptic: 05.13.2000 E.E.", "2454720", dstring);
-        // 01.01.0001 E.E. (ethiopic)
-        cal = MCRCalendar.getHistoryDateAsCalendar("1 E.E.", false, MCRCalendar.TAG_ETHIOPIC);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("coptic: 01.01.0001 E.E.", "1724221", dstring);
-        // 05.13.2000 E.E. (ethiopic)
-        cal = MCRCalendar.getHistoryDateAsCalendar("2000 E.E.", true, MCRCalendar.TAG_ETHIOPIC);
-        dstring = MCRCalendar.getJulianDayNumberAsString(cal);
-        assertEquals("coptic: 05.13.2000 E.E.", "2454720", dstring);
     }
 
     /*
@@ -288,14 +1273,13 @@ public class MCRCalendarTest extends MCRTestCase {
         calendar = MCRCalendar.getHistoryDateAsCalendar("-15.3.44", true, MCRCalendar.TAG_GREGORIAN);
         dstring = MCRCalendar.getCalendarDateToFormattedString(calendar, "dd.MM.yyyy G");
         assertEquals("is not gregorian date 15.03.44 BC", "15.03.0044 BC", dstring);
-        // 29.02.1700 BC (julian)
+        // 29.02.1700 (julian)
         calendar = MCRCalendar.getHistoryDateAsCalendar("29.02.1700", true, MCRCalendar.TAG_JULIAN);
         dstring = MCRCalendar.getCalendarDateToFormattedString(calendar, "dd.MM.yyyy G");
-        assertEquals("is not julian date 11.03.1700 AD", "11.03.1700 AD", dstring);
-        // 29.02.1700 BC (julian)
-        calendar = MCRCalendar.getHistoryDateAsCalendar("29.02.1700", true, MCRCalendar.TAG_GREGORIAN);
-        dstring = MCRCalendar.getCalendarDateToFormattedString(calendar, "dd.MM.yyyy G");
-        assertEquals("is not julian date 01.03.1700 AD", "01.03.1700 AD", dstring);
+        assertEquals("is not julian date 29.02.1700 AD", "29.02.1700 AD", dstring);
+        // 29.02.1700 (gregorian) -> no leap year in gregorian calendar
+        assertThrows(MCRException.class,
+            () -> MCRCalendar.getHistoryDateAsCalendar("29.02.1700", true, MCRCalendar.TAG_GREGORIAN));
         // 30.01.800 H. (islamic)
         calendar = MCRCalendar.getHistoryDateAsCalendar("30.1.800 H.", true, MCRCalendar.TAG_ISLAMIC);
         dstring = MCRCalendar.getCalendarDateToFormattedString(calendar, "dd.MM.yyy");
@@ -323,12 +1307,202 @@ public class MCRCalendarTest extends MCRTestCase {
 
         // 01.01.1724 A.M. (coptic)
         calendar = MCRCalendar.getHistoryDateAsCalendar("1724", false, MCRCalendar.TAG_COPTIC);
-        dstring = MCRCalendar.getCalendarDateToFormattedString(calendar, "dd.MM.yyy");
+        dstring = MCRCalendar.getCalendarDateToFormattedString(calendar, "dd.MM.yyyy");
         assertEquals("is not coptic date 01.01.1724 A.M.", "01.01.1724 A.M.", dstring);
 
         // 01.01.2000 A.M. (ethiopic)
         calendar = MCRCalendar.getHistoryDateAsCalendar("2000", true, MCRCalendar.TAG_ETHIOPIC);
-        dstring = MCRCalendar.getCalendarDateToFormattedString(calendar, "dd.MM.yyy");
+        dstring = MCRCalendar.getCalendarDateToFormattedString(calendar, "dd.MM.yyyy");
         assertEquals("is not ethiopic date 05.13.2000 E.E.", "05.13.2000 E.E.", dstring);
+
+        calendar = MCRCalendar.getHistoryDateAsCalendar("1.1.500", false, MCRCalendar.TAG_ARMENIAN);
+        dstring = MCRCalendar.getCalendarDateToFormattedString(calendar, "dd.MM.yyyy");
+        assertEquals("is not armenian date 11.03.1051", "11.03.1051", dstring);
+
+        calendar = MCRCalendar.getHistoryDateAsCalendar("5.7.H2", false, MCRCalendar.TAG_JAPANESE);
+        dstring = MCRCalendar.getCalendarDateToFormattedString(calendar, "dd.MM.Y");
+        assertEquals("is not japanese date 05.07.1990", "05.07.1990", dstring);
+
+        calendar = MCRCalendar.getHistoryDateAsCalendar("2.7.20", false, MCRCalendar.TAG_BUDDHIST);
+        dstring = MCRCalendar.getCalendarDateToFormattedString(calendar, "dd.MM.yy");
+        assertEquals("is not japanese date 02.07.20", "02.07.20", dstring);
+
+        calendar = MCRCalendar.getHistoryDateAsCalendar("2.7.20", false, MCRCalendar.TAG_BUDDHIST);
+        dstring = MCRCalendar.getCalendarDateToFormattedString(calendar, "dd.MM.Y");
+        assertEquals("is not buddhist date 02.07.-523", "02.07.-523", dstring);
+    }
+
+    @Test
+    public void testIsoFormat() {
+        assertFalse(MCRCalendar.isoFormat("23.03.2022"));
+        assertFalse(MCRCalendar.isoFormat("23/03/2022"));
+        assertTrue(MCRCalendar.isoFormat("23-03-2022"));
+        assertFalse(MCRCalendar.isoFormat("-23.03.2022"));
+        assertFalse(MCRCalendar.isoFormat("-23/03/2022"));
+        assertTrue(MCRCalendar.isoFormat("-23-03-2022"));
+
+        assertFalse(MCRCalendar.isoFormat("800"));
+    }
+
+    @Test
+    public void testDelimiter() {
+        assertEquals(MCRCalendar.delimiter("23.03.2022"), ".");
+        assertEquals(MCRCalendar.delimiter("23/03/2022"), "/");
+        assertEquals(MCRCalendar.delimiter("23-03-2022"), "-");
+        assertEquals(MCRCalendar.delimiter("-23.03.2022"), ".");
+        assertEquals(MCRCalendar.delimiter("-23/03/2022"), "/");
+        assertEquals(MCRCalendar.delimiter("-23-03-2022"), "-");
+
+        assertEquals(MCRCalendar.delimiter("800"), ".");
+    }
+
+    @Test
+    public void testBeforeZero() {
+        assertFalse(MCRCalendar.beforeZero("23.03.2022", MCRCalendar.CalendarType.Gregorian));
+        assertFalse(MCRCalendar.beforeZero("23/03/2022", MCRCalendar.CalendarType.Gregorian));
+        assertFalse(MCRCalendar.beforeZero("23-03-2022", MCRCalendar.CalendarType.Gregorian));
+        assertTrue(MCRCalendar.beforeZero("-23.03.2022", MCRCalendar.CalendarType.Gregorian));
+        assertTrue(MCRCalendar.beforeZero("-23/03/2022", MCRCalendar.CalendarType.Gregorian));
+        assertTrue(MCRCalendar.beforeZero("-23-03-2022", MCRCalendar.CalendarType.Gregorian));
+
+        assertFalse(MCRCalendar.beforeZero("23-03-2022 AD", MCRCalendar.CalendarType.Gregorian));
+        assertFalse(MCRCalendar.beforeZero("AD 23-03-2022", MCRCalendar.CalendarType.Gregorian));
+        assertTrue(MCRCalendar.beforeZero("23-03-2022 BC", MCRCalendar.CalendarType.Gregorian));
+        assertTrue(MCRCalendar.beforeZero("BC 23-03-2022", MCRCalendar.CalendarType.Gregorian));
+    }
+
+    @Test
+    public void testGetLastDayOfMonth() {
+        assertEquals(MCRCalendar.getLastDayOfMonth(GregorianCalendar.JANUARY, 2000, MCRCalendar.CalendarType.Gregorian),
+                31);
+        assertEquals(
+                MCRCalendar.getLastDayOfMonth(GregorianCalendar.FEBRUARY, 2000, MCRCalendar.CalendarType.Gregorian),
+                29);
+        assertEquals(
+                MCRCalendar.getLastDayOfMonth(GregorianCalendar.FEBRUARY, 2001, MCRCalendar.CalendarType.Gregorian),
+                28);
+        assertEquals(MCRCalendar.getLastDayOfMonth(GregorianCalendar.MARCH, 2000, MCRCalendar.CalendarType.Gregorian),
+                31);
+        assertEquals(MCRCalendar.getLastDayOfMonth(GregorianCalendar.APRIL, 2000, MCRCalendar.CalendarType.Gregorian),
+                30);
+
+        assertEquals(
+                MCRCalendar.getLastDayOfMonth(GregorianCalendar.FEBRUARY, 1700, MCRCalendar.CalendarType.Gregorian),
+                28);
+        assertEquals(MCRCalendar.getLastDayOfMonth(GregorianCalendar.FEBRUARY, 1700, MCRCalendar.CalendarType.Julian),
+                29);
+
+        assertEquals(MCRCalendar.getLastDayOfMonth(CopticCalendar.NASIE, 2000, MCRCalendar.CalendarType.Coptic),
+                5);
+
+        assertEquals(MCRCalendar.getLastDayOfMonth(11, 2000, MCRCalendar.CalendarType.Egyptian),
+                30);
+        assertEquals(MCRCalendar.getLastDayOfMonth(12, 2000, MCRCalendar.CalendarType.Egyptian),
+                5);
+
+        assertEquals(MCRCalendar.getLastDayOfMonth(11, 2000, MCRCalendar.CalendarType.Armenian),
+                30);
+        assertEquals(MCRCalendar.getLastDayOfMonth(12, 2000, MCRCalendar.CalendarType.Armenian),
+                5);
+    }
+
+    @Test
+    public void testIsLeapYear() {
+        assertTrue(MCRCalendar.isLeapYear(2000, MCRCalendar.CalendarType.Gregorian));
+        assertFalse(MCRCalendar.isLeapYear(1999, MCRCalendar.CalendarType.Gregorian));
+        assertFalse(MCRCalendar.isLeapYear(1582, MCRCalendar.CalendarType.Gregorian));
+        assertFalse(MCRCalendar.isLeapYear(1900, MCRCalendar.CalendarType.Gregorian));
+        assertTrue(MCRCalendar.isLeapYear(1900, MCRCalendar.CalendarType.Julian));
+    }
+
+    @Test
+    public void testGetCalendarTypeString() {
+        assertEquals(MCRCalendar.getCalendarTypeString(
+                        MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_ARMENIAN)),
+                MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getCalendarTypeString(
+                        MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_BUDDHIST)),
+                MCRCalendar.TAG_BUDDHIST);
+        assertEquals(MCRCalendar.getCalendarTypeString(
+                        MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_COPTIC)),
+                MCRCalendar.TAG_COPTIC);
+        assertEquals(MCRCalendar.getCalendarTypeString(
+                        MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_ETHIOPIC)),
+                MCRCalendar.TAG_ETHIOPIC);
+        assertEquals(MCRCalendar.getCalendarTypeString(
+                        MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_GREGORIAN)),
+                MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getCalendarTypeString(
+                        MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_JULIAN)),
+                MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getCalendarTypeString(
+                        MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_HEBREW)),
+                MCRCalendar.TAG_HEBREW);
+        assertEquals(MCRCalendar.getCalendarTypeString(
+                        MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_ISLAMIC)),
+                MCRCalendar.TAG_ISLAMIC);
+        assertEquals(MCRCalendar.getCalendarTypeString(
+                        MCRCalendar.getHistoryDateAsCalendar("1.1.1H1", false, MCRCalendar.TAG_JAPANESE)),
+                MCRCalendar.TAG_JAPANESE);
+        assertEquals(MCRCalendar.getCalendarTypeString(
+                        MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_PERSIC)),
+                MCRCalendar.TAG_GREGORIAN);
+        assertEquals(MCRCalendar.getCalendarTypeString(
+                        MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_EGYPTIAN)),
+                MCRCalendar.TAG_GREGORIAN);
+    }
+
+    @Test
+    public void testGetGregorianCalendarOfACalendar() {
+        compareCalendarDates(MCRCalendar.getGregorianCalendarOfACalendar(
+            MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_ARMENIAN)),
+            MCRCalendar.getHistoryDateAsCalendar("13.7.552", false, MCRCalendar.TAG_GREGORIAN));
+
+        compareCalendarDates(MCRCalendar.getGregorianCalendarOfACalendar(
+            MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_BUDDHIST)),
+            MCRCalendar.getHistoryDateAsCalendar("1.1.543 BC", false, MCRCalendar.TAG_GREGORIAN));
+
+        compareCalendarDates(MCRCalendar.getGregorianCalendarOfACalendar(
+            MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_COPTIC)),
+            MCRCalendar.getHistoryDateAsCalendar("29.8.284", false, MCRCalendar.TAG_GREGORIAN));
+
+        compareCalendarDates(MCRCalendar.getGregorianCalendarOfACalendar(
+            MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_ETHIOPIC)),
+            MCRCalendar.getHistoryDateAsCalendar("29.8.8", false, MCRCalendar.TAG_GREGORIAN));
+
+        compareCalendarDates(MCRCalendar.getGregorianCalendarOfACalendar(
+            MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_GREGORIAN)),
+            MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_GREGORIAN));
+
+        compareCalendarDates(MCRCalendar.getGregorianCalendarOfACalendar(
+            MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_JULIAN)),
+            MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_GREGORIAN));
+
+        compareCalendarDates(MCRCalendar.getGregorianCalendarOfACalendar(
+            MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_HEBREW)),
+            MCRCalendar.getHistoryDateAsCalendar("-7.10.3761", false, MCRCalendar.TAG_GREGORIAN));
+
+        compareCalendarDates(MCRCalendar.getGregorianCalendarOfACalendar(
+            MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_ISLAMIC)),
+            MCRCalendar.getHistoryDateAsCalendar("16.7.622", false, MCRCalendar.TAG_GREGORIAN));
+
+        compareCalendarDates(MCRCalendar.getGregorianCalendarOfACalendar(
+            MCRCalendar.getHistoryDateAsCalendar("1.1.H1", false, MCRCalendar.TAG_JAPANESE)),
+            MCRCalendar.getHistoryDateAsCalendar("1.1.1989", false, MCRCalendar.TAG_GREGORIAN));
+
+        compareCalendarDates(MCRCalendar.getGregorianCalendarOfACalendar(
+            MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_PERSIC)),
+            MCRCalendar.getHistoryDateAsCalendar("21.3.622", false, MCRCalendar.TAG_GREGORIAN));
+
+        compareCalendarDates(MCRCalendar.getGregorianCalendarOfACalendar(
+            MCRCalendar.getHistoryDateAsCalendar("1.1.1", false, MCRCalendar.TAG_EGYPTIAN)),
+            MCRCalendar.getHistoryDateAsCalendar("18.2.747 BC", false, MCRCalendar.TAG_GREGORIAN));
+    }
+
+    private void compareCalendarDates(Calendar actual, Calendar expected) {
+        assertEquals(actual.get(Calendar.YEAR), expected.get(Calendar.YEAR));
+        assertEquals(actual.get(Calendar.MONTH), expected.get(Calendar.MONTH));
+        assertEquals(actual.get(Calendar.DAY_OF_MONTH), expected.get(Calendar.DAY_OF_MONTH));
+        assertEquals(actual.get(Calendar.ERA), expected.get(Calendar.ERA));
     }
 }

--- a/mycore-base/src/test/java/org/mycore/common/xml/MCRXMLFunctionsTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/xml/MCRXMLFunctionsTest.java
@@ -69,8 +69,8 @@ public class MCRXMLFunctionsTest extends MCRTestCase {
             MCRXMLFunctions.getISODateFromMCRHistoryDate("1964-02-24", "von", "gregorian"));
         assertEquals("1964-03-08T00:00:00.000Z",
             MCRXMLFunctions.getISODateFromMCRHistoryDate("1964-02-24", "von", "julian"));
-        assertEquals("1964-02-28T00:00:00.000Z",
-            MCRXMLFunctions.getISODateFromMCRHistoryDate("1964-02", "bis", "gregorian"));
+        assertEquals("1964-02-29T00:00:00.000Z",
+                MCRXMLFunctions.getISODateFromMCRHistoryDate("1964-02", "bis", "gregorian"));
         assertEquals("-0100-12-31T00:00:00.000Z",
             MCRXMLFunctions.getISODateFromMCRHistoryDate("100 BC", "bis", "gregorian"));
     }

--- a/mycore-base/src/test/java/org/mycore/datamodel/metadata/MCRMetaHistoryDateTest.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/metadata/MCRMetaHistoryDateTest.java
@@ -19,13 +19,11 @@
 package org.mycore.datamodel.metadata;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import org.jdom2.Element;
 import org.junit.Test;
 import org.mycore.common.MCRCalendar;
 import org.mycore.common.MCRTestCase;
-import org.mycore.common.xml.MCRXMLHelper;
 
 import com.ibm.icu.util.GregorianCalendar;
 
@@ -71,7 +69,6 @@ public class MCRMetaHistoryDateTest extends MCRTestCase {
         julian_date.setVonDate("22.02.1964", julian_date.getCalendar());
         julian_date.setBisDate("22.02.1964", julian_date.getCalendar());
         julian_date.addText("mein Tag", "de");
-        julian_date.setCalendar(MCRCalendar.TAG_GREGORIAN);
 
         MCRMetaHistoryDate gregorian_date = new MCRMetaHistoryDate("subtag", "type", 0);
         gregorian_date.setCalendar(MCRCalendar.TAG_GREGORIAN);
@@ -81,7 +78,18 @@ public class MCRMetaHistoryDateTest extends MCRTestCase {
 
         Element julian_date_xml = julian_date.createXML();
         Element gregorian_date_xml = gregorian_date.createXML();
-        assertTrue("XML elements should be equal", MCRXMLHelper.deepEqual(julian_date_xml, gregorian_date_xml));
+
+        assertEquals(julian_date_xml.getChildText("text"), gregorian_date_xml.getChildText("text"));
+        assertEquals(julian_date_xml.getChildText("ivon"), gregorian_date_xml.getChildText("ivon"));
+        assertEquals(julian_date_xml.getChildText("ibis"), gregorian_date_xml.getChildText("ibis"));
+
+        assertEquals(julian_date_xml.getChildText("calendar"), MCRCalendar.TAG_JULIAN);
+        assertEquals(julian_date_xml.getChildText("von"), "1964-02-22 AD");
+        assertEquals(julian_date_xml.getChildText("bis"), "1964-02-22 AD");
+
+        assertEquals(gregorian_date_xml.getChildText("calendar"), MCRCalendar.TAG_GREGORIAN);
+        assertEquals(gregorian_date_xml.getChildText("von"), "1964-03-06 AD");
+        assertEquals(gregorian_date_xml.getChildText("bis"), "1964-03-06 AD");
 
         MCRMetaHistoryDate julian_date_read = new MCRMetaHistoryDate();
         julian_date_read.setFromDOM(julian_date_xml);


### PR DESCRIPTION
This PR cleans the MCRCalendar class from redundant code and adds support for missing calendars. Since the class is heavily rewritten, I added a lot of tests in MCRCalendarTest to show functionality.

The following calendars are supported with this PR
* Gregorian
* Julian
* Islamic
* Hebrew
* Coptic
* Ethiopian
* Japanese 
* Buddhist
* Persian
* Armenian
* Egyptian

Two existing tests were modified due to the following reasons
* MCRXMLFunctionsTest#getISODateFromMCRHistoryDate: 1964 was a leap year so last day in February was the 29th
* MCRMetaHistoryDateTest#checkCreateParseEqualsClone: clearified behaviour


[Link to jira](https://mycore.atlassian.net/browse/MCR-604).
