### PR TITLE
MCR-3085 Upgrade citeproc-java to version 3.1.0 (supports new variable citation-key)

### DIFF
--- a/mycore-bom/pom.xml
+++ b/mycore-bom/pom.xml
@@ -208,7 +208,7 @@
       <dependency>
         <groupId>de.undercouch</groupId>
         <artifactId>citeproc-java</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
       </dependency>
       <dependency>
         <groupId>edu.wisc.library.ocfl</groupId>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3085).
