### PR TITLE
MCR-2724 OCFL Users

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/events/MCREvent.java
+++ b/mycore-base/src/main/java/org/mycore/common/events/MCREvent.java
@@ -52,6 +52,8 @@ public class MCREvent extends java.util.Hashtable<String, Object> {
 
     public static final String PATH_TYPE = "MCRPath";
 
+    public static final String USER_TYPE = "MCRUser";
+
     public static final String MOVE_EVENT = "move";
 
     public static final String PATH_KEY = PATH_TYPE;
@@ -65,6 +67,10 @@ public class MCREvent extends java.util.Hashtable<String, Object> {
     public static final String DERIVATE_KEY = "derivate";
 
     public static final String DERIVATE_OLD_KEY = "derivate.old";
+
+    public static final String USER_KEY = "user";
+
+    public static final String USER_OLD_KEY = "user.old";
 
     /** The object type like object or file * */
     private String objType;

--- a/mycore-ocfl/pom.xml
+++ b/mycore-ocfl/pom.xml
@@ -57,5 +57,9 @@
       <groupId>org.mycore</groupId>
       <artifactId>mycore-base</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.mycore</groupId>
+      <artifactId>mycore-user2</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/commands/MCROCFLCommands.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/commands/MCROCFLCommands.java
@@ -142,15 +142,13 @@ public class MCROCFLCommands {
         if (MCRUserManager.getUser(userId) == null) {
             throw new MCRUsageException("The User '" + userId + "' does not exist!");
         }
-        new MCROCFLXMLUserManager(MCRConfiguration2.getStringOrThrow("MCR.Users.Manager.Repository"))
-            .updateUser(MCRUserManager.getUser(userId));
+        new MCROCFLXMLUserManager().updateUser(MCRUserManager.getUser(userId));
     }
 
     @MCRCommand(syntax = "delete ocfl user {0}",
         help = "Delete user {0} in the OCFL Store")
     public static void deleteOCFLUser(String userId) {
-        new MCROCFLXMLUserManager(MCRConfiguration2.getStringOrThrow("MCR.Users.Manager.Repository"))
-            .deleteUser(userId);
+        new MCROCFLXMLUserManager().deleteUser(userId);
     }
 
     @MCRCommand(syntax = "sync ocfl users",
@@ -168,8 +166,7 @@ public class MCROCFLCommands {
     @MCRCommand(syntax = "restore database user {0} with version {1} from ocfl",
         help = "restore a specified revision of a ocfl user backup to the database")
     public static void writeUserToDb(String userId, String revision) throws IOException {
-        MCRUser user = new MCROCFLXMLUserManager(MCRConfiguration2.getStringOrThrow("MCR.Users.Manager.Repository"))
-            .retrieveContent(userId, revision);
+        MCRUser user = new MCROCFLXMLUserManager().retrieveContent(userId, revision);
         MCRUserManager.updateUser(user);
     }
 

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/commands/MCROCFLCommands.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/commands/MCROCFLCommands.java
@@ -165,8 +165,15 @@ public class MCROCFLCommands {
 
     @MCRCommand(syntax = "restore user {0} from ocfl with version {1}",
         help = "restore a specified revision of a ocfl user backup to the primary user store")
-    public static void writeUserToDb(String userId, String revision) throws IOException {
+    public static void writeUserToDbVersioned(String userId, String revision) throws IOException {
         MCRUser user = new MCROCFLXMLUserManager().retrieveContent(userId, revision);
+        MCRUserManager.updateUser(user);
+    }
+
+    @MCRCommand(syntax = "restore user {0} from ocfl",
+        help = "restore the latest revision of a ocfl user backup to the primary user store")
+    public static void writeUserToDb(String userId) throws IOException {
+        MCRUser user = new MCROCFLXMLUserManager().retrieveContent(userId, null);
         MCRUserManager.updateUser(user);
     }
 

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/commands/MCROCFLCommands.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/commands/MCROCFLCommands.java
@@ -18,6 +18,7 @@
 
 package org.mycore.ocfl.commands;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
@@ -25,6 +26,7 @@ import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.mycore.common.MCRUsageException;
 import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.datamodel.classifications2.MCRCategoryID;
 import org.mycore.datamodel.classifications2.impl.MCRCategoryDAOImpl;
@@ -36,6 +38,9 @@ import org.mycore.ocfl.MCROCFLObjectIDPrefixHelper;
 import org.mycore.ocfl.MCROCFLPersistenceTransaction;
 import org.mycore.ocfl.MCROCFLRepositoryProvider;
 import org.mycore.ocfl.MCROCFLXMLClassificationManager;
+import org.mycore.ocfl.user.MCROCFLXMLUserManager;
+import org.mycore.user2.MCRUser;
+import org.mycore.user2.MCRUserManager;
 
 import edu.wisc.library.ocfl.api.OcflRepository;
 
@@ -121,6 +126,53 @@ public class MCROCFLCommands {
         return commands;
     }
 
+    @MCRCommand(syntax = "update ocfl users",
+        help = "Update all users in the OCFL store from database")
+    public static List<String> updateOCFLUsers() {
+        List<MCRUser> list = MCRUserManager.listUsers("*", null, null, null);
+
+        return list.stream()
+            .map(usr -> "update ocfl user " + usr.getUserID())
+            .collect(Collectors.toList());
+    }
+
+    @MCRCommand(syntax = "update ocfl user {0}",
+        help = "Update user {0} in the OCFL Store from database")
+    public static void updateOCFLUser(String userId) {
+        if (MCRUserManager.getUser(userId) == null) {
+            throw new MCRUsageException("The User '" + userId + "' does not exist!");
+        }
+        new MCROCFLXMLUserManager(MCRConfiguration2.getStringOrThrow("MCR.Users.Manager.Repository"))
+            .updateUser(MCRUserManager.getUser(userId));
+    }
+
+    @MCRCommand(syntax = "delete ocfl user {0}",
+        help = "Delete user {0} in the OCFL Store")
+    public static void deleteOCFLUser(String userId) {
+        new MCROCFLXMLUserManager(MCRConfiguration2.getStringOrThrow("MCR.Users.Manager.Repository"))
+            .deleteUser(userId);
+    }
+
+    @MCRCommand(syntax = "sync ocfl users",
+        help = "Update all users and remove deleted users to resync OCFL Store to the Database")
+    public static List<String> syncUserRepository() {
+        List<String> commands = new ArrayList<>();
+        commands.add("update ocfl users");
+        List<String> outOfSync = getStaleOCFLUserIDs();
+        commands.addAll(
+            outOfSync.stream()
+                .map(id -> "delete ocfl user " + id).collect(Collectors.toList()));
+        return commands;
+    }
+
+    @MCRCommand(syntax = "restore database user {0} with version {1} from ocfl",
+        help = "restore a specified revision of a ocfl user backup to the database")
+    public static void writeUserToDb(String userId, String revision) throws IOException {
+        MCRUser user = new MCROCFLXMLUserManager(MCRConfiguration2.getStringOrThrow("MCR.Users.Manager.Repository"))
+            .retrieveContent(userId, revision);
+        MCRUserManager.updateUser(user);
+    }
+
     private static List<String> getStaleOCFLClassificationIDs() {
         String repositoryKey = MCRConfiguration2.getStringOrThrow("MCR.Classification.Manager.Repository");
         List<String> classDAOList = new MCRCategoryDAOImpl().getRootCategoryIDs().stream()
@@ -133,6 +185,21 @@ public class MCROCFLCommands {
                 .getHeadVersion().getVersionInfo().getMessage()))
             .map(obj -> obj.replace(MCROCFLObjectIDPrefixHelper.CLASSIFICATION, ""))
             .filter(Predicate.not(classDAOList::contains))
+            .collect(Collectors.toList());
+    }
+
+    private static List<String> getStaleOCFLUserIDs() {
+        String repositoryKey = MCRConfiguration2.getStringOrThrow("MCR.Users.Manager.Repository");
+        List<String> userEMList = MCRUserManager.listUsers("*", null, null, null).stream()
+            .map(MCRUser::getUserID)
+            .collect(Collectors.toList());
+        OcflRepository repository = MCROCFLRepositoryProvider.getRepository(repositoryKey);
+        return repository.listObjectIds()
+            .filter(obj -> obj.startsWith(MCROCFLObjectIDPrefixHelper.USER))
+            .filter(obj -> !MCROCFLXMLUserManager.MESSAGE_DELETED.equals(repository.describeObject(obj)
+                .getHeadVersion().getVersionInfo().getMessage()))
+            .map(obj -> obj.replace(MCROCFLObjectIDPrefixHelper.USER, ""))
+            .filter(Predicate.not(userEMList::contains))
             .collect(Collectors.toList());
     }
 }

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/commands/MCROCFLCommands.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/commands/MCROCFLCommands.java
@@ -163,8 +163,8 @@ public class MCROCFLCommands {
         return commands;
     }
 
-    @MCRCommand(syntax = "restore database user {0} with version {1} from ocfl",
-        help = "restore a specified revision of a ocfl user backup to the database")
+    @MCRCommand(syntax = "restore user {0} from ocfl with version {1}",
+        help = "restore a specified revision of a ocfl user backup to the primary user store")
     public static void writeUserToDb(String userId, String revision) throws IOException {
         MCRUser user = new MCROCFLXMLUserManager().retrieveContent(userId, revision);
         MCRUserManager.updateUser(user);

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/user/MCROCFLUserEventHandler.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/user/MCROCFLUserEventHandler.java
@@ -21,7 +21,6 @@ package org.mycore.ocfl.user;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.mycore.common.MCRException;
-import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.events.MCREvent;
 import org.mycore.common.events.MCREventHandler;
 import org.mycore.user2.MCRUser;
@@ -34,8 +33,7 @@ public class MCROCFLUserEventHandler implements MCREventHandler {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private static final MCROCFLXMLUserManager MANAGER = new MCROCFLXMLUserManager(
-        MCRConfiguration2.getStringOrThrow("MCR.Users.Manager.Repository"));
+    private static final MCROCFLXMLUserManager MANAGER = new MCROCFLXMLUserManager();
 
     @Override
     public void doHandleEvent(MCREvent evt) throws MCRException {

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/user/MCROCFLUserEventHandler.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/user/MCROCFLUserEventHandler.java
@@ -1,0 +1,70 @@
+/*
+* This file is part of ***  M y C o R e  ***
+* See http://www.mycore.de/ for details.
+*
+* MyCoRe is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* MyCoRe is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mycore.ocfl.user;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.mycore.common.MCRException;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.common.events.MCREvent;
+import org.mycore.common.events.MCREventHandler;
+import org.mycore.user2.MCRUser;
+
+/**
+ * Event Handler to Handle MCRUser Events for OCFL
+ * @author Tobias Lenhardt [Hammer1279]
+ */
+public class MCROCFLUserEventHandler implements MCREventHandler {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private static final MCROCFLXMLUserManager MANAGER = new MCROCFLXMLUserManager(
+        MCRConfiguration2.getStringOrThrow("MCR.Users.Manager.Repository"));
+
+    @Override
+    public void doHandleEvent(MCREvent evt) throws MCRException {
+        if (evt.getObjectType().equals(MCREvent.USER_TYPE)) {
+            MCRUser user = (MCRUser)evt.get(MCREvent.USER_KEY);
+            LOGGER.debug("{} handling {} {}", getClass().getName(), user.getUserID(),
+                evt.getEventType());
+            switch (evt.getEventType()) {
+                case MCREvent.UPDATE_EVENT:
+                    MANAGER.updateUser(user);
+                    break;
+                case MCREvent.CREATE_EVENT:
+                    MANAGER.createUser(user);
+                    break;
+                case MCREvent.DELETE_EVENT:
+                    MANAGER.deleteUser(user);
+                    break;
+
+                default:
+                    LOGGER.info("Event Type '{}' is not valid for {}", evt.getEventType(), getClass().getName());
+                    break;
+            }
+        }
+    }
+
+    @Override
+    public void undoHandleEvent(MCREvent evt) throws MCRException {
+        // undo not supported
+        LOGGER.warn("A Error has occurred while saving User, please run 'sync ocfl users' in cli.");
+    }
+
+}

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/user/MCROCFLXMLUserManager.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/user/MCROCFLXMLUserManager.java
@@ -54,8 +54,6 @@ import edu.wisc.library.ocfl.api.model.VersionInfo;
  */
 public class MCROCFLXMLUserManager {
 
-    private static final String THE_USER = "The User '";
-
     private static final Logger LOGGER = LogManager.getLogger();
 
     public static final String MESSAGE_CREATED = "Created";
@@ -136,7 +134,7 @@ public class MCROCFLXMLUserManager {
         String ocflUserID = MCROCFLObjectIDPrefixHelper.USER + user.getUserID();
 
         if (exists(ocflUserID)) {
-            throw new MCRUsageException(THE_USER + user.getUserID() + "' already exists in OCFL Repository");
+            throw new MCRUsageException("The User '" + user.getUserID() + "' already exists in OCFL Repository");
         }
 
         VersionInfo info = new VersionInfo()
@@ -168,7 +166,7 @@ public class MCROCFLXMLUserManager {
 
         if (!exists(ocflUserID)) {
             throw new MCRUsageException(
-                THE_USER + userId + "' does not exist or has already been deleted!");
+                "The User '" + userId + "' does not exist or has already been deleted!");
         }
 
         VersionInfo info = new VersionInfo()
@@ -189,14 +187,14 @@ public class MCROCFLXMLUserManager {
         String ocflUserID = MCROCFLObjectIDPrefixHelper.USER + userId;
 
         if (!repository.containsObject(ocflUserID)) {
-            throw new MCRUsageException(THE_USER + ocflUserID + "' does not exist!");
+            throw new MCRUsageException("The User '" + ocflUserID + "' does not exist!");
         }
 
         ObjectVersionId version = revision == null ? ObjectVersionId.head(ocflUserID)
             : ObjectVersionId.version(ocflUserID, revision);
 
         if (isDeleted(version)) {
-            throw new MCRUsageException(THE_USER + ocflUserID + "' with version '" + revision
+            throw new MCRUsageException("The User '" + ocflUserID + "' with version '" + revision
                 + "' has been deleted!");
         }
 

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/user/MCROCFLXMLUserManager.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/user/MCROCFLXMLUserManager.java
@@ -183,6 +183,13 @@ public class MCROCFLXMLUserManager {
         return Optional.ofNullable(currentUser.getEMailAddress()).map(email -> "mailto:" + email).orElse(null);
     }
 
+    /**
+     * Retrieve a MCRUser from the ocfl store.
+     * @param userId the userId of the requested user
+     * @param revision the version in ocfl store or <code>null</code> for latest
+     * @return the requested MCRUser
+     * @throws IOException if a error occurs during retrieval
+     */
     public MCRUser retrieveContent(String userId, String revision) throws IOException {
         String ocflUserID = MCROCFLObjectIDPrefixHelper.USER + userId;
 

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/user/MCROCFLXMLUserManager.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/user/MCROCFLXMLUserManager.java
@@ -1,0 +1,198 @@
+/*
+* This file is part of ***  M y C o R e  ***
+* See http://www.mycore.de/ for details.
+*
+* MyCoRe is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* MyCoRe is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mycore.ocfl.user;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.ZoneOffset;
+import java.util.Date;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jdom2.Document;
+import org.jdom2.JDOMException;
+import org.mycore.common.MCRPersistenceException;
+import org.mycore.common.MCRSystemUserInformation;
+import org.mycore.common.MCRUsageException;
+import org.mycore.common.content.MCRJAXBContent;
+import org.mycore.common.content.MCRStreamContent;
+import org.mycore.ocfl.MCROCFLObjectIDPrefixHelper;
+import org.mycore.ocfl.MCROCFLRepositoryProvider;
+import org.mycore.user2.MCRTransientUser;
+import org.mycore.user2.MCRUser;
+import org.mycore.user2.MCRUserManager;
+import org.mycore.user2.utils.MCRUserTransformer;
+import org.xml.sax.SAXException;
+
+import edu.wisc.library.ocfl.api.OcflOption;
+import edu.wisc.library.ocfl.api.OcflRepository;
+import edu.wisc.library.ocfl.api.exception.OverwriteException;
+import edu.wisc.library.ocfl.api.model.ObjectVersionId;
+import edu.wisc.library.ocfl.api.model.VersionInfo;
+
+/**
+ * XML Manager to handle MCRUsers in a MyCoRe OCFL Repository
+ * @author Tobias Lenhardt [Hammer1279]
+ */
+public class MCROCFLXMLUserManager {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public static final String MESSAGE_CREATED = "Created";
+
+    public static final String MESSAGE_UPDATED = "Updated";
+
+    public static final String MESSAGE_DELETED = "Deleted";
+
+    private static final String IGNORING_TRANSIENT_USER = "Got TransientUser, ignoring...";
+
+    private final OcflRepository repository;
+
+    public MCROCFLXMLUserManager(String repositoryKey) {
+        this.repository = MCROCFLRepositoryProvider.getRepository(repositoryKey);
+    }
+
+    public void updateUser(MCRUser user) {
+        MCRUser currentUser = MCRUserManager.getCurrentUser();
+        String ocflUserID = MCROCFLObjectIDPrefixHelper.USER + user.getUserID();
+
+        if (MCRSystemUserInformation.getGuestInstance().getUserID().equals(currentUser.getUserID())) {
+            LOGGER.debug("Login Detected, ignoring...");
+            return;
+        }
+
+        if (user instanceof MCRTransientUser) {
+            LOGGER.debug(IGNORING_TRANSIENT_USER);
+            return;
+        }
+
+        if (!exists(ocflUserID)) {
+            createUser(user);
+            return;
+        }
+
+        VersionInfo info = new VersionInfo()
+            .setMessage(MESSAGE_UPDATED)
+            .setCreated((new Date()).toInstant().atOffset(ZoneOffset.UTC))
+            .setUser(currentUser.getUserName(), currentUser.getEMailAddress());
+        MCRJAXBContent<MCRUser> content = new MCRJAXBContent<>(MCRUserTransformer.JAXB_CONTEXT, user);
+        try (InputStream userAsStream = content.getInputStream()) {
+            repository.updateObject(ObjectVersionId.head(ocflUserID), info,
+                updater -> {
+                    updater.writeFile(userAsStream, user.getUserID() + ".xml", OcflOption.OVERWRITE);
+                });
+        } catch (IOException | OverwriteException e) {
+            throw new MCRPersistenceException("Failed to update user '" + ocflUserID + "'", e);
+        }
+    }
+
+    public void createUser(MCRUser user) {
+        if (user instanceof MCRTransientUser) {
+            LOGGER.debug(IGNORING_TRANSIENT_USER);
+            return;
+        }
+
+        MCRUser currentUser = MCRUserManager.getCurrentUser();
+        String ocflUserID = MCROCFLObjectIDPrefixHelper.USER + user.getUserID();
+
+        if (exists(ocflUserID)) {
+            throw new MCRUsageException("The User '" + user.getUserID() + "' already exists in OCFL Repository");
+        }
+
+        VersionInfo info = new VersionInfo()
+            .setMessage(MESSAGE_CREATED)
+            .setCreated((new Date()).toInstant().atOffset(ZoneOffset.UTC))
+            .setUser(currentUser.getUserName(), currentUser.getEMailAddress());
+        MCRJAXBContent<MCRUser> content = new MCRJAXBContent<>(MCRUserTransformer.JAXB_CONTEXT, user);
+        try (InputStream userAsStream = content.getInputStream()) {
+            repository.updateObject(ObjectVersionId.head(ocflUserID), info,
+                updater -> {
+                    updater.writeFile(userAsStream, user.getUserID() + ".xml");
+                });
+        } catch (IOException | OverwriteException e) {
+            throw new MCRPersistenceException("Failed to update user '" + ocflUserID + "'", e);
+        }
+    }
+
+    public void deleteUser(MCRUser user) {
+        if (user instanceof MCRTransientUser) {
+            LOGGER.debug(IGNORING_TRANSIENT_USER);
+            return;
+        }
+        deleteUser(user.getUserID());
+    }
+
+    public void deleteUser(String userId) {
+        MCRUser currentUser = MCRUserManager.getCurrentUser();
+        String ocflUserID = MCROCFLObjectIDPrefixHelper.USER + userId;
+
+        if (!exists(ocflUserID)) {
+            throw new MCRUsageException(
+                "The User '" + userId + "' does not exist or has already been deleted!");
+        }
+
+        VersionInfo info = new VersionInfo()
+            .setMessage(MESSAGE_DELETED)
+            .setCreated((new Date()).toInstant().atOffset(ZoneOffset.UTC))
+            .setUser(currentUser.getUserName(), currentUser.getEMailAddress());
+        repository.updateObject(ObjectVersionId.head(ocflUserID), info,
+            updater -> {
+                updater.removeFile(userId + ".xml");
+            });
+    }
+
+    public MCRUser retrieveContent(String userId, String revision) throws IOException {
+        String ocflUserID = MCROCFLObjectIDPrefixHelper.USER + userId;
+
+        if (!repository.containsObject(ocflUserID)) {
+            throw new MCRUsageException("The User '" + ocflUserID + "' does not exist!");
+        }
+
+        ObjectVersionId version = revision == null ? ObjectVersionId.head(ocflUserID)
+            : ObjectVersionId.version(ocflUserID, revision);
+
+        if (isDeleted(version)) {
+            throw new MCRUsageException("The User '" + ocflUserID + "' with version '" + revision
+                + "' has been deleted!");
+        }
+
+        try (InputStream storedContentStream = repository.getObject(version).getFile(userId + ".xml").getStream()) {
+            Document xml = new MCRStreamContent(storedContentStream).asXML();
+            return MCRUserTransformer.buildMCRUser(xml.getRootElement());
+        } catch (JDOMException | IOException | SAXException e) {
+            throw new IOException("Can not parse XML from OCFL-Store", e);
+        }
+    }
+
+    private boolean isDeleted(ObjectVersionId version) {
+        return repository.describeVersion(version).getVersionInfo().getMessage().equals(MESSAGE_DELETED);
+    }
+
+    boolean exists(String ocflUserID) {
+        return repository.containsObject(ocflUserID)
+            && !repository.describeVersion(ObjectVersionId.head(ocflUserID)).getVersionInfo().getMessage()
+                .equals(MESSAGE_DELETED);
+    }
+
+    boolean exists(String ocflUserID, String revision) {
+        return repository.containsObject(ocflUserID)
+            && !repository.describeVersion(ObjectVersionId.version(ocflUserID, revision)).getVersionInfo().getMessage()
+                .equals(MESSAGE_DELETED);
+    }
+}

--- a/mycore-ocfl/src/main/resources/components/ocfl/config/mycore.properties
+++ b/mycore-ocfl/src/main/resources/components/ocfl/config/mycore.properties
@@ -68,3 +68,13 @@ MCR.Classification.Manager.Repository=Main
 
 # Event Handler Binding for Classification Manager
 # MCR.EventHandler.MCRClassification.020.Class=org.mycore.ocfl.MCROCFLClassificationEventHandler
+
+######################################################################
+#                      OCFL Users Configuration                      #
+######################################################################
+
+# bind OCFL event handler
+# MCR.EventHandler.MCRUser.020.Class=org.mycore.ocfl.user.MCROCFLUserEventHandler
+
+# default user repository
+MCR.Users.Manager.Repository=Main

--- a/mycore-user2/src/main/java/org/mycore/user2/MCRUserManager.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/MCRUserManager.java
@@ -40,6 +40,8 @@ import org.mycore.common.MCRSystemUserInformation;
 import org.mycore.common.MCRUserInformation;
 import org.mycore.common.MCRUtils;
 import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.common.events.MCREvent;
+import org.mycore.common.events.MCREventManager;
 import org.mycore.common.xml.MCRXMLFunctions;
 import org.mycore.datamodel.classifications2.MCRCategoryID;
 import org.mycore.datamodel.common.MCRISO8601Format;
@@ -219,6 +221,9 @@ public class MCRUserManager {
         em.persist(user);
         LOGGER.info(() -> "user saved: " + user.getUserID());
         MCRRoleManager.storeRoleAssignments(user);
+        MCREvent evt = new MCREvent(MCREvent.USER_TYPE, MCREvent.CREATE_EVENT);
+        evt.put(MCREvent.USER_KEY, user);
+        MCREventManager.instance().handleEvent(evt);
     }
 
     /**
@@ -271,6 +276,9 @@ public class MCRUserManager {
             em.merge(user);
             MCRRoleManager.unassignRoles(user);
             MCRRoleManager.storeRoleAssignments(user);
+            MCREvent evt = new MCREvent(MCREvent.USER_TYPE, MCREvent.UPDATE_EVENT);
+            evt.put(MCREvent.USER_KEY, user);
+            MCREventManager.instance().handleEvent(evt);
         });
     }
 
@@ -306,6 +314,9 @@ public class MCRUserManager {
      */
     public static void deleteUser(String userName, String realmId) {
         MCRUser user = getUser(userName, realmId);
+        MCREvent evt = new MCREvent(MCREvent.USER_TYPE, MCREvent.DELETE_EVENT);
+        evt.put(MCREvent.USER_KEY, user);
+        MCREventManager.instance().handleEvent(evt);
         MCRRoleManager.unassignRoles(user);
         EntityManager em = MCREntityManagerProvider.getCurrentEntityManager();
         em.remove(user);


### PR DESCRIPTION
This adds:

Events to MCRUser changes for create, update and delete

OCFL XML UserManger

Commands to manage users in OCFL repository

The UserManager creates, just like with the classifications, backups of the entries within the database, which can be used to write user data back when needed.

This also implements [MCR-2746](https://mycore.atlassian.net/browse/MCR-2746) for user objects.

[Link to jira](https://mycore.atlassian.net/browse/MCR-2724).
