### PR TITLE
MCR-3299 Fixed ArrayIndexOutOfBoundsException in MCRClassificationMappingEventHandler

### DIFF
--- a/mycore-mods/src/main/java/org/mycore/mods/classification/MCRClassificationMappingEventHandler.java
+++ b/mycore-mods/src/main/java/org/mycore/mods/classification/MCRClassificationMappingEventHandler.java
@@ -97,6 +97,7 @@ public class MCRClassificationMappingEventHandler extends MCREventHandlerBase {
             String label = labelOptional.get().getText();
             return Stream.of(label.split("\\s"))
                 .map(categIdString -> categIdString.split(":"))
+                .filter(categIdArr -> categIdArr != null && categIdArr.length > 1)
                 .map(categIdArr -> new MCRCategoryID(categIdArr[0], categIdArr[1]))
                 .filter(dao::exist)
                 .map(mappingTarget -> new AbstractMap.SimpleEntry<>(category.getId(), mappingTarget))


### PR DESCRIPTION
[MCR-3299](https://mycore.atlassian.net/browse/MCR-3299).


[MCR-3299]: https://mycore.atlassian.net/browse/MCR-3299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ