### PR TITLE
MCR-3156 Add null check for Neo4J parser

### DIFF
--- a/mycore-neo4j/src/main/java/org/mycore/mcr/neo4j/datamodel/metadata/neo4jparser/MCRNeo4JParser.java
+++ b/mycore-neo4j/src/main/java/org/mycore/mcr/neo4j/datamodel/metadata/neo4jparser/MCRNeo4JParser.java
@@ -186,6 +186,11 @@ public class MCRNeo4JParser implements MCRNeo4JMetaParser {
                     LOGGER.info("parse: {}", classAttribute.getValue());
 
                     MCRNeo4JAbstractDataModelParser clazz = parserMap.get(classAttribute.getValue());
+                    if (null == clazz) {
+                        LOGGER.error("Could not find Neo4J parser for metadata of type {}. Skipping", classAttribute.getValue());
+                        continue;
+                    }
+
                     for (Element elm : elms) {
                         // should only one elm in elms
                         List<Neo4JRelation> relations = clazz.parse(elm, id);

--- a/mycore-neo4j/src/main/java/org/mycore/mcr/neo4j/datamodel/metadata/neo4jparser/MCRNeo4JParser.java
+++ b/mycore-neo4j/src/main/java/org/mycore/mcr/neo4j/datamodel/metadata/neo4jparser/MCRNeo4JParser.java
@@ -187,7 +187,8 @@ public class MCRNeo4JParser implements MCRNeo4JMetaParser {
 
                     MCRNeo4JAbstractDataModelParser clazz = parserMap.get(classAttribute.getValue());
                     if (null == clazz) {
-                        LOGGER.error("Could not find Neo4J parser for metadata of type {}. Skipping", classAttribute.getValue());
+                        LOGGER.error("Could not find Neo4J parser for metadata of type {}. Skipping",
+                            classAttribute.getValue());
                         continue;
                     }
 


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3156)

Currently, the Neo4J parser raises a NullPointerException when a metadata type is to be indexed for which no parser is defined in mycore.properties. We should change this to an error message
