### PR TITLE
MCR-3008 remove jpa-defaults.xml from property

### DIFF
--- a/mycore-base/src/main/resources/config/mycore.properties
+++ b/mycore-base/src/main/resources/config/mycore.properties
@@ -420,7 +420,7 @@ MCR.ContentTransformer.derivate-json-normal.Class=org.mycore.common.content.tran
 # The files can be loaded as resources from /configdir.template folder
 
 MCR.ConfigurationDirectory.template.directories=data,lib,resources
-MCR.ConfigurationDirectory.template.files=mycore.properties,resources/META-INF/persistence.xml,resources/META-INF/mycore-jpa-defaults.xml
+MCR.ConfigurationDirectory.template.files=mycore.properties,resources/META-INF/persistence.xml
 
 ##############################################################################
 # MCRMailer base configuration


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3008).

The jpa-defaults is present in the property which leads to errors when creating the configuration dir.