### PR TITLE
MCR-3316_OOM Exception when indexing many documents with ocfl

### DIFF
--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/metadata/MCROCFLContent.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/metadata/MCROCFLContent.java
@@ -30,29 +30,30 @@ public class MCROCFLContent extends MCRContent {
 
     private OcflRepository repository;
 
-    private String objectid;
+    private String ocflObjectID;
 
     private String fileName;
 
     private String version = null;
 
-    public MCROCFLContent(OcflRepository repository, String objectid, String fileName, String version) {
+    public MCROCFLContent(OcflRepository repository, String ocflObjectID, String fileName, String version) {
         this.repository = repository;
-        this.objectid = objectid;
+        this.ocflObjectID = ocflObjectID;
         this.fileName = fileName;
         this.version = version;
     }
 
-    public MCROCFLContent(OcflRepository repository, String objectid, String fileName) {
+    public MCROCFLContent(OcflRepository repository, String ocflObjectID, String fileName) {
         this.repository = repository;
-        this.objectid = objectid;
+        this.ocflObjectID = ocflObjectID;
         this.fileName = fileName;
     }
 
     @Override
     public InputStream getInputStream() throws IOException {
         return repository
-            .getObject(version == null ? ObjectVersionId.head(objectid) : ObjectVersionId.version(objectid, version))
+            .getObject(version == null ? ObjectVersionId.head(ocflObjectID) :
+                    ObjectVersionId.version(ocflObjectID, version))
             .getFile(fileName).getStream();
     }
 }

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/metadata/MCROCFLXMLMetadataManager.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/metadata/MCROCFLXMLMetadataManager.java
@@ -224,23 +224,18 @@ public class MCROCFLXMLMetadataManager implements MCRXMLMetadataManagerAdapter {
     public MCRContent retrieveContent(MCRObjectID mcrid) throws IOException {
         String ocflObjectID = getOCFLObjectID(mcrid);
         OcflObjectVersion storeObject;
+        OcflRepository repository = getRepository();
         try {
-            storeObject = getRepository().getObject(ObjectVersionId.head(ocflObjectID));
+            storeObject = repository.getObject(ObjectVersionId.head(ocflObjectID));
         } catch (NotFoundException e) {
             throw new IOException("Object '" + ocflObjectID + "' could not be found", e);
         }
 
         if (convertMessageToType(
-            storeObject.getVersionInfo().getMessage()) == MCROCFLMetadataVersion.DELETED) {
+                storeObject.getVersionInfo().getMessage()) == MCROCFLMetadataVersion.DELETED) {
             throw new IOException("Cannot read already deleted object '" + ocflObjectID + "'");
         }
-
-        // "metadata/" +
-        try (InputStream storedContentStream = getStoredContentStream(mcrid, storeObject)) {
-            return new MCRJDOMContent(new MCRStreamContent(storedContentStream).asXML());
-        } catch (JDOMException e) {
-            throw new IOException("Can not parse XML from OCFL-Store", e);
-        }
+        return new MCROCFLContent(repository, ocflObjectID, buildFilePath(mcrid));
     }
 
     protected InputStream getStoredContentStream(MCRObjectID mcrid, OcflObjectVersion storeObject) throws IOException {


### PR DESCRIPTION
- using lazy MCROCFLContent instead of MCRJDOMContent to load data the latest possible time
- rename objectid to ocflObjectID to make it more clear that its mcrobject:mir_mods_... instead of mir_mods_...

[Link to jira](https://mycore.atlassian.net/browse/MCR-3316).
