### PR TITLE
MCR-2968 fix ArrayIndexOutOfBoundsException

### DIFF
--- a/mycore-base/src/main/java/org/mycore/datamodel/language/MCRLanguageResolver.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/language/MCRLanguageResolver.java
@@ -24,6 +24,8 @@ import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.URIResolver;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.transform.JDOMSource;
@@ -31,14 +33,21 @@ import org.mycore.tools.MCRLanguageOrientationHelper;
 
 /**
  * Resolves languages by code. Syntax: language:{ISOCode}
- * 
+ *
  * @author Frank Lützenkirchen
  */
 public class MCRLanguageResolver implements URIResolver {
 
+    private static final Logger LOGGER = LogManager.getLogger();
+
     public Source resolve(String href, String base) throws TransformerException {
         try {
-            String code = href.split(":")[1];
+            String[] hrefContent = href.split(":");
+            if (hrefContent.length < 2) {
+                LOGGER.warn("Empty language code found while resolving URI 'language:'. Returning empty language tag.");
+                return new JDOMSource(new Document(new Element("language")));
+            }
+            String code = hrefContent[1];
             MCRLanguage language = MCRLanguageFactory.instance().getLanguage(code);
             Document doc = new Document(buildXML(language));
             return new JDOMSource(doc);
@@ -66,4 +75,5 @@ public class MCRLanguageResolver implements URIResolver {
 
         return xml;
     }
+
 }

--- a/mycore-base/src/main/java/org/mycore/datamodel/language/MCRLanguageResolver.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/language/MCRLanguageResolver.java
@@ -18,18 +18,15 @@
 
 package org.mycore.datamodel.language;
 
-import java.util.Map.Entry;
-
-import javax.xml.transform.Source;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.URIResolver;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.transform.JDOMSource;
 import org.mycore.tools.MCRLanguageOrientationHelper;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.URIResolver;
+import java.util.Map.Entry;
 
 /**
  * Resolves languages by code. Syntax: language:{ISOCode}
@@ -38,15 +35,12 @@ import org.mycore.tools.MCRLanguageOrientationHelper;
  */
 public class MCRLanguageResolver implements URIResolver {
 
-    private static final Logger LOGGER = LogManager.getLogger();
-
-    public Source resolve(String href, String base) throws TransformerException {
+    public Source resolve(String href, String base) throws TransformerException, IllegalArgumentException {
+        String[] hrefContent = href.split(":");
+        if (hrefContent.length < 2) {
+            throw new IllegalArgumentException("Empty language code found while resolving URI 'language:'.");
+        }
         try {
-            String[] hrefContent = href.split(":");
-            if (hrefContent.length < 2) {
-                LOGGER.warn("Empty language code found while resolving URI 'language:'. Returning empty language tag.");
-                return new JDOMSource(new Document(new Element("language")));
-            }
             String code = hrefContent[1];
             MCRLanguage language = MCRLanguageFactory.instance().getLanguage(code);
             Document doc = new Document(buildXML(language));

--- a/mycore-base/src/test/java/org/mycore/datamodel/language/MCRLanguageResolverTest.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/language/MCRLanguageResolverTest.java
@@ -9,11 +9,8 @@ import org.mycore.common.MCRTestCase;
 import javax.xml.transform.TransformerException;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class MCRLanguageResolverTest extends MCRTestCase {
 

--- a/mycore-base/src/test/java/org/mycore/datamodel/language/MCRLanguageResolverTest.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/language/MCRLanguageResolverTest.java
@@ -1,0 +1,34 @@
+package org.mycore.datamodel.language;
+
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.transform.JDOMSource;
+import org.junit.Test;
+import org.mycore.common.MCRTestCase;
+
+import javax.xml.transform.TransformerException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class MCRLanguageResolverTest extends MCRTestCase {
+
+    @Test
+    public void resolve() throws TransformerException {
+        // german code
+        MCRLanguageResolver languageResolver = new MCRLanguageResolver();
+        JDOMSource jdomSource = (JDOMSource) languageResolver.resolve("language:de", "");
+        Document document = jdomSource.getDocument();
+        assertNotNull(document);
+        assertNotNull(document.getRootElement());
+        Element languageElement = document.getRootElement();
+        assertEquals(2, languageElement.getChildren().size());
+
+        // empty code
+        jdomSource = (JDOMSource) languageResolver.resolve("language:", "");
+        document = jdomSource.getDocument();
+        assertNotNull(document);
+        assertNotNull(document.getRootElement());
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/datamodel/language/MCRLanguageResolverTest.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/language/MCRLanguageResolverTest.java
@@ -9,7 +9,11 @@ import org.mycore.common.MCRTestCase;
 import javax.xml.transform.TransformerException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class MCRLanguageResolverTest extends MCRTestCase {
 
@@ -25,10 +29,9 @@ public class MCRLanguageResolverTest extends MCRTestCase {
         assertEquals(2, languageElement.getChildren().size());
 
         // empty code
-        jdomSource = (JDOMSource) languageResolver.resolve("language:", "");
-        document = jdomSource.getDocument();
-        assertNotNull(document);
-        assertNotNull(document.getRootElement());
+        assertThrows(IllegalArgumentException.class, () -> {
+            languageResolver.resolve("language:", "");
+        });
     }
 
 }


### PR DESCRIPTION
MCRLanguageResolver - return empty language tag when language code is empty

[Link to jira](https://mycore.atlassian.net/browse/MCR-2968).
