### PR TITLE
MCR-2995 always return Source with systemId

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/xml/MCRURIResolver.java
+++ b/mycore-base/src/main/java/org/mycore/common/xml/MCRURIResolver.java
@@ -352,7 +352,11 @@ public final class MCRURIResolver implements URIResolver {
 
         URIResolver uriResolver = SUPPORTED_SCHEMES.get(scheme);
         if (uriResolver != null) {
-            return uriResolver.resolve(href, base);
+            Source resolved = uriResolver.resolve(href, base);
+            if (resolved.getSystemId() == null) {
+                resolved.setSystemId(href);
+            }
+            return resolved;
         } else { // try to handle as URL, use default resolver for file:// and
             try {
                 InputSource entity = MCREntityResolver.instance().resolveEntity(null, href);

--- a/mycore-base/src/main/java/org/mycore/common/xsl/MCRTemplatesSource.java
+++ b/mycore-base/src/main/java/org/mycore/common/xsl/MCRTemplatesSource.java
@@ -22,19 +22,16 @@ import java.io.IOException;
 import java.net.URL;
 
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
 import javax.xml.transform.sax.SAXSource;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.mycore.common.MCRCache;
 import org.mycore.common.MCRClassTools;
-import org.mycore.common.config.MCRConfigurationDir;
-import org.mycore.common.xml.MCREntityResolver;
-import org.mycore.common.xml.MCRXMLParserFactory;
+import org.mycore.common.xml.MCRURIResolver;
 import org.mycore.common.xml.MCRXMLResource;
-import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-import org.xml.sax.XMLReader;
 
 /**
  * Represents an XSL file that will be used in XSL transformation and which is loaded
@@ -60,14 +57,11 @@ public class MCRTemplatesSource {
 
     /** Have to use SAX here to resolve entities */
     public SAXSource getSource() throws SAXException, ParserConfigurationException {
-        XMLReader reader = MCRXMLParserFactory.getNonValidatingParser().getXMLReader();
-        reader.setEntityResolver(MCREntityResolver.instance());
-        URL resourceURL = MCRConfigurationDir.getConfigResource(resource);
-        if (resourceURL == null) {
-            throw new SAXException("Could not find resource: " + resource);
+        try {
+            return (SAXSource) MCRURIResolver.instance().resolve("resource:" + resource, null);
+        } catch (TransformerException e) {
+            throw new SAXException(e);
         }
-        InputSource input = new InputSource(resourceURL.toString());
-        return new SAXSource(reader, input);
     }
 
     /** Returns the path to the XSL file, for use as a caching key */


### PR DESCRIPTION
uses original systemId if an URIResolver does not provide one on return

[Link to jira](https://mycore.atlassian.net/browse/MCR-2995).
