### PR TITLE
MCR-3297 MCR.ContentTransformer.mycoreobject-compress.Stylesheet uses xsl folder

### DIFF
--- a/mycore-base/src/main/resources/config/mycore.properties
+++ b/mycore-base/src/main/resources/config/mycore.properties
@@ -364,13 +364,6 @@ MCR.Access.Facts.Condition.category=org.mycore.access.facts.condition.fact.MCRCa
   MCR.classifications_search_sequence=remote-local
 
 ##############################################################################
-# Configuration for the zip tool
-##############################################################################
-
-# The name of the stylesheet, for the metadata-transformation
-  MCR.zip.metadata.transformer=MyCoReZip2dc.xsl
-
-##############################################################################
 # FileUpload
 ##############################################################################
 # Maximum file size for HTML form based uploads, here 4 GB
@@ -442,7 +435,7 @@ MCR.ContentTransformer.stylesheets-yed.TransformerFactoryClass=%SAXON%
 MCR.ContentTransformer.stylesheets-yed.Stylesheet=xsl/stylesheets-graphml.xsl,xsl/graphml-yed.xsl
 MCR.ContentTransformer.mycoreobject-compress.Class=org.mycore.common.content.transformer.MCRXSLTransformer
 MCR.ContentTransformer.mycoreobject-compress.TransformerFactoryClass=%SAXON%
-MCR.ContentTransformer.mycoreobject-compress.Stylesheet=xsl/%MCR.zip.metadata.transformer%
+MCR.ContentTransformer.mycoreobject-compress.Stylesheet=xslt/save-object.xsl
 MCR.ContentTransformer.mcr_directory-json.Class=org.mycore.common.content.transformer.MCRToJSONTransformer
 #MCR.LayoutService.TransformerFactoryClass=%XALAN%
 #MCR.LayoutService.TransformerFactoryClass=%SAXON%


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3297).

* removed property MCR.zip.metadata.transformer referencing a non-existing XSL file
* set default value of MCR.ContentTransformer.mycoreobject-compress.Stylesheet to xslt/save-object.xsl (copies object metadata)