### PR TITLE
MCR-2830 the file name check user readable message

### DIFF
--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRDerivateServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRDerivateServlet.java
@@ -38,6 +38,7 @@ import org.mycore.frontend.fileupload.MCRUploadHelper;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.mycore.services.i18n.MCRTranslation;
 
 /**
  * @author Sebastian Hofmann; Silvio Hermann; Thomas Scheffler (yagee); Sebastian Röher
@@ -168,6 +169,14 @@ public class MCRDerivateServlet extends MCRServlet {
         if (Files.isDirectory(pathFrom)) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, String.format(Locale.ENGLISH,
                 "Renaming directory %s is not supported!", pathFrom));
+            return;
+        }
+
+        try {
+            MCRUploadHelper.checkPathName(pathTo.getOwnerRelativePath(), true);
+        } catch (MCRException ex){
+            String translatedMessage = MCRTranslation.translate("IFS.invalid.fileName", pathTo.getOwnerRelativePath());
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, translatedMessage);
             return;
         }
 

--- a/mycore-base/src/main/resources/config/messages_de.properties
+++ b/mycore-base/src/main/resources/config/messages_de.properties
@@ -20,6 +20,7 @@ IFS.resolveHandle      = Handle aufl\u00F6sen
 IFS.size               = Gr\u00F6\u00DFe
 IFS.startFile          = Start-Datei
 IFS.total              = Gesamtzahl Dateien/Verzeichnisse
+IFS.invalid.fileName   = Der Dateiname {0} ist ung\u00FCltig.
 
 MCRDericateServlet.error.noDerivateId = Es wurde keine Derivate Id angegeben.
 MCRDericateServlet.error.noObjectId   = Es wurde keine MyCoRe - Object - ID angegeben.

--- a/mycore-base/src/main/resources/config/messages_en.properties
+++ b/mycore-base/src/main/resources/config/messages_en.properties
@@ -20,6 +20,7 @@ IFS.resolveHandle      = resolve handle
 IFS.size               = Size
 IFS.startFile          = Start file
 IFS.total              = Total number files/directories
+IFS.invalid.fileName   = The filename {0} is not allowed.
 
 MCRDericateServlet.error.noDerivateId = The Derivate - id cannot resolved.
 MCRDericateServlet.error.noObjectId   = The MyCoRe - Object - id cannot resolved.


### PR DESCRIPTION
- the file name check in the move file method of MCRDerivateServlet now produce a user redable message (rendered by xsl)
- the file name check in the MCRUploadResource now produces a user readable message (send as plain text)

[Link to jira](https://mycore.atlassian.net/browse/MCR-2830).
