### PR TITLE
MCR-3315 add correct check for rtl language

### DIFF
--- a/mycore-base/src/main/resources/xslt/functions/i18n.xsl
+++ b/mycore-base/src/main/resources/xslt/functions/i18n.xsl
@@ -44,7 +44,7 @@
 
         <xsl:variable name="langXML" select="fn:document(concat('language:', $language))" />
         <xsl:choose>
-            <xsl:when test="$langXML/language/@rtl">rtl</xsl:when>
+            <xsl:when test="$langXML/language/@rtl = 'true'">rtl</xsl:when>
             <xsl:otherwise>ltr</xsl:otherwise>
         </xsl:choose>
     </xsl:function>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3315).


mcri18n:text-direction always returns rtl, since it does not take into account that the language XML generated by MCRLanguageResolver always contans an rtl attribute.