### PR TITLE
MCR-2773 Rest api v1 file upload copies two times to derivate

### DIFF
--- a/mycore-restapi/src/main/java/org/mycore/restapi/v1/utils/MCRRestAPIUploadHelper.java
+++ b/mycore-restapi/src/main/java/org/mycore/restapi/v1/utils/MCRRestAPIUploadHelper.java
@@ -305,9 +305,7 @@ public class MCRRestAPIUploadHelper {
             if (Files.notExists(derRoot)) {
                 derRoot.getFileSystem().createRoot(derID.toString());
             }
-
-            der.getDerivate().getInternals().setSourcePath(derDir.toString());
-
+            
             if (formParamUnzip) {
                 String maindoc = null;
                 try (ZipInputStream zis = new ZipInputStream(new BufferedInputStream(uploadedInputStream))) {


### PR DESCRIPTION
Remove the source attribute to prevent the metadata manager from copying the uploaded contents a second time.

[Link to jira](https://mycore.atlassian.net/browse/MCR-2773).
