### PR TITLE
MCR-3079 fix property check

### DIFF
--- a/mycore-pi/src/main/java/org/mycore/pi/MCRPIService.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/MCRPIService.java
@@ -494,7 +494,9 @@ public abstract class MCRPIService<T extends MCRPersistentIdentifier> {
      */
     protected String requireNotEmptyProperty(String propertyName) throws MCRConfigurationException {
         final Map<String, String> properties = getProperties();
-        if (!properties.containsKey(propertyName) && properties.get(propertyName).length() > 0) {
+        if (!properties.containsKey(propertyName) ||
+            properties.get(propertyName) == null ||
+            properties.get(propertyName).isEmpty()) {
             throw new MCRConfigurationException(String
                 .format(Locale.ROOT, "The property %s%s.%s is empty or not set!", REGISTRATION_CONFIG_PREFIX,
                     registrationServiceID,


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3079).

In the current implementation MCRPIService.requireNotEmptyProperty throws an NPE when a property is not set:

java.lang.NullPointerException: Cannot invoke "String.length()" because the return value of "java.util.Map.get(Object)" is null
[INFO] [talledLocalContainer] 	at org.mycore.pi.MCRPIService.requireNotEmptyProperty(MCRPIService.java:502)

 
It is not an urgent fix, as a missing property is supposed to throw an exception anyway. But the NPE obscures the intended error message.
