### PR TITLE
MCR-2738 MCRObjectStaticContentGenerator now allows filtering

### DIFF
--- a/mycore-base/src/main/java/org/mycore/services/staticcontent/MCRStaticContentEventHandler.java
+++ b/mycore-base/src/main/java/org/mycore/services/staticcontent/MCRStaticContentEventHandler.java
@@ -42,7 +42,7 @@ public class MCRStaticContentEventHandler extends MCREventHandlerBase {
     protected void handleObjectUpdated(MCREvent evt, MCRObject obj) {
         MCRObjectStaticContentGenerator.getContentGenerators()
             .stream()
-            .map(MCRObjectStaticContentGenerator::new)
+            .map(MCRObjectStaticContentGenerator::get)
             .forEach(cg -> {
                 try {
                     cg.generate(obj);


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-2738).

- Added filter method to MCRObjectStaticContentGenerator
- Allow own implementations of MCRObjectStaticContentGenerator by adding optional dynamic property MCR.Object.Static.Content.Generator.$id.Class which should contain a class name extending MCRObjectStaticContentGenerator with the id constructor
