### PR TITLE
MCR-3157 fixed uuid column annotation in MCRAccessKey

### DIFF
--- a/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/model/MCRAccessKey.java
+++ b/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/model/MCRAccessKey.java
@@ -72,7 +72,7 @@ import jakarta.persistence.Transient;
 public class MCRAccessKey {
 
     /** The unique and internal information id */
-    private Long id;
+    private Integer id;
 
     /** The access key information */
     private String reference;
@@ -199,14 +199,14 @@ public class MCRAccessKey {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "accesskey_id",
         nullable = false)
-    public Long getId() {
+    public Integer getId() {
         return id;
     }
 
     /**
      * @param id internal id
      */
-    public void setId(Long id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 

--- a/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/model/MCRAccessKey.java
+++ b/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/model/MCRAccessKey.java
@@ -139,6 +139,7 @@ public class MCRAccessKey {
      * @return the UUID or null
      */
     @JsonIgnore
+    @Column(name = "uuid", nullable = true)
     public UUID getUuid() {
         return uuid;
     }
@@ -148,7 +149,6 @@ public class MCRAccessKey {
      *
      * @param uuid the uuid to set
      */
-    @Column(name = "uuid", nullable = false)
     public void setUuid(UUID uuid) {
         this.uuid = uuid;
     }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3157).
The annotation has somehow slipped in there. In practice, it is irrelevant because it is in the wrong place respectively it must annotate the getter. The column has to be nullable for the migration of the table to work. Changing the data type for ID to Long has turned out to be unnecessary at present.