### PR TITLE
MCR-2801 mod2dc.xsl coverage ranges should use iso format

### DIFF
--- a/mycore-mods/src/main/resources/xsl/mods2dc.xsl
+++ b/mycore-mods/src/main/resources/xsl/mods2dc.xsl
@@ -173,7 +173,7 @@
 			<dc:coverage>
 				<xsl:for-each select="mods:temporal">
 					<xsl:value-of select="."/>
-					<xsl:if test="position()!=last()">-</xsl:if>
+					<xsl:if test="position()!=last()">/</xsl:if>
 				</xsl:for-each>
 			</dc:coverage>
 		</xsl:if>


### PR DESCRIPTION
change the mods2dc stylesheet to use "/" iso date separators

[Link to jira](https://mycore.atlassian.net/browse/MCR-2801).
