### PR TITLE
MCR-2974 add support for mycore serviceworker

### DIFF
--- a/mycore-restapi/src/main/java/org/mycore/restapi/MCRCORSResponseFilter.java
+++ b/mycore-restapi/src/main/java/org/mycore/restapi/MCRCORSResponseFilter.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.mycore.restapi.annotations.MCRAccessControlExposeHeaders;
@@ -76,6 +77,11 @@ public class MCRCORSResponseFilter implements ContainerResponseFilter {
         if (requestHeaders != null) {
             //todo: may be restricted?
             responseHeaders.putSingle(ACCESS_CONTROL_ALLOW_HEADERS, requestHeaders);
+            //check if the request is a preflight request and the Authorization header will be sent
+            if (StringUtils.containsIgnoreCase(requestHeaders,HttpHeaders.AUTHORIZATION)) {
+                responseHeaders.putSingle(ACCESS_CONTROL_ALLOW_CREDENTIALS, true);
+                responseHeaders.putSingle(ACCESS_CONTROL_ALLOW_ORIGIN, requestContext.getHeaderString(ORIGIN));
+            }
         }
         long cacheSeconds = TimeUnit.DAYS.toSeconds(1);
         responseHeaders.putSingle(ACCESS_CONTROL_MAX_AGE, cacheSeconds);
@@ -90,7 +96,9 @@ public class MCRCORSResponseFilter implements ContainerResponseFilter {
         if (origin == null) {
             return; //No CORS Request
         }
-        boolean authenticatedRequest = requestContext.getSecurityContext().getAuthenticationScheme() != null;
+        boolean authenticatedRequest = requestContext.getSecurityContext().getAuthenticationScheme() != null
+            //check if the Authorization header was sent
+            || requestContext.getHeaderString(HttpHeaders.AUTHORIZATION) != null;
         MultivaluedMap<String, Object> responseHeaders = responseContext.getHeaders();
         if (authenticatedRequest) {
             responseHeaders.putSingle(ACCESS_CONTROL_ALLOW_CREDENTIALS, true);
@@ -101,6 +109,9 @@ public class MCRCORSResponseFilter implements ContainerResponseFilter {
             ArrayList<String> exposedHeaders = new ArrayList<>();
             if (authenticatedRequest && responseHeaders.getFirst(HttpHeaders.AUTHORIZATION) != null) {
                 exposedHeaders.add(HttpHeaders.AUTHORIZATION);
+            }
+            if ("ServiceWorker".equals(requestContext.getHeaderString("X-Requested-With"))) {
+                exposedHeaders.add(HttpHeaders.WWW_AUTHENTICATE);
             }
             Optional.ofNullable(resourceInfo)
                 .map(ResourceInfo::getResourceMethod)

--- a/mycore-restapi/src/main/java/org/mycore/restapi/MCRSessionFilter.java
+++ b/mycore-restapi/src/main/java/org/mycore/restapi/MCRSessionFilter.java
@@ -290,12 +290,13 @@ public class MCRSessionFilter implements ContainerRequestFilter, ContainerRespon
 
     //returns true for Ajax-Requests or requests for embedded images
     private static boolean doNotWWWAuthenticate(ContainerRequestContext requestContext) {
-        return "XMLHttpRequest".equals(requestContext.getHeaderString("X-Requested-With")) ||
+        return !"ServiceWorker".equals(requestContext.getHeaderString("X-Requested-With")) &&
+            ("XMLHttpRequest".equals(requestContext.getHeaderString("X-Requested-With")) ||
             requestContext.getAcceptableMediaTypes()
                 .stream()
                 .findFirst()
                 .filter(m -> "image".equals(m.getType()))
-                .isPresent();
+                .isPresent());
     }
 
     private static void closeSessionIfNeeded() {


### PR DESCRIPTION
This commit adds support for ServiceWorker in 'MCRSessionFilter' by making changes to how WWW-Authenticate requests are handled. It also includes substantial modifications to 'MCRJWTResource' for JWT validation. The logic for a session is now changed: not only does it verify the token, but it also checks the corresponding session exists and the user's IDs match. This strengthens the security around session handling. CORS support is enhanced in 'MCRCORSResponseFilter' by considering the 'Authorization' header for both normal & preflight requests.

[Link to jira](https://mycore.atlassian.net/browse/MCR-2974).
