### PR TITLE
MCR-3081 Support new csl variable “citation-key" with csl version 1.0.2 in MCRModsItemDataProvider

### DIFF
--- a/mycore-mods/src/main/java/org/mycore/mods/csl/MCRModsItemDataProvider.java
+++ b/mycore-mods/src/main/java/org/mycore/mods/csl/MCRModsItemDataProvider.java
@@ -109,6 +109,7 @@ public class MCRModsItemDataProvider extends MCRItemDataProvider {
     public CSLItemData retrieveItem(String id) {
         final CSLItemDataBuilder idb = new CSLItemDataBuilder().id(id);
 
+        processMyCoReId(id, idb);
         processURL(id, idb);
         processGenre(idb);
         processTitles(idb);
@@ -128,6 +129,10 @@ public class MCRModsItemDataProvider extends MCRItemDataProvider {
         }
 
         return build;
+    }
+
+    private void processMyCoReId(String id, CSLItemDataBuilder idb) {
+        idb.citationKey(id);
     }
 
     private void processSubject(CSLItemDataBuilder idb) {


### PR DESCRIPTION
[MCR-3081](https://mycore.atlassian.net/browse/MCR-3081)

[MCR-3081]: https://mycore.atlassian.net/browse/MCR-3081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ