### PR TITLE
MCR-2850 Update citeproc-java to 3.0.0-beta.2 to fix duplicate date in some csl styles

### DIFF
--- a/mycore-bom/pom.xml
+++ b/mycore-bom/pom.xml
@@ -193,7 +193,7 @@
       <dependency>
         <groupId>de.undercouch</groupId>
         <artifactId>citeproc-java</artifactId>
-        <version>3.0.0-alpha.6</version>
+        <version>3.0.0-beta.2</version>
       </dependency>
       <dependency>
         <groupId>edu.wisc.library.ocfl</groupId>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-2850).
