### PR TITLE
MCR-2790 bad default filename

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/xml/MCRLayoutService.java
+++ b/mycore-base/src/main/java/org/mycore/common/xml/MCRLayoutService.java
@@ -161,7 +161,7 @@ public class MCRLayoutService {
             return extractFileName(req.getPathInfo());
         }
         return new MessageFormat("{0}-{1}", Locale.ROOT).format(
-            new Object[] { extractFileName(req.getServletPath()), System.currentTimeMillis() });
+            new Object[] { extractFileName(req.getServletPath()), String.valueOf(System.currentTimeMillis())});
     }
 
     private String extractFileName(String filename) {


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-2790).

In class MCRLayoutService method getFileName Line 162/163 the default generate a filename like MCRLpzBasketServlet-1,668,077,879,683 or MCRLpzBasketServlet-1.668.077.879.683 . This is not good. it should be independend from the Locale and it should be a String like MCRLpzBasketServlet-1668077879683 .
