### PR TITLE
MCR-3317 fix NPE if mime type cannot be determined

### DIFF
--- a/mycore-mets/src/main/java/org/mycore/mets/model/MCRMETSDefaultGenerator.java
+++ b/mycore-mets/src/main/java/org/mycore/mets/model/MCRMETSDefaultGenerator.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -246,8 +247,11 @@ public class MCRMETSDefaultGenerator extends MCRMETSAbstractGenerator {
 
     private void sortFileToGrp(FileSec fileSec, Map.Entry<MCRPath, BasicFileAttributes> file, String fileID,
         final String href, String fileUse) throws IOException {
+        //MCR-3317: fix NPE when mime type cannot be determined
+        String mimeType = Optional.ofNullable(MCRContentTypes.probeContentType(file.getKey()))
+            .orElse("application/octet-stream");
         // file
-        File metsFile = new File(fileID, MCRContentTypes.probeContentType(file.getKey()));
+        File metsFile = new File(fileID, mimeType);
         FLocat fLocat = new FLocat(LOCTYPE.URL, href);
         metsFile.setFLocat(fLocat);
 


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3317).

This pull request includes changes to the `MCRMETSDefaultGenerator` class to address a NullPointerException (NPE) when the MIME type cannot be determined. 