### PR TITLE
MCR-3109 Code cleanup for classification.xsl

### DIFF
--- a/mycore-base/src/main/resources/xslt/functions/classification.xsl
+++ b/mycore-base/src/main/resources/xslt/functions/classification.xsl
@@ -1,36 +1,44 @@
 <?xml version="1.0"?>
-<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  xmlns:xlink="http://www.w3.org/1999/xlink" 
-  xmlns:fn="http://www.w3.org/2005/xpath-functions"
-  xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  xmlns:mcrclass="http://www.mycore.de/xslt/classification"
-  exclude-result-prefixes="fn">
+<xsl:stylesheet version="3.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:mcrclass="http://www.mycore.de/xslt/classification"
+                exclude-result-prefixes="#all">
 
+  <!--
+    Returns the MCR category entry for the given classification and category ID
+
+    Parameters
+      * classid: the classification ID
+      * categid: the category ID
+  -->
   <xsl:function name="mcrclass:category" as="element()?">
     <xsl:param name="classid" as="xs:string" />
     <xsl:param name="categid" as="xs:string" />
+
     <xsl:sequence
       select="document(concat('classification:metadata:0:children:',$classid,':',$categid))//category" />
   </xsl:function>
 
+  <!--
+    Returns the CurrentLang label element of the given classification.
+
+    Parameters
+      * class: the MCR category element
+  -->
   <xsl:function name="mcrclass:current-label" as="element()?">
     <xsl:param name="class" as="element()?" />
-    <xsl:choose>
-      <xsl:when test="$class[@classid and @categid]">
-        <xsl:sequence select="mcrclass:current-label(document(concat('classification:metadata:0:children:',$class/@classid,':',$class/@categid))//category)" />
-      </xsl:when>
-      <xsl:when test="$class/label[@xml:lang=$CurrentLang]">
-        <xsl:sequence select="$class/label[@xml:lang=$CurrentLang]" />
-      </xsl:when>
-      <xsl:when test="$class/label[@xml:lang=$DefaultLang]">
-        <xsl:sequence select="$class/label[@xml:lang=$DefaultLang]" />
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:sequence select="$class/label[1]" />
-      </xsl:otherwise>
-    </xsl:choose>
+
+    <xsl:copy-of select="mcrclass:label($CurrentLang, $class)"/>
   </xsl:function>
 
+  <!--
+    Returns the label element of the given classification
+
+    Parameters
+      * lang: the language of the label element
+      * class: the MCR category element
+  -->
   <xsl:function name="mcrclass:label" as="element()?">
     <xsl:param name="lang" as="xs:string"/>
     <xsl:param name="class" as="element()?"/>
@@ -53,23 +61,26 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:function>
-  
+
+  <!--
+    Returns the text of the CurrentLang label element of the given classification
+
+    Parameters
+      * class: the MCR category element
+  -->
   <xsl:function name="mcrclass:current-label-text" as="xs:string?">
     <xsl:param name="class" as="element()?" />
-    <xsl:variable name="label" select="mcrclass:current-label($class)" />
-    <xsl:choose>
-      <xsl:when test="$label">
-        <xsl:sequence select="$label/@text" />
-      </xsl:when>
-      <xsl:when test="$class/@ID">
-        <xsl:sequence select="fn:concat('??', $class/@ID, '@', $CurrentLang, '??')" />
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:sequence select="()" />
-      </xsl:otherwise>
-    </xsl:choose>
+
+    <xsl:value-of select="mcrclass:label-text($CurrentLang, $class)"/>
   </xsl:function>
 
+  <!--
+    Returns the text of the label element with the given language of the given classification.
+
+    Parameters
+      * lang: the language of the label
+      * class: the MCR category element
+  -->
   <xsl:function name="mcrclass:label-text" as="xs:string?">
     <xsl:param name="lang" as="xs:string"/>
     <xsl:param name="class" as="element()?"/>

--- a/mycore-base/src/test/java/org/mycore/frontend/xsl/MCRXSLClassificationTest.java
+++ b/mycore-base/src/test/java/org/mycore/frontend/xsl/MCRXSLClassificationTest.java
@@ -20,6 +20,7 @@ package org.mycore.frontend.xsl;
 
 import org.jdom2.Document;
 import org.jdom2.Element;
+import org.jdom2.Namespace;
 import org.junit.Test;
 import org.mycore.common.MCRJPATestCase;
 import org.mycore.common.util.MCRTestCaseClassificationUtil;
@@ -27,6 +28,7 @@ import org.mycore.common.util.MCRTestCaseClassificationUtil;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mycore.common.util.MCRTestCaseXSLTUtil.prepareTestDocument;
 import static org.mycore.common.util.MCRTestCaseXSLTUtil.transform;
 
@@ -34,31 +36,178 @@ public class MCRXSLClassificationTest extends MCRJPATestCase {
     private static final String XSL = "/xslt/functions/classificationTest.xsl";
 
     @Test
+    public void testCategory() throws Exception {
+        final Document testDoc = prepareTestDocument("test-category");
+        final Map<String, Object> params = Map.of("classid", "TestClassification", "categid", "junit_1");
+
+        Element result = transform(testDoc, XSL, params).getRootElement();
+
+        // existing classification: return category with respective labels
+        assertEquals(1, result.getChildren("category").size());
+        assertEquals("junit_1", result.getChild("category").getAttributeValue("ID"));
+        assertEquals(3, result.getChild("category").getChildren("label").size());
+        assertEquals("de",
+            result.getChild("category").getChildren("label").get(0).getAttributeValue("lang", Namespace.XML_NAMESPACE));
+        assertEquals("junit_1 (de)",
+            result.getChild("category").getChildren("label").get(0).getAttributeValue("text"));
+        assertEquals("en",
+            result.getChild("category").getChildren("label").get(1).getAttributeValue("lang", Namespace.XML_NAMESPACE));
+        assertEquals("junit_1 (en)",
+            result.getChild("category").getChildren("label").get(1).getAttributeValue("text"));
+        assertEquals("x-xxx",
+            result.getChild("category").getChildren("label").get(2).getAttributeValue("lang", Namespace.XML_NAMESPACE));
+        assertEquals("abc",
+            result.getChild("category").getChildren("label").get(2).getAttributeValue("text"));
+
+        // non-existing classification/category: empty result
+        result = transform(testDoc, XSL, Map.of("classid", "TestClassification", "categid", "xxx")).getRootElement();
+        assertEquals(0, result.getChildren("category").size());
+    }
+
+    @Test
+    public void testCurrentLabel() throws Exception {
+        final Document testDoc = prepareTestDocument("test-current-label");
+
+        // existing category: return label of current lang
+        Element result = transform(testDoc, XSL,
+            Map.of(
+                "classid", "TestClassification",
+                "categid", "junit_1")).getRootElement();
+        assertEquals(1, result.getChildren("label").size());
+        assertEquals("de", result.getChild("label").getAttributeValue("lang", Namespace.XML_NAMESPACE));
+        assertEquals("junit_1 (de)", result.getChild("label").getAttributeValue("text"));
+
+        // current Lang does not exist, use default lang
+        result = transform(testDoc, XSL,
+            Map.of(
+                "classid", "TestClassification",
+                "categid", "junit_1",
+                "CurrentLang", "ar")).getRootElement();
+        assertEquals("en", result.getChild("label").getAttributeValue("lang", Namespace.XML_NAMESPACE));
+        assertEquals("junit_1 (en)", result.getChild("label").getAttributeValue("text"));
+
+        // current and default lang do not exist, use first label
+        result = transform(testDoc, XSL,
+            Map.of(
+                "classid", "TestClassification",
+                "categid", "junit_1",
+                "CurrentLang", "ar",
+                "DefaultLang", "es")).getRootElement();
+        assertEquals("de", result.getChild("label").getAttributeValue("lang", Namespace.XML_NAMESPACE));
+        assertEquals("junit_1 (de)", result.getChild("label").getAttributeValue("text"));
+
+        // category does not exist: return empty result
+        result = transform(testDoc, XSL,
+            Map.of("classid", "TestClassification", "categid", "xxx")).getRootElement();
+        assertTrue(result.getChildren("label").isEmpty());
+    }
+
+    @Test
+    public void testLabel() throws Exception {
+        final Document testDoc = prepareTestDocument("test-label");
+
+        // existing label and category
+        Element result = transform(testDoc, XSL,
+            Map.of(
+                "classid", "TestClassification",
+                "categid", "junit_1",
+                "lang", "x-xxx")).getRootElement();
+        assertEquals(1, result.getChildren("label").size());
+        assertEquals("x-xxx", result.getChild("label").getAttributeValue("lang", Namespace.XML_NAMESPACE));
+        assertEquals("abc", result.getChild("label").getAttributeValue("text"));
+
+        // not-existing label: use current lang label
+        result = transform(testDoc, XSL,
+            Map.of(
+                "classid", "TestClassification",
+                "categid", "junit_1",
+                "CurrentLang", "en",
+                "lang", "es")).getRootElement();
+        assertEquals(1, result.getChildren("label").size());
+        assertEquals("en", result.getChild("label").getAttributeValue("lang", Namespace.XML_NAMESPACE));
+        assertEquals("junit_1 (en)", result.getChild("label").getAttributeValue("text"));
+
+        // not existing label and not existing in current/default lang: use first label
+        result = transform(testDoc, XSL,
+            Map.of(
+                "classid", "TestClassification",
+                "categid", "junit_1",
+                "CurrentLang", "ar",
+                "DefaultLang", "it",
+                "lang", "es")).getRootElement();
+        assertEquals(1, result.getChildren("label").size());
+        assertEquals("de", result.getChild("label").getAttributeValue("lang", Namespace.XML_NAMESPACE));
+        assertEquals("junit_1 (de)", result.getChild("label").getAttributeValue("text"));
+    }
+
+    @Test
     public void testCurrentLabelText() throws Exception {
-        MCRTestCaseClassificationUtil.addClassification("/classification/TestClassification.xml");
         final Document testDoc = prepareTestDocument("test-current-label-text");
 
         // we have a current lang label (de) and a default lang label (en) entry
         Element result = transform(testDoc, XSL,
-            Map.of("classid", "TestClassification", "categid", "junit_1"))
-            .getRootElement();
+            Map.of(
+                "classid", "TestClassification",
+                "categid", "junit_1")).getRootElement();
         assertEquals("junit_1 (de)", result.getText());
 
         result = transform(testDoc, XSL,
-            Map.of("classid", "TestClassification", "categid", "junit_1", "CurrentLang", "en"))
-            .getRootElement();
+            Map.of(
+                "classid", "TestClassification",
+                "categid", "junit_1",
+                "CurrentLang", "en")).getRootElement();
         assertEquals("junit_1 (en)", result.getText());
 
         // we do not have a current lang label (de) entry, but default lang label (en) entry
         result = transform(testDoc, XSL,
-            Map.of("classid", "TestClassification", "categid", "junit_2"))
-            .getRootElement();
+            Map.of(
+                "classid", "TestClassification",
+                "categid", "junit_2")).getRootElement();
         assertEquals("junit_2 (en)", result.getText());
 
         // we neither have current lang nor default lang label
         result = transform(testDoc, XSL,
-            Map.of("classid", "TestClassification", "categid", "junit_3"))
-            .getRootElement();
+            Map.of(
+                "classid", "TestClassification",
+                "categid", "junit_3")).getRootElement();
         assertEquals("??junit_3@de??", result.getText());
+    }
+
+    @Test
+    public void testLabelText() throws Exception {
+        final Document testDoc = prepareTestDocument("test-label-text");
+
+        // we have an entry for the given language
+        Element result = transform(testDoc, XSL,
+            Map.of(
+                "classid", "TestClassification",
+                "categid", "junit_1",
+                "lang", "x-xxx")).getRootElement();
+        assertEquals("abc", result.getText());
+
+        // not existing language: return current lange entry
+        result = transform(testDoc, XSL,
+            Map.of(
+                "classid", "TestClassification",
+                "categid", "junit_1",
+                "lang", "ar")).getRootElement();
+        assertEquals("junit_1 (de)", result.getText());
+
+        // not existing language, not existing current and default lang: return first label
+        result = transform(testDoc, XSL,
+            Map.of(
+                "classid", "TestClassification",
+                "categid", "junit_2",
+                "CurrentLang", "ar",
+                "DefaultLang", "it",
+                "lang", "es")).getRootElement();
+        assertEquals("junit_2 (en)", result.getText());
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        MCRTestCaseClassificationUtil.addClassification("/classification/TestClassification.xml");
     }
 }

--- a/mycore-base/src/test/resources/classification/TestClassification.xml
+++ b/mycore-base/src/test/resources/classification/TestClassification.xml
@@ -5,6 +5,7 @@
         <category ID="junit_1">
             <label xml:lang="de" text="junit_1 (de)"/>
             <label xml:lang="en" text="junit_1 (en)"/>
+            <label xml:lang="x-xxx" text="abc"/>
         </category>
         <category ID="junit_2">
             <label xml:lang="en" text="junit_2 (en)"/>

--- a/mycore-base/src/test/resources/xslt/functions/classificationTest.xsl
+++ b/mycore-base/src/test/resources/xslt/functions/classificationTest.xsl
@@ -8,15 +8,44 @@
 
   <xsl:param name="classid" as="xs:string"/>
   <xsl:param name="categid" as="xs:string"/>
+  <xsl:param name="lang" as="xs:string"/>
   <xsl:param name="CurrentLang" as="xs:string?" select="'de'"/>
   <xsl:param name="DefaultLang" as="xs:string?" select="'en'"/>
 
+  <xsl:template match="test-category">
+    <result>
+      <xsl:copy-of select="mcrclass:category($classid, $categid)"/>
+    </result>
+  </xsl:template>
+
+  <xsl:template match="test-current-label">
+    <xsl:variable name="class" select="mcrclass:category($classid, $categid)"/>
+    <result>
+      <xsl:copy-of select="mcrclass:current-label($class)"/>
+    </result>
+  </xsl:template>
+
+  <xsl:template match="test-label">
+    <xsl:variable name="class" select="mcrclass:category($classid, $categid)"/>
+    <result>
+      <xsl:copy-of select="mcrclass:label($lang, $class)"/>
+    </result>
+
+  </xsl:template>
 
   <xsl:template match="test-current-label-text">
     <xsl:variable name="class" select="mcrclass:category($classid, $categid)"/>
     <result>
       <xsl:value-of select="mcrclass:current-label-text($class)"/>
     </result>
+  </xsl:template>
+
+  <xsl:template match="test-label-text">
+    <xsl:variable name="class" select="mcrclass:category($classid, $categid)"/>
+    <result>
+      <xsl:copy-of select="mcrclass:label-text($lang, $class)"/>
+    </result>
+
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3109).

work done in this PR:
* documentation of XSL templates in classification.xsl
* test code for these templates
* cleanup mcrclass:current-label and mcrclass:current-label-text to call templates with lang parameter
