### PR TITLE
MCR-2761 "OCFL" in OCFL Property Keys

### DIFF
--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/MCROCFLClassificationEventHandler.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/MCROCFLClassificationEventHandler.java
@@ -18,7 +18,7 @@
 
 package org.mycore.ocfl;
 
-import static org.mycore.ocfl.MCROCFLPersistenceTransaction.addClassficationEvent;
+import static org.mycore.ocfl.MCROCFLPersistenceTransaction.addClassificationEvent;
 
 import java.util.Objects;
 
@@ -44,18 +44,18 @@ public class MCROCFLClassificationEventHandler implements MCREventHandler {
             LOGGER.debug("{} handling {} {}", getClass().getName(), mcrCg.getId(), evt.getEventType());
             switch (evt.getEventType()) {
             case MCREvent.CREATE_EVENT:
-                addClassficationEvent(mcrCg.getRoot().getId(), MCRAbstractMetadataVersion.CREATED);
+                addClassificationEvent(mcrCg.getRoot().getId(), MCRAbstractMetadataVersion.CREATED);
                 break;
             case MCREvent.UPDATE_EVENT:
-                addClassficationEvent(mcrCg.getRoot().getId(), MCRAbstractMetadataVersion.UPDATED);
+                addClassificationEvent(mcrCg.getRoot().getId(), MCRAbstractMetadataVersion.UPDATED);
                 break;
             case MCREvent.DELETE_EVENT:
                 if (mcrCg.getId().isRootID()) {
                     // delete complete classification
-                    addClassficationEvent(mcrCg.getRoot().getId(), MCRAbstractMetadataVersion.DELETED);
+                    addClassificationEvent(mcrCg.getRoot().getId(), MCRAbstractMetadataVersion.DELETED);
                 } else {
                     // update classification to new version
-                    addClassficationEvent(mcrCg.getRoot().getId(), MCRAbstractMetadataVersion.UPDATED);
+                    addClassificationEvent(mcrCg.getRoot().getId(), MCRAbstractMetadataVersion.UPDATED);
                 }
                 break;
             default:

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/MCROCFLPersistenceTransaction.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/MCROCFLPersistenceTransaction.java
@@ -47,7 +47,7 @@ public class MCROCFLPersistenceTransaction implements MCRPersistenceTransaction 
     private static final Logger LOGGER = LogManager.getLogger();
 
     private static final MCROCFLXMLClassificationManager MANAGER = MCRConfiguration2
-        .<MCROCFLXMLClassificationManager>getSingleInstanceOf("MCR.Classification.Manager")
+        .<MCROCFLXMLClassificationManager>getSingleInstanceOf("MCR.OCFL.Classification.Manager")
         .orElse(null);
 
     private static final ThreadLocal<Map<MCRCategoryID, Character>> CATEGORY_WORKSPACE = new ThreadLocal<>();
@@ -166,7 +166,7 @@ public class MCROCFLPersistenceTransaction implements MCRPersistenceTransaction 
      * @param id The ID of the Classification
      * @param type 'A' for created, 'M' for modified, 'D' deleted
      */
-    public static void addClassficationEvent(MCRCategoryID id, char type) {
+    public static void addClassificationEvent(MCRCategoryID id, char type) {
         if (!Objects.requireNonNull(id).isRootID()) {
             throw new IllegalArgumentException("Only root category ids are allowed: " + id);
         }

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/MCROCFLXMLClassificationManager.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/MCROCFLXMLClassificationManager.java
@@ -58,7 +58,7 @@ public class MCROCFLXMLClassificationManager implements MCRXMLClassificationMana
 
     private static final String ROOT_FOLDER = "classification/";
 
-    @MCRProperty(name = "Repository")
+    @MCRProperty(name = "MCR.OCFL.Classification.Repository", absolute = true)
     public String repositoryKey;
 
     protected static final Map<String, Character> MESSAGE_TYPE_MAPPING = Map.ofEntries(

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/MCROCFLXMLMetadataManager.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/MCROCFLXMLMetadataManager.java
@@ -94,7 +94,7 @@ public class MCROCFLXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
         return repositoryKey;
     }
 
-    @MCRProperty(name = "Repository", required = false)
+    @MCRProperty(name = "MCR.OCFL.Metadata.Repository", absolute = true, required = false)
     public void setRepositoryKey(String repositoryKey) {
         this.repositoryKey = repositoryKey;
     }

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/commands/MCROCFLCommands.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/commands/MCROCFLCommands.java
@@ -104,14 +104,14 @@ public class MCROCFLCommands {
         help = "Update classification {0} in the OCFL Store from database")
     public static void updateOCFLClassification(String classId) {
         final MCRCategoryID rootID = MCRCategoryID.rootID(classId);
-        MCROCFLPersistenceTransaction.addClassficationEvent(rootID, MCRAbstractMetadataVersion.UPDATED);
+        MCROCFLPersistenceTransaction.addClassificationEvent(rootID, MCRAbstractMetadataVersion.UPDATED);
     }
 
     @MCRCommand(syntax = "delete ocfl classification {0}",
         help = "Delete classification {0} in the OCFL Store")
     public static void deleteOCFLClassification(String classId) {
         final MCRCategoryID rootID = MCRCategoryID.rootID(classId);
-        MCROCFLPersistenceTransaction.addClassficationEvent(rootID, MCRAbstractMetadataVersion.DELETED);
+        MCROCFLPersistenceTransaction.addClassificationEvent(rootID, MCRAbstractMetadataVersion.DELETED);
     }
 
     @MCRCommand(syntax = "sync ocfl classifications",
@@ -178,7 +178,7 @@ public class MCROCFLCommands {
     }
 
     private static List<String> getStaleOCFLClassificationIDs() {
-        String repositoryKey = MCRConfiguration2.getStringOrThrow("MCR.Classification.Manager.Repository");
+        String repositoryKey = MCRConfiguration2.getStringOrThrow("MCR.OCFL.Classification.Repository");
         List<String> classDAOList = new MCRCategoryDAOImpl().getRootCategoryIDs().stream()
             .map(MCRCategoryID::toString)
             .collect(Collectors.toList());
@@ -193,7 +193,7 @@ public class MCROCFLCommands {
     }
 
     private static List<String> getStaleOCFLUserIDs() {
-        String repositoryKey = MCRConfiguration2.getStringOrThrow("MCR.Users.Manager.Repository");
+        String repositoryKey = MCRConfiguration2.getStringOrThrow("MCR.OCFL.Users.Repository");
         List<String> userEMList = MCRUserManager.listUsers("*", null, null, null).stream()
             .map(MCRUser::getUserID)
             .collect(Collectors.toList());

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/user/MCROCFLXMLUserManager.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/user/MCROCFLXMLUserManager.java
@@ -71,7 +71,7 @@ public class MCROCFLXMLUserManager {
      */
     public MCROCFLXMLUserManager() {
         this.repository = MCROCFLRepositoryProvider.getRepository(
-            MCRConfiguration2.getStringOrThrow("MCR.Users.Manager.Repository"));
+            MCRConfiguration2.getStringOrThrow("MCR.OCFL.Users.Repository"));
     }
 
     /**

--- a/mycore-ocfl/src/main/resources/components/ocfl/config/mycore.properties
+++ b/mycore-ocfl/src/main/resources/components/ocfl/config/mycore.properties
@@ -51,7 +51,7 @@ MCR.OCFL.Repository.Main.WorkDir=%MCR.datadir%/ocfl-temp
 # MCR.Metadata.Manager=org.mycore.ocfl.MCROCFLXMLMetadataManager
 
 # Default Metadata Manager repository
-MCR.Metadata.Manager.Repository=Main
+MCR.OCFL.Metadata.Repository=Main
 
 ######################################################################
 #                  OCFL Classification Configuration                 #
@@ -61,10 +61,10 @@ MCR.Metadata.Manager.Repository=Main
 # MCR.Category.DAO=org.mycore.datamodel.classifications2.impl.MCREventedCategoryDAOImpl
 
 # Enable the OCFL Classification Manager
-# MCR.Classification.Manager=org.mycore.ocfl.MCROCFLXMLClassificationManager
+# MCR.OCFL.Classification.Manager=org.mycore.ocfl.MCROCFLXMLClassificationManager
 
 # Default Classification Manager repository
-MCR.Classification.Manager.Repository=Main
+MCR.OCFL.Classification.Repository=Main
 
 # Event Handler Binding for Classification Manager
 # MCR.EventHandler.MCRClassification.020.Class=org.mycore.ocfl.MCROCFLClassificationEventHandler
@@ -77,4 +77,4 @@ MCR.Classification.Manager.Repository=Main
 # MCR.EventHandler.MCRUser.020.Class=org.mycore.ocfl.user.MCROCFLUserEventHandler
 
 # default user repository
-MCR.Users.Manager.Repository=Main
+MCR.OCFL.Users.Repository=Main


### PR DESCRIPTION
Changes Property Keys like:
`MCR.<Type>.Manager.Repository=Main`
to
`MCR.OCFL.<Type>.Repository=Main`

- added "OCFL" to ocfl property keys and reformed them
- fixed typo in OCFLPersistenceTransaction method name

[Link to jira](https://mycore.atlassian.net/browse/MCR-2761).
