### PR TITLE
MCR-2690 Fix RegEx to properly match requestHandler group in the abse…

### DIFF
--- a/mycore-solr/src/main/java/org/mycore/solr/common/xml/MCRSolrQueryResolver.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/common/xml/MCRSolrQueryResolver.java
@@ -56,8 +56,9 @@ public class MCRSolrQueryResolver implements URIResolver {
     public static final String CORE_GROUP_NAME = "core";
 
     private static final Pattern URI_PATTERN = Pattern
-        .compile("\\Asolr:((?<" + CORE_GROUP_NAME + ">[a-zA-Z0-9-]+):)?(" + REQUEST_HANDLER_QUALIFIER + ":(?<"
-            + REQUEST_HANDLER_GROUP_NAME + ">[a-zA-Z0-9-]+):)?(?<" + QUERY_GROUP_NAME + ">.+)\\z");
+        .compile("\\Asolr:((?!" + REQUEST_HANDLER_QUALIFIER + ")(?<" + CORE_GROUP_NAME + ">[a-zA-Z0-9-]+):)?("
+            + REQUEST_HANDLER_QUALIFIER + ":(?<" + REQUEST_HANDLER_GROUP_NAME + ">[a-zA-Z0-9-]+):)?(?<"
+            + QUERY_GROUP_NAME + ">.+)\\z");
 
     @Override
     public Source resolve(String href, String base) throws TransformerException {


### PR DESCRIPTION
…nce of a core

[Link to jira](https://mycore.atlassian.net/browse/MCR-2690).

The RegEx does not properly detect a specified requestHandler unless a core is specified as well. Therefore the first named group match must not match on "requestHandler".
