### PR TITLE
MCR-2881 fix stalled session for MCRResourceServlet

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/content/util/ContentUtils.java
+++ b/mycore-base/src/main/java/org/mycore/common/content/util/ContentUtils.java
@@ -308,8 +308,7 @@ final class ContentUtils {
      * Called before sending data to end hibernate transaction, if any.
      */
     static void endCurrentTransaction() {
-        if (!MCRSessionMgr.isLocked()) {
-            MCRSessionMgr.getCurrentSession();
+        if (!MCRSessionMgr.isLocked() && MCRSessionMgr.hasCurrentSession()) {
             MCRTransactionHelper.commitTransaction();
         }
     }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-2881).

MCRResourceServlet uses ContentUtils to serve resources. In ContentUtils a MCRSession may be opened and attached to the thread which causes problems on the next request on this thread.

This fix does not open a MCRSession in the first place.