### PR TITLE
MCR-2902 Faster GetHighestStoredID

### DIFF
--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/metadata/MCROCFLXMLMetadataManager.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/metadata/MCROCFLXMLMetadataManager.java
@@ -420,7 +420,7 @@ public class MCROCFLXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
             return 0;
         }
         if (depth <= 1) {
-            return max;
+            return Math.max(0, max);
         } else {
             return traverseMCRStorageDirectory(newPath, depth - 1);
         }

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/metadata/MCROCFLXMLMetadataManager.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/metadata/MCROCFLXMLMetadataManager.java
@@ -21,6 +21,9 @@ package org.mycore.ocfl.metadata;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.Collections;
@@ -30,8 +33,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.jdom2.Document;
 import org.jdom2.JDOMException;
@@ -41,6 +46,7 @@ import org.mycore.common.MCRSession;
 import org.mycore.common.MCRSessionMgr;
 import org.mycore.common.MCRUsageException;
 import org.mycore.common.MCRUserInformation;
+import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.config.annotation.MCRProperty;
 import org.mycore.common.content.MCRContent;
 import org.mycore.common.content.MCRJDOMContent;
@@ -49,6 +55,9 @@ import org.mycore.datamodel.common.MCRObjectIDDate;
 import org.mycore.datamodel.common.MCRXMLMetadataManagerAdapter;
 import org.mycore.datamodel.ifs2.MCRObjectIDDateImpl;
 import org.mycore.datamodel.metadata.MCRObjectID;
+import org.mycore.datamodel.metadata.history.MCRMetadataHistoryManager;
+import org.mycore.ocfl.layout.MCRStorageLayoutConfig;
+import org.mycore.ocfl.layout.MCRStorageLayoutExtension;
 import org.mycore.ocfl.repository.MCROCFLRepositoryProvider;
 import org.mycore.ocfl.util.MCROCFLDeleteUtils;
 import org.mycore.ocfl.util.MCROCFLMetadataVersion;
@@ -64,6 +73,9 @@ import edu.wisc.library.ocfl.api.model.OcflObjectVersion;
 import edu.wisc.library.ocfl.api.model.VersionDetails;
 import edu.wisc.library.ocfl.api.model.VersionInfo;
 import edu.wisc.library.ocfl.api.model.VersionNum;
+import edu.wisc.library.ocfl.core.extension.OcflExtensionConfig;
+import edu.wisc.library.ocfl.core.extension.storage.layout.HashedNTupleIdEncapsulationLayoutExtension;
+import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedNTupleIdEncapsulationLayoutConfig;
 
 /**
  * Manages persistence of MCRObject and MCRDerivate xml metadata. Provides
@@ -317,7 +329,60 @@ public class MCROCFLXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
 
     @Override
     public int getHighestStoredID(String project, String type) {
-        return getStoredIDs(project, type).max().orElse(0);
+        Path path
+            = Path.of(MCRConfiguration2.getStringOrThrow("MCR.OCFL.Repository." + repositoryKey + ".RepositoryRoot"));
+        int highestStoredID = 0;
+        int maxDepth = Integer.MAX_VALUE;
+        OcflExtensionConfig config = MCRConfiguration2.getSingleInstanceOf("MCR.OCFL.Repository." + repositoryKey)
+            .map(MCROCFLRepositoryProvider.class::cast).orElseThrow().getExtensionConfig();
+        // optimization for known layouts
+        if (Objects.equals(config.getExtensionName(), MCRStorageLayoutExtension.EXTENSION_NAME)) {
+            maxDepth = ((MCRStorageLayoutConfig) config).getSlotLayout().split("-").length;
+            path = Path.of(path.toString(), MCROCFLObjectIDPrefixHelper.MCROBJECT.replace(":", ""), project, type);
+            highestStoredID = travelDirectory(path, 1, maxDepth);
+        } else if (Objects.equals(config.getExtensionName(),
+            HashedNTupleIdEncapsulationLayoutExtension.EXTENSION_NAME)) {
+            maxDepth = ((HashedNTupleIdEncapsulationLayoutConfig) config).getNumberOfTuples() + 1;
+        }
+        if (highestStoredID == 0) {
+            Pattern pattern = Pattern.compile("^.*" + project + "_{1}" + type + "_{1}\\d+$");
+            try (Stream<Path> stream = Files.find(path, maxDepth,
+                (filePath, fileAttr) -> pattern.matcher(filePath.getFileName().toString()).matches())) {
+                highestStoredID = stream.map(entry -> entry.getFileName().toString())
+                    .map(fileName -> Integer.parseInt(fileName.substring(fileName.lastIndexOf('_') + 1)))
+                    .max(Integer::compareTo).orElse(0);
+            } catch (Exception e) {
+                return MCRMetadataHistoryManager.getHighestStoredID(project, type)
+                    .map(MCRObjectID::getNumberAsInteger)
+                    .orElse(0);
+            }
+        }
+        return Math.max(highestStoredID, MCRMetadataHistoryManager.getHighestStoredID(project, type)
+            .map(MCRObjectID::getNumberAsInteger)
+            .orElse(0));
+    }
+
+    private int travelDirectory(Path path, int depth, int maxDepth) {
+        int max = -1;
+        Path newPath = path;
+        try (DirectoryStream<Path> ds
+            = Files.newDirectoryStream(path, p -> p.getFileName().toString().matches("^.*\\d+$"))) {
+            for (Path entry : ds) {
+                int current = Integer.parseInt(entry.getFileName().toString().replaceAll("^.*_", ""));
+                if (max < current) {
+                    max = current;
+                    newPath = entry;
+                }
+            }
+        } catch (IOException | NumberFormatException e) {
+            // fallback to slower full tree search
+            return 0;
+        }
+        if (depth == maxDepth) {
+            return max;
+        } else {
+            return travelDirectory(newPath, depth + 1, maxDepth);
+        }
     }
 
     @Override

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/metadata/MCROCFLXMLMetadataManager.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/metadata/MCROCFLXMLMetadataManager.java
@@ -24,6 +24,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.Collections;
@@ -351,8 +352,12 @@ public class MCROCFLXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
             HashedNTupleIdEncapsulationLayoutExtension.EXTENSION_NAME)) {
             maxDepth = ((HashedNTupleIdEncapsulationLayoutConfig) config).getNumberOfTuples() + 1;
             basePath = ((MCROCFLHashRepositoryProvider) oclfRepoProvider).getRepositoryRoot();
+        } else {
+            //for other repository provider implementation start with root directory
+            basePath = MCRConfiguration2.getString("MCR.OCFL.Repository." + repositoryKey + ".RepositoryRoot")
+                .map(Paths::get).orElse(null);
         }
-        
+
         if (basePath != null && highestStoredID == 0) {
             Pattern pattern = Pattern.compile("^.*" + project + "_{1}" + type + "_{1}\\d+$");
             try (Stream<Path> stream = Files.find(basePath, maxDepth,

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/metadata/MCROCFLXMLMetadataManager.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/metadata/MCROCFLXMLMetadataManager.java
@@ -24,7 +24,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.Collections;
@@ -57,10 +56,10 @@ import org.mycore.datamodel.common.MCRXMLMetadataManagerAdapter;
 import org.mycore.datamodel.ifs2.MCRObjectIDDateImpl;
 import org.mycore.datamodel.metadata.MCRObjectID;
 import org.mycore.datamodel.metadata.history.MCRMetadataHistoryManager;
-import org.mycore.ocfl.repository.MCROCFLHashRepositoryProvider;
-import org.mycore.ocfl.repository.MCROCFLMCRRepositoryProvider;
 import org.mycore.ocfl.layout.MCRStorageLayoutConfig;
 import org.mycore.ocfl.layout.MCRStorageLayoutExtension;
+import org.mycore.ocfl.repository.MCROCFLHashRepositoryProvider;
+import org.mycore.ocfl.repository.MCROCFLMCRRepositoryProvider;
 import org.mycore.ocfl.repository.MCROCFLRepositoryProvider;
 import org.mycore.ocfl.util.MCROCFLDeleteUtils;
 import org.mycore.ocfl.util.MCROCFLMetadataVersion;
@@ -355,7 +354,7 @@ public class MCROCFLXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
         } else {
             //for other repository provider implementation start with root directory
             basePath = MCRConfiguration2.getString("MCR.OCFL.Repository." + repositoryKey + ".RepositoryRoot")
-                .map(Paths::get).orElse(null);
+                .map(Path::of).orElse(null);
         }
 
         if (basePath != null && highestStoredID == 0) {

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/repository/MCROCFLRepositoryProvider.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/repository/MCROCFLRepositoryProvider.java
@@ -21,6 +21,7 @@ package org.mycore.ocfl.repository;
 import org.mycore.common.config.MCRConfiguration2;
 
 import edu.wisc.library.ocfl.api.OcflRepository;
+import edu.wisc.library.ocfl.core.extension.OcflExtensionConfig;
 
 /**
  * Base Class to provide a {@link OcflRepository}. A {@link MCROCFLRepositoryProvider} will be loaded from the property
@@ -38,4 +39,6 @@ public abstract class MCROCFLRepositoryProvider {
     }
 
     public abstract OcflRepository getRepository();
+
+    public abstract OcflExtensionConfig getExtensionConfig();
 }


### PR DESCRIPTION
This implements a faster, OCFL Optimized method giving more speed.
It is similar to the way IFS2 resolves it.

Compared to https://github.com/MyCoRe-Org/mycore/pull/1876, it does not fully rely on the HistoryManager but actually checks its storage.

Some performance metrics were collected with the old and current implementation and can be found here:
https://speicherwolke.uni-leipzig.de/index.php/s/WD8BW53Wx69nSWX

[Link to jira](https://mycore.atlassian.net/browse/MCR-2902).