### PR TITLE
MCR-3110 HTML titles and abstracts lead to empty elements in Dublin Core

### DIFF
--- a/mycore-mods/src/main/resources/xsl/mods2dc.xsl
+++ b/mycore-mods/src/main/resources/xsl/mods2dc.xsl
@@ -72,7 +72,7 @@
 		</xsl:choose>
 	</xsl:template>
 
-	<xsl:template match="mods:titleInfo">
+	<xsl:template match="mods:titleInfo[not(@altFormat)]">
 		<dc:title>
 			<xsl:value-of select="mods:nonSort"/>
 			<xsl:if test="mods:nonSort">
@@ -189,7 +189,7 @@
 		</xsl:if>
 	</xsl:template>
 
-	<xsl:template match="mods:abstract | mods:tableOfContents | mods:note">
+	<xsl:template match="mods:abstract[not(@altFormat)] | mods:tableOfContents[not(@altFormat)] | mods:note">
 		<dc:description>
 			<xsl:value-of select="."/>
 		</dc:description>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3110).
