### PR TITLE
workaround to support new maven-dependency-plugin

### DIFF
--- a/mycore-iiif/pom.xml
+++ b/mycore-iiif/pom.xml
@@ -28,6 +28,24 @@
   </parent>
   <artifactId>mycore-iiif</artifactId>
   <name>MyCoRe IIIF</name>
+  <build>
+    <plugins>
+      <plugin>
+        <!-- due to: https://issues.apache.org/jira/projects/MDEP/issues/MDEP-891 -->
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>analyze</id>
+            <configuration>
+              <ignoredDependencies>
+                <ignoredDependency>org.glassfish.jersey.core:jersey-server</ignoredDependency>
+              </ignoredDependencies>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/mycore-impex/pom.xml
+++ b/mycore-impex/pom.xml
@@ -32,6 +32,25 @@
   <properties>
     <manifest.priority>95</manifest.priority>
   </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <!-- due to: https://issues.apache.org/jira/projects/MDEP/issues/MDEP-891 -->
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>analyze</id>
+            <configuration>
+              <ignoredDependencies>
+                <ignoredDependency>org.apache.solr:solr-solrj</ignoredDependency>
+                <ignoredDependency>org.mycore:mycore-jobqueue</ignoredDependency>
+              </ignoredDependencies>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
new version of plugin is required for Java 21

to be used until https://issues.apache.org/jira/projects/MDEP/issues/MDEP-891 is resolved.
