### PR TITLE
MCR-2901 downgrade fop-core to version 2.6 to make relative font paths

### DIFF
--- a/mycore-bom/pom.xml
+++ b/mycore-bom/pom.xml
@@ -397,7 +397,7 @@
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>fop-core</artifactId>
-        <version>2.7</version>
+        <version>2.6</version>
         <exclusions>
           <exclusion>
             <groupId>xml-apis</groupId>


### PR DESCRIPTION
... work again

[Link to jira](https://mycore.atlassian.net/browse/MCR-2901).
