### PR TITLE
MCR-3226 activate PMD rule ForLoopVariableCount

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/log/MCRTreeMessage.java
+++ b/mycore-base/src/main/java/org/mycore/common/log/MCRTreeMessage.java
@@ -67,15 +67,16 @@ public final class MCRTreeMessage {
 
     private void treeLines(List<Indent> prefix, List<String> lines) {
         prefix.add(Indent.LEAD);
-        for (int i = 0, n = entries.size(); i < n; i++) {
+        int entriesCount = entries.size();
+        for (int i = 0; i < entriesCount; i++) {
             Entry entry = entries.get(i);
-            if (i == n - 1) {
-                prefix.remove(prefix.size() - 1);
+            if (i == entriesCount - 1) {
+                prefix.removeLast();
                 prefix.add(Indent.LAST);
             }
             entry.treeLines(prefix, lines);
         }
-        prefix.remove(prefix.size() - 1);
+        prefix.removeLast();
     }
 
     private enum Indent {
@@ -101,9 +102,10 @@ public final class MCRTreeMessage {
 
         protected String prefixString(List<Indent> prefix) {
             StringBuilder builder = new StringBuilder();
-            for (int i = 0, n = prefix.size(); i < n; i++) {
+            int prefixCount = prefix.size();
+            for (int i = 0; i < prefixCount; i++) {
                 Indent indent = prefix.get(i);
-                String symbol = i == n - 1 ? indent.lastSymbol : indent.leadSymbol;
+                String symbol = i == prefixCount - 1 ? indent.lastSymbol : indent.leadSymbol;
                 builder.append(symbol);
             }
             return builder.toString();

--- a/mycore-base/src/main/java/org/mycore/common/xsl/MCRParameterCollector.java
+++ b/mycore-base/src/main/java/org/mycore/common/xsl/MCRParameterCollector.java
@@ -42,8 +42,8 @@ import jakarta.servlet.http.HttpSession;
 
 /**
  * Collects parameters used in XSL transformations, by copying them from
- * MCRConfiguration, from the HTTP and MyCoRe session, from request attributes etc. 
- * 
+ * MCRConfiguration, from the HTTP and MyCoRe session, from request attributes etc.
+ *
  * @author Frank Lützenkirchen
  */
 public class MCRParameterCollector {
@@ -63,14 +63,14 @@ public class MCRParameterCollector {
     /**
      * Collects parameters The collecting of parameters is done in steps,
      * each step may overwrite parameters that already have been set.
-     * 
+     *
      * First, all configuration properties from MCRConfiguration are copied.
      * Second, those variables stored in the HTTP session, that start with "XSL." are copied.
      * Next, variables stored in the MCRSession are copied.
      * Next, HTTP request parameters are copied.
-     * 
+     *
      * Only those parameters starting with "XSL." are copied from session and request,
-     * 
+     *
      * @param request the HttpRequest causing the XSL transformation, must NOT be null
      */
     public MCRParameterCollector(HttpServletRequest request) {
@@ -80,13 +80,13 @@ public class MCRParameterCollector {
     /**
      * Collects parameters The collecting of parameters is done in steps,
      * each step may overwrite parameters that already have been set.
-     * 
+     *
      * First, all configuration properties from MCRConfiguration are copied.
      * Second, those variables stored in the HTTP session, that start with "XSL." are copied.
      * Next, variables stored in the MCRSession are copied.
      * Next, HTTP request parameters are copied.
      * Next, HTTP request attributes are copied.
-     * 
+     *
      * @param request the HttpRequest causing the XSL transformation, must NOT be null
      * @param onlySetXSLParameters if true, only those parameters starting with "XSL."
      *                            are copied from session and request
@@ -116,7 +116,7 @@ public class MCRParameterCollector {
     /**
      * Collects parameters The collecting of parameters is done in steps,
      * each step may overwrite parameters that already have been set.
-     * 
+     *
      * First, all configuration properties from MCRConfiguration are copied.
      * Next, those variables stored in the MCRSession that start with "XSL." are copied.
      */
@@ -127,10 +127,10 @@ public class MCRParameterCollector {
     /**
      * Collects parameters The collecting of parameters is done in steps,
      * each step may overwrite parameters that already have been set.
-     * 
+     *
      * First, all configuration properties from MCRConfiguration are copied.
      * Next, those variables stored in the MCRSession are copied.
-     * 
+     *
      * @param onlySetXSLParameters if true, only those parameters starting with "XSL." are copied from session
      */
     public MCRParameterCollector(boolean onlySetXSLParameters) {
@@ -181,7 +181,7 @@ public class MCRParameterCollector {
     }
 
     /**
-     * Returns the parameter map.  
+     * Returns the parameter map.
      */
     public Map<String, Object> getParameterMap() {
         return Collections.unmodifiableMap(parameters);
@@ -200,10 +200,10 @@ public class MCRParameterCollector {
 
     private String xmlSafe(String key) {
         StringBuilder builder = new StringBuilder();
-        if (key.length() != 0) {
+        if (!key.isEmpty()) {
             char first = key.charAt(0);
             builder.append(first == ':' || !Verifier.isXMLNameStartCharacter(first) ? "_" : first);
-            for (int i = 1, n = key.length(); i < n; i++) {
+            for (int i = 1; i < key.length(); i++) {
                 char following = key.charAt(i);
                 builder.append(following == ':' || !Verifier.isXMLNameCharacter(following) ? "_" : following);
             }
@@ -297,8 +297,8 @@ public class MCRParameterCollector {
         parameters.put("UserAgent", request.getHeader("User-Agent") != null ? request.getHeader("User-Agent") : "");
     }
 
-    /** 
-     * Calculates the complete request URL, so that mod_proxy is supported 
+    /**
+     * Calculates the complete request URL, so that mod_proxy is supported
      */
     private String getCompleteURL(HttpServletRequest request) {
         StringBuilder buffer = getBaseURLUpToHostName();
@@ -332,7 +332,7 @@ public class MCRParameterCollector {
     /**
      * Sets XSL parameters for the given transformer by taking them from the
      * properties object provided.
-     * 
+     *
      * @param transformer
      *            the Transformer object thats parameters should be set
      */

--- a/mycore-user2/src/main/java/org/mycore/user2/hash/MCRS2KStrategy.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/hash/MCRS2KStrategy.java
@@ -140,12 +140,13 @@ public class MCRS2KStrategy extends MCRPasswordCheckStrategyBase {
         int digestLength = digest.getDigestLength();
 
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        for (int i = 0, n = hashSizeBytes / digestLength; i < n; i++) {
+        int hashIterations = hashSizeBytes / digestLength;
+        for (int i = 0; i < hashIterations; i++) {
             buffer.write(getHash(digest, source, numberOfBytes, i));
             digest.reset();
         }
-        buffer.write(getHash(digest, source, numberOfBytes, hashSizeBytes / digestLength),
-            0, hashSizeBytes - (hashSizeBytes / digestLength) * digestLength);
+        buffer.write(getHash(digest, source, numberOfBytes, hashIterations), 0,
+            hashSizeBytes - hashIterations * digestLength);
 
         return buffer.toByteArray();
 
@@ -157,10 +158,11 @@ public class MCRS2KStrategy extends MCRPasswordCheckStrategyBase {
             digest.update((byte) 0);
         }
 
-        for (long i = 0, n = numberOfBytes / source.length; i < n; i++) {
+        long iterations = numberOfBytes / source.length;
+        for (long i = 0; i < iterations; i++) {
             digest.update(source);
         }
-        digest.update(source, 0, (int) (numberOfBytes - (numberOfBytes / source.length) * source.length));
+        digest.update(source, 0, (int) (numberOfBytes - iterations * source.length));
 
         return digest.digest();
 

--- a/mycore-user2/src/main/java/org/mycore/user2/hash/bouncycastle/MCRBCryptStrategy.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/hash/bouncycastle/MCRBCryptStrategy.java
@@ -101,12 +101,12 @@ public class MCRBCryptStrategy extends MCRPasswordCheckStrategyBase {
         };
 
         BASE_64_TO_RADIX_64_MAP = new char[max(base64Alphabet) + 1];
-        for (int i = 0, n = base64Alphabet.length; i < n; i++) {
+        for (int i = 0; i < base64Alphabet.length; i++) {
             BASE_64_TO_RADIX_64_MAP[base64Alphabet[i]] = radix64Alphabet[i];
         }
 
         RADIX_64_TO_BASE_64_MAP = new char[max(radix64Alphabet) + 1];
-        for (int i = 0, n = radix64Alphabet.length; i < n; i++) {
+        for (int i = 0; i < radix64Alphabet.length; i++) {
             RADIX_64_TO_BASE_64_MAP[radix64Alphabet[i]] = base64Alphabet[i];
         }
 

--- a/mycore-xeditor/src/main/java/org/mycore/frontend/xeditor/validation/MCRXEditorValidator.java
+++ b/mycore-xeditor/src/main/java/org/mycore/frontend/xeditor/validation/MCRXEditorValidator.java
@@ -53,7 +53,8 @@ public class MCRXEditorValidator {
         NamedNodeMap attributes = ruleElement.getAttributes();
         Attr enableReplacementNode = (Attr) attributes.getNamedItem("enable-replacements");
         if (enableReplacementNode != null && enableReplacementNode.getValue().equals("true")) {
-            for (int i = 0, n = attributes.getLength(); i < n; i++) {
+            int attributesLength = attributes.getLength();
+            for (int i = 0; i < attributesLength; i++) {
                 Attr attribute = (Attr) attributes.item(i);
                 String oldValue = attribute.getNodeValue();
                 String newValue = session.replaceParameters(oldValue);

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -30,10 +30,7 @@
   <rule ref="category/java/bestpractices.xml/DefaultLabelNotLastInSwitch"/>
   <rule ref="category/java/bestpractices.xml/DoubleBraceInitialization"/>
   <rule ref="category/java/bestpractices.xml/ForLoopCanBeForeach"/>
-  <!-- TODO: Create PR to fix this rule -->
-  <!--
   <rule ref="category/java/bestpractices.xml/ForLoopVariableCount"/>
-  -->
   <!-- TODO: Create PR to fix this rule -->
   <!--
   <rule ref="category/java/bestpractices.xml/GuardLogStatement"/>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3226).

This pull request includes several changes to improve code readability and maintainability by replacing repeated calculations with variables and using more descriptive method calls. The most important changes are summarized below:

### Code readability improvements:

* [`mycore-base/src/main/java/org/mycore/common/log/MCRTreeMessage.java`](diffhunk://#diff-0f31b9004148a55e5c9f39887b5cfd7bcc3e15aade0737474f7c9f31854b6824L70-R79): Replaced repeated calculations of list sizes with variables and used `removeLast()` method for better readability. [[1]](diffhunk://#diff-0f31b9004148a55e5c9f39887b5cfd7bcc3e15aade0737474f7c9f31854b6824L70-R79) [[2]](diffhunk://#diff-0f31b9004148a55e5c9f39887b5cfd7bcc3e15aade0737474f7c9f31854b6824L104-R108)
* [`mycore-base/src/main/java/org/mycore/common/xsl/MCRParameterCollector.java`](diffhunk://#diff-e6ca6e60370563c62c3636f335b1a4a7dac7a7f610b6351a422ffebc912d6ccbL203-R206): Simplified string length checks by using `isEmpty()` method.

### Maintainability improvements:

* [`mycore-user2/src/main/java/org/mycore/user2/hash/MCRS2KStrategy.java`](diffhunk://#diff-30896cb529d78b2e5b0e1440061cb467bc18be47d76d79d5b6cf3d1e103f3563L143-R149): Replaced repeated calculations of iteration counts with variables for clarity. [[1]](diffhunk://#diff-30896cb529d78b2e5b0e1440061cb467bc18be47d76d79d5b6cf3d1e103f3563L143-R149) [[2]](diffhunk://#diff-30896cb529d78b2e5b0e1440061cb467bc18be47d76d79d5b6cf3d1e103f3563L160-R165)
* [`mycore-user2/src/main/java/org/mycore/user2/hash/bouncycastle/MCRBCryptStrategy.java`](diffhunk://#diff-11704b97fe2a89531b1374e02c293fa4f459c2c337c2f27fe47af314ac7c83a9L104-R109): Simplified loop conditions by removing unnecessary length calculations within the loop.
* [`mycore-xeditor/src/main/java/org/mycore/frontend/xeditor/validation/MCRXEditorValidator.java`](diffhunk://#diff-3fa947488feb71695baa302833ed746a70914654548caba716a1408ef1c0f308L56-R57): Replaced repeated calls to `attributes.getLength()` with a variable for better maintainability.