### PR TITLE
MCR-2988 Add sourceUri validation in xEditor

### DIFF
--- a/mycore-xeditor/src/main/resources/components/xeditor/config/mycore.properties
+++ b/mycore-xeditor/src/main/resources/components/xeditor/config/mycore.properties
@@ -44,6 +44,9 @@ MCR.ContentTransformer.xeditor.Class=org.mycore.common.content.transformer.MCRXS
 MCR.ContentTransformer.xeditor.TransformerFactoryClass=org.apache.xalan.processor.TransformerFactoryImpl
 MCR.ContentTransformer.xeditor.Stylesheet=xsl/xeditor-templates.xsl,xsl/xeditor.xsl
 
+# Comma separated list of uri resolvers disallowed in the xed:source/@uri
+MCR.XEditor.MCRXEditorTransformer.URISchema.disallowList=callJava:
+
 # Undo implementations for change tracking edited XML
 MCR.XEditor.ChangeTracker.added-this-element.Class=org.mycore.frontend.xeditor.tracker.MCRAddedElement
 MCR.XEditor.ChangeTracker.removed-element.Class=org.mycore.frontend.xeditor.tracker.MCRRemoveElement


### PR DESCRIPTION
Added property `MCR.XEditor.MCRXEditorTransformer.URISchema.disallowList=callJava`:

[Link to JIRA](https://mycore.atlassian.net/browse/MCR-2988).
