### PR TITLE
MCR-2838 MCRMODSMetadataShareAgent.checkHierarchy should only check nodes inheriting metadata

### DIFF
--- a/mycore-mods/src/main/java/org/mycore/mods/MCRMODSMetadataShareAgent.java
+++ b/mycore-mods/src/main/java/org/mycore/mods/MCRMODSMetadataShareAgent.java
@@ -43,6 +43,8 @@ import org.mycore.datamodel.metadata.MCRObjectID;
 import org.mycore.datamodel.metadata.MCRObjectMetadata;
 import org.mycore.datamodel.metadata.share.MCRMetadataShareAgent;
 
+import static org.mycore.mods.MCRMODSWrapper.LINKED_RELATED_ITEMS;
+
 /**
  * @author Thomas Scheffler (yagee)
  */
@@ -173,7 +175,8 @@ public class MCRMODSMetadataShareAgent implements MCRMetadataShareAgent {
     private void checkHierarchy(MCRMODSWrapper mods) throws MCRPersistenceException {
         final MCRObjectID modsId = Objects.requireNonNull(mods.getMCRObject().getId());
         LOGGER.info("Checking relatedItem hierarchy of {}.", modsId);
-        final List<Element> relatedItemLeaves = mods.getElements(".//mods:relatedItem[not(mods:relatedItem)]");
+        final List<Element> relatedItemLeaves
+            = mods.getElements(".//" + LINKED_RELATED_ITEMS + "[not(mods:relatedItem)]");
         try {
             relatedItemLeaves.forEach(e -> checkHierarchy(e, new HashSet<>(Set.of(modsId))));
         } catch (MCRPersistenceException e) {

--- a/mycore-mods/src/main/java/org/mycore/mods/MCRMODSWrapper.java
+++ b/mycore-mods/src/main/java/org/mycore/mods/MCRMODSWrapper.java
@@ -53,7 +53,7 @@ import org.mycore.mods.classification.MCRClassMapper;
 public class MCRMODSWrapper {
 
     //ancestor::mycoreobject required for MCR-927
-    private static final String LINKED_RELATED_ITEMS = "mods:relatedItem[@type='host'"
+    static final String LINKED_RELATED_ITEMS = "mods:relatedItem[@type='host'"
         + " and ancestor::mycoreobject/structure/parents/parent or"
         + " string-length(substring-after(@xlink:href,'_')) > 0 and"
         + " string-length(substring-after(substring-after(@xlink:href,'_'), '_')) > 0 and"

--- a/mycore-mods/src/test/java/org/mycore/mods/MCRMODSLinkedMetadataTest.java
+++ b/mycore-mods/src/test/java/org/mycore/mods/MCRMODSLinkedMetadataTest.java
@@ -133,4 +133,13 @@ public class MCRMODSLinkedMetadataTest extends MCRJPATestCase {
         MCRObject series = new MCRObject(getResourceAsURL(seriesID + "-updated2.xml").toURI());
         MCRMetadataManager.update(series);
     }
+
+    @Test()
+    public void testHierarchyNoInheritance() throws URISyntaxException, SAXParseException, IOException, MCRAccessException {
+        MCRObjectID book4ID = MCRObjectID.getInstance("junit_mods_00000004");
+        MCRObject book2 = new MCRObject(getResourceAsURL(book4ID + ".xml").toURI());
+        MCRMetadataManager.create(book2);
+        book2 = new MCRObject(getResourceAsURL(book4ID + "-updated.xml").toURI());
+        MCRMetadataManager.update(book2);
+    }
 }

--- a/mycore-mods/src/test/java/org/mycore/mods/MCRMODSLinkedMetadataTest.java
+++ b/mycore-mods/src/test/java/org/mycore/mods/MCRMODSLinkedMetadataTest.java
@@ -134,8 +134,12 @@ public class MCRMODSLinkedMetadataTest extends MCRJPATestCase {
         MCRMetadataManager.update(series);
     }
 
-    @Test()
-    public void testHierarchyNoInheritance() throws URISyntaxException, SAXParseException, IOException, MCRAccessException {
+    /**
+     * The tests check if the relatedItems with no inherited data are ignored by the hierarchy check of the ShareAgent
+     */
+    @Test(expected = Test.None.class)
+    public void testHierarchyNoInheritance() throws URISyntaxException, SAXParseException, IOException,
+            MCRAccessException {
         MCRObjectID book4ID = MCRObjectID.getInstance("junit_mods_00000004");
         MCRObject book2 = new MCRObject(getResourceAsURL(book4ID + ".xml").toURI());
         MCRMetadataManager.create(book2);

--- a/mycore-mods/src/test/resources/MCRMODSLinkedMetadataTest/junit_mods_00000004-updated.xml
+++ b/mycore-mods/src/test/resources/MCRMODSLinkedMetadataTest/junit_mods_00000004-updated.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mycoreobject xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="datamodel-mods.xsd" ID="junit_mods_00000004" label="" version="2019.06">
+  <structure />
+  <metadata>
+    <def.modsContainer class="MCRMetaXML" heritable="false" notinherit="true">
+      <modsContainer inherited="0">
+        <mods:mods xmlns:mods="http://www.loc.gov/mods/v3">
+          <mods:titleInfo supplied="yes" usage="primary">
+            <mods:title>Related title</mods:title>
+          </mods:titleInfo>
+          <mods:name type="personal" usage="primary">
+            <mods:displayForm>Doe, John</mods:displayForm>
+            <mods:role>
+              <mods:roleTerm authority="marcrelator" type="code">aut</mods:roleTerm>
+            </mods:role>
+          </mods:name>
+          <mods:originInfo>
+            <mods:dateIssued encoding="w3cdtf" keyDate="yes">2020</mods:dateIssued>
+          </mods:originInfo>
+          <mods:language usage="primary">
+            <mods:languageTerm authority="rfc5646" type="code">de</mods:languageTerm>
+          </mods:language>
+          <mods:relatedItem type="series" xlink:href="junit_mods_00000001">
+            <mods:genre usage="primary">series</mods:genre>
+            <mods:titleInfo supplied="yes" usage="primary">
+              <mods:title>Series title</mods:title>
+            </mods:titleInfo>
+            <mods:part>
+              <mods:detail type="volume">
+                <mods:number>43</mods:number>
+              </mods:detail>
+            </mods:part>
+          </mods:relatedItem>
+          <mods:relatedItem type="otherVersion" xlink:href="junit_mods_00000004">
+          </mods:relatedItem>
+        </mods:mods>
+      </modsContainer>
+    </def.modsContainer>
+  </metadata>
+  <service />
+</mycoreobject>

--- a/mycore-mods/src/test/resources/MCRMODSLinkedMetadataTest/junit_mods_00000004.xml
+++ b/mycore-mods/src/test/resources/MCRMODSLinkedMetadataTest/junit_mods_00000004.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mycoreobject xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="datamodel-mods.xsd" ID="junit_mods_00000004" label="" version="2019.06">
+  <structure />
+  <metadata>
+    <def.modsContainer class="MCRMetaXML" heritable="false" notinherit="true">
+      <modsContainer inherited="0">
+        <mods:mods xmlns:mods="http://www.loc.gov/mods/v3">
+          <mods:titleInfo supplied="yes" usage="primary">
+            <mods:title>Related title</mods:title>
+          </mods:titleInfo>
+          <mods:name type="personal" usage="primary">
+            <mods:displayForm>Doe, John</mods:displayForm>
+            <mods:role>
+              <mods:roleTerm authority="marcrelator" type="code">aut</mods:roleTerm>
+            </mods:role>
+          </mods:name>
+          <mods:originInfo>
+            <mods:dateIssued encoding="w3cdtf" keyDate="yes">2020</mods:dateIssued>
+          </mods:originInfo>
+          <mods:language usage="primary">
+            <mods:languageTerm authority="rfc5646" type="code">de</mods:languageTerm>
+          </mods:language>
+          <mods:relatedItem type="series" xlink:href="junit_mods_00000001">
+            <mods:genre usage="primary">series</mods:genre>
+            <mods:titleInfo supplied="yes" usage="primary">
+              <mods:title>Series title</mods:title>
+            </mods:titleInfo>
+            <mods:part>
+              <mods:detail type="volume">
+                <mods:number>43</mods:number>
+              </mods:detail>
+            </mods:part>
+          </mods:relatedItem>
+          <mods:relatedItem type="otherVersion" xlink:href="junit_mods_00000002">
+          </mods:relatedItem>
+        </mods:mods>
+      </modsContainer>
+    </def.modsContainer>
+  </metadata>
+  <service />
+</mycoreobject>


### PR DESCRIPTION
- Changed XPath to catch only related items which inherit metadata
- Added test which tests if a simple relatedItems(which will not inherit metadata) does not produce a exception

[Link to jira](https://mycore.atlassian.net/browse/MCR-2838).
