### PR TITLE
MCR-2744 Classification browser with filterCategory=true creates invalid URL query parameters

### DIFF
--- a/mycore-solr/src/main/java/org/mycore/solr/search/MCRSolrQueryAdapter.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/search/MCRSolrQueryAdapter.java
@@ -91,7 +91,8 @@ public class MCRSolrQueryAdapter implements MCRQueryAdapter {
     @Override
     public String getQueryAsString() {
         configureSolrQuery();
-        return solrQuery.toString();
+        String queryString = solrQuery.toQueryString();
+        return queryString.isEmpty() ? "" : queryString.substring("?".length());
     }
 
     public void prepareQuery() {


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-2744).
