### PR TITLE
MCR-3225 activate PMD rule AvoidReassigningLoopVariables

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/digest/MCRDigest.java
+++ b/mycore-base/src/main/java/org/mycore/common/digest/MCRDigest.java
@@ -66,6 +66,15 @@ public abstract class MCRDigest {
         return MCRUtils.toHexString(this.value);
     }
 
+    /**
+     * Returns the value of the digest.
+     *
+     * @return Digest value.
+     */
+    public byte[] getValue() {
+        return Arrays.copyOf(value, value.length);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof MCRDigest mcrDigest)) {

--- a/mycore-base/src/main/java/org/mycore/common/digest/MCRDigest.java
+++ b/mycore-base/src/main/java/org/mycore/common/digest/MCRDigest.java
@@ -66,15 +66,6 @@ public abstract class MCRDigest {
         return MCRUtils.toHexString(this.value);
     }
 
-    /**
-     * Returns the value of the digest.
-     *
-     * @return Digest value.
-     */
-    public byte[] getValue() {
-        return Arrays.copyOf(value, value.length);
-    }
-
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof MCRDigest mcrDigest)) {

--- a/mycore-restapi/src/main/java/org/mycore/restapi/v2/MCRRestDerivateContents.java
+++ b/mycore-restapi/src/main/java/org/mycore/restapi/v2/MCRRestDerivateContents.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -53,7 +54,6 @@ import org.mycore.common.MCRTransactionManager;
 import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.content.MCRPathContent;
 import org.mycore.common.content.util.MCRRestContentHelper;
-import org.mycore.common.digest.MCRMD5Digest;
 import org.mycore.datamodel.metadata.MCRObjectID;
 import org.mycore.datamodel.niofs.MCRDigestAttributeView;
 import org.mycore.datamodel.niofs.MCRFileAttributes;
@@ -253,13 +253,8 @@ public class MCRRestDerivateContents {
      * @see <a href="https://tools.ietf.org/html/rfc5843">RFC 45843</a>
      */
     private static String getDigestHeader(String md5sum) {
-        final String md5Base64 = Base64.getEncoder().encodeToString(getMD5Digest(md5sum));
+        final String md5Base64 = Base64.getEncoder().encodeToString(HexFormat.of().parseHex(md5sum));
         return "MD5=" + md5Base64;
-    }
-
-    private static byte[] getMD5Digest(String md5sum) {
-        MCRMD5Digest md5 = new MCRMD5Digest(md5sum);
-        return md5.getValue();
     }
 
     @HEAD

--- a/mycore-restapi/src/main/java/org/mycore/restapi/v2/MCRRestDerivateContents.java
+++ b/mycore-restapi/src/main/java/org/mycore/restapi/v2/MCRRestDerivateContents.java
@@ -53,6 +53,7 @@ import org.mycore.common.MCRTransactionManager;
 import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.content.MCRPathContent;
 import org.mycore.common.content.util.MCRRestContentHelper;
+import org.mycore.common.digest.MCRMD5Digest;
 import org.mycore.datamodel.metadata.MCRObjectID;
 import org.mycore.datamodel.niofs.MCRDigestAttributeView;
 import org.mycore.datamodel.niofs.MCRFileAttributes;
@@ -257,19 +258,8 @@ public class MCRRestDerivateContents {
     }
 
     private static byte[] getMD5Digest(String md5sum) {
-        final char[] data = md5sum.toCharArray();
-        final int len = data.length;
-
-        // two characters form the hex value.
-        final byte[] md5Bytes = new byte[len >> 1];
-        for (int i = 0, j = 0; j < len; i++) {
-            int f = Character.digit(data[j], 16) << 4;
-            j++;
-            f = f | Character.digit(data[j], 16);
-            j++;
-            md5Bytes[i] = (byte) (f & 0xFF);
-        }
-        return md5Bytes;
+        MCRMD5Digest md5 = new MCRMD5Digest(md5sum);
+        return md5.getValue();
     }
 
     @HEAD
@@ -432,7 +422,7 @@ public class MCRRestDerivateContents {
         MCRPath mcrPath = getPath();
         try {
             if (Files.exists(mcrPath) && Files.isDirectory(mcrPath)) {
-                //delete (sub-)directory and all its containing files and dirs 
+                //delete (sub-)directory and all its containing files and dirs
                 Files.walkFileTree(mcrPath, MCRRecursiveDeleter.instance());
                 return Response.noContent().build();
             } else if (Files.deleteIfExists(mcrPath)) {

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -20,14 +20,11 @@
   <rule ref="category/java/bestpractices.xml/AvoidMessageDigestField"/>
   <rule ref="category/java/bestpractices.xml/AvoidPrintStackTrace"/>
   <rule ref="category/java/bestpractices.xml/AvoidReassigningCatchVariables"/>
-  <!-- TODO: Create PR to fix this rule -->
-  <!--
   <rule ref="category/java/bestpractices.xml/AvoidReassigningLoopVariables">
     <properties>
       <property name="foreachReassign" value="allow"/>
     </properties>
   </rule>
-  -->
   <rule ref="category/java/bestpractices.xml/CheckResultSet"/>
   <rule ref="category/java/bestpractices.xml/ConstantsInInterface"/>
   <rule ref="category/java/bestpractices.xml/DefaultLabelNotLastInSwitch"/>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3225).

This pull request adds a new method to retrieve the digest value, refactoring the MD5 digest calculation, and updating the ruleset configuration.

Enhancements to functionality:

* [`mycore-base/src/main/java/org/mycore/common/digest/MCRDigest.java`](diffhunk://#diff-c91022b7fd98110935e66e1752ca57578d88b75e5fa2ff5c64baee71eff09221R69-R77): Added a new method `getValue()` to return a copy of the digest value.

Refactoring:

* [`mycore-restapi/src/main/java/org/mycore/restapi/v2/MCRRestDerivateContents.java`](diffhunk://#diff-6054e3a4bf229af922f7d0797f0d550606248d2e3f765f0f1961f8a910bc13bcL260-R262): Refactored the `getMD5Digest` method to use the `MCRMD5Digest` class for MD5 digest calculation.

Configuration updates:

* [`ruleset.xml`](diffhunk://#diff-a6839fbfcf5024903ed122d22112e9e54011183ccc884da9d1e3a3c2a9d9e04cL23-L30): Uncommented the rule for `AvoidReassigningLoopVariables` and removed the TODO comment.