### PR TITLE
MCR-3269 enable PMD rule MissingSerialVersionUID

### DIFF
--- a/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/dto/util/MCRNullableDeserializer.java
+++ b/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/dto/util/MCRNullableDeserializer.java
@@ -19,6 +19,7 @@
 package org.mycore.mcr.acl.accesskey.dto.util;
 
 import java.io.IOException;
+import java.io.Serial;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -40,6 +41,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
  */
 public class MCRNullableDeserializer<T> extends StdDeserializer<MCRNullable<T>> implements ContextualDeserializer {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**

--- a/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyCollisionException.java
+++ b/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyCollisionException.java
@@ -18,12 +18,15 @@
 
 package org.mycore.mcr.acl.accesskey.exception;
 
+import java.io.Serial;
+
 /**
  * Exception that refers to a collision of access keys.
  * This refers to secret duplicates.
  */
 public class MCRAccessKeyCollisionException extends MCRAccessKeyException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRAccessKeyCollisionException(String errorMessage) {

--- a/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyDisabledException.java
+++ b/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyDisabledException.java
@@ -18,11 +18,14 @@
 
 package org.mycore.mcr.acl.accesskey.exception;
 
+import java.io.Serial;
+
 /**
  * Exception that refers to a disabled access key.
  */
 public class MCRAccessKeyDisabledException extends MCRAccessKeyException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRAccessKeyDisabledException(String errorMessage) {

--- a/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyException.java
+++ b/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyException.java
@@ -20,11 +20,14 @@ package org.mycore.mcr.acl.accesskey.exception;
 
 import org.mycore.common.MCRException;
 
+import java.io.Serial;
+
 /**
  * Instances of this class represent a general exception related to access keys.
  */
 public class MCRAccessKeyException extends MCRException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**

--- a/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyExpiredException.java
+++ b/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyExpiredException.java
@@ -18,11 +18,14 @@
 
 package org.mycore.mcr.acl.accesskey.exception;
 
+import java.io.Serial;
+
 /**
  * Exception that refers to an expired access key.
  */
 public class MCRAccessKeyExpiredException extends MCRAccessKeyException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRAccessKeyExpiredException(String errorMessage) {

--- a/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyInvalidSecretException.java
+++ b/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyInvalidSecretException.java
@@ -18,11 +18,14 @@
 
 package org.mycore.mcr.acl.accesskey.exception;
 
+import java.io.Serial;
+
 /**
  * Exception that refers to an invalid secret.
  */
 public class MCRAccessKeyInvalidSecretException extends MCRAccessKeyException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRAccessKeyInvalidSecretException(String errorMessage) {

--- a/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyInvalidTypeException.java
+++ b/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyInvalidTypeException.java
@@ -18,11 +18,14 @@
 
 package org.mycore.mcr.acl.accesskey.exception;
 
+import java.io.Serial;
+
 /**
  * Exception that refers to an invalid permission type.
  */
 public class MCRAccessKeyInvalidTypeException extends MCRAccessKeyException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRAccessKeyInvalidTypeException(String errorMessage) {

--- a/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyNotFoundException.java
+++ b/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyNotFoundException.java
@@ -18,11 +18,14 @@
 
 package org.mycore.mcr.acl.accesskey.exception;
 
+import java.io.Serial;
+
 /**
  * Exception that refers to an unknown access key.
  */
 public class MCRAccessKeyNotFoundException extends MCRAccessKeyException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRAccessKeyNotFoundException(String errorMessage) {

--- a/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyTransformationException.java
+++ b/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyTransformationException.java
@@ -18,11 +18,14 @@
 
 package org.mycore.mcr.acl.accesskey.exception;
 
+import java.io.Serial;
+
 /**
  * Exception that refers to an error during transformation of an access key.
  */
 public class MCRAccessKeyTransformationException extends MCRAccessKeyException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRAccessKeyTransformationException(String errorMessage) {

--- a/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyValidationException.java
+++ b/mycore-acl/src/main/java/org/mycore/mcr/acl/accesskey/exception/MCRAccessKeyValidationException.java
@@ -18,6 +18,8 @@
 
 package org.mycore.mcr.acl.accesskey.exception;
 
+import java.io.Serial;
+
 /**
  * Exception thrown when an access key validation fails.
  *
@@ -27,6 +29,7 @@ package org.mycore.mcr.acl.accesskey.exception;
  */
 public class MCRAccessKeyValidationException extends MCRAccessKeyException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**

--- a/mycore-base/src/main/java/org/mycore/access/MCRAccessException.java
+++ b/mycore-base/src/main/java/org/mycore/access/MCRAccessException.java
@@ -28,7 +28,7 @@ import org.mycore.common.MCRCatchException;
 public final class MCRAccessException extends MCRCatchException {
 
     @Serial
-    private static final long serialVersionUID = 6494399676882465653L;
+    private static final long serialVersionUID = 1L;
 
     private final String action;
 

--- a/mycore-base/src/main/java/org/mycore/backend/jpa/access/MCRACCESSPK.java
+++ b/mycore-base/src/main/java/org/mycore/backend/jpa/access/MCRACCESSPK.java
@@ -18,6 +18,7 @@
 
 package org.mycore.backend.jpa.access;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 import jakarta.persistence.Column;
@@ -26,7 +27,8 @@ import jakarta.persistence.Embeddable;
 @Embeddable
 public class MCRACCESSPK implements Serializable {
 
-    private static final long serialVersionUID = 1177905976922683366L;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Column(name = "ACPOOL")
     private String acpool;

--- a/mycore-base/src/main/java/org/mycore/backend/jpa/dnbtransfer/MCRDNBTRANSFERRESULTS.java
+++ b/mycore-base/src/main/java/org/mycore/backend/jpa/dnbtransfer/MCRDNBTRANSFERRESULTS.java
@@ -18,6 +18,7 @@
 
 package org.mycore.backend.jpa.dnbtransfer;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -31,7 +32,8 @@ import jakarta.persistence.Id;
 @Entity
 public class MCRDNBTRANSFERRESULTS implements Serializable {
 
-    private static final long serialVersionUID = -5543608475323581768L;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private int id;
 

--- a/mycore-base/src/main/java/org/mycore/backend/jpa/links/MCRLINKHREFPK.java
+++ b/mycore-base/src/main/java/org/mycore/backend/jpa/links/MCRLINKHREFPK.java
@@ -18,6 +18,7 @@
 
 package org.mycore.backend.jpa.links;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -34,7 +35,8 @@ import jakarta.persistence.Embeddable;
 @Embeddable
 public class MCRLINKHREFPK implements Serializable {
 
-    private static final long serialVersionUID = -5838803852559721772L;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String mcrfrom;
 

--- a/mycore-base/src/main/java/org/mycore/common/MCRCatchException.java
+++ b/mycore-base/src/main/java/org/mycore/common/MCRCatchException.java
@@ -18,6 +18,8 @@
 
 package org.mycore.common;
 
+import java.io.Serial;
+
 /**
  * Instances of this class represent a general exception thrown by any part of
  * the MyCoRe implementation classes.
@@ -31,9 +33,12 @@ package org.mycore.common;
  * @see java.lang.Exception
  */
 public class MCRCatchException extends Exception {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     /** Counter to prevent a recursion between getStackTrace() and toString() */
     private int toStringInvocationCounter;
-    private static final long serialVersionUID = -2244850451757768863L;
 
     /**
      * Creates a new MCRCatchException with an error message

--- a/mycore-base/src/main/java/org/mycore/common/MCRException.java
+++ b/mycore-base/src/main/java/org/mycore/common/MCRException.java
@@ -20,6 +20,7 @@ package org.mycore.common;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Serial;
 import java.io.StringWriter;
 
 import org.apache.logging.log4j.LogManager;
@@ -34,7 +35,9 @@ import org.apache.logging.log4j.LogManager;
  * @see RuntimeException
  */
 public class MCRException extends RuntimeException {
-    private static final long serialVersionUID = -3396055962010289244L;
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     /**
      * Creates a new MCRException with an error message

--- a/mycore-base/src/main/java/org/mycore/common/MCRMailer.java
+++ b/mycore-base/src/main/java/org/mycore/common/MCRMailer.java
@@ -19,6 +19,7 @@
 package org.mycore.common;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -87,6 +88,9 @@ import jakarta.xml.bind.annotation.XmlValue;
  */
 public class MCRMailer extends MCRServlet {
 
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     private static final Logger LOGGER = LogManager.getLogger(MCRMailer.class);
 
     private static final String DELIMITER = "\n--------------------------------------\n";
@@ -97,8 +101,6 @@ public class MCRMailer extends MCRServlet {
 
     /** How often should MCRMailer try to send mail? */
     protected static int numTries;
-
-    private static final long serialVersionUID = 1L;
 
     @Override
     protected void doGetPost(MCRServletJob job) throws Exception {

--- a/mycore-base/src/main/java/org/mycore/common/MCRPersistenceException.java
+++ b/mycore-base/src/main/java/org/mycore/common/MCRPersistenceException.java
@@ -18,6 +18,8 @@
 
 package org.mycore.common;
 
+import java.io.Serial;
+
 /**
  * Instances of this class represent a general exception thrown by the
  * persistency layer of the MyCoRe implementation. This will be the case when
@@ -27,6 +29,10 @@ package org.mycore.common;
  * @author Frank Lützenkirchen
  */
 public class MCRPersistenceException extends MCRException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     /**
      * Creates a new MCRPersistenceException with an error message
      * 

--- a/mycore-base/src/main/java/org/mycore/common/MCRSessionResolver.java
+++ b/mycore-base/src/main/java/org/mycore/common/MCRSessionResolver.java
@@ -18,6 +18,7 @@
 
 package org.mycore.common;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.Optional;
@@ -35,6 +36,9 @@ import jakarta.servlet.http.HttpSessionBindingListener;
  * because values need to be {@link java.io.Serializable}.
  */
 public final class MCRSessionResolver implements Serializable, HttpSessionBindingListener {
+
+    @Serial
+    private static final long serialVersionUID = 1;
 
     private static final Logger LOGGER = LogManager.getLogger();
 

--- a/mycore-base/src/main/java/org/mycore/common/MCRTextResolver.java
+++ b/mycore-base/src/main/java/org/mycore/common/MCRTextResolver.java
@@ -18,6 +18,7 @@
 
 package org.mycore.common;
 
+import java.io.Serial;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -707,7 +708,8 @@ public class MCRTextResolver {
 
     protected static class CircularDependencyExecption extends RuntimeException {
 
-        private static final long serialVersionUID = -2448797538275144448L;
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         private List<String> dependencyList;
 

--- a/mycore-base/src/main/java/org/mycore/common/MCRTransactionException.java
+++ b/mycore-base/src/main/java/org/mycore/common/MCRTransactionException.java
@@ -18,6 +18,8 @@
 
 package org.mycore.common;
 
+import java.io.Serial;
+
 /**
  * Exception thrown to indicate an error during transaction handling in the
  * {@link MCRTransactionManager} or any other transaction management component.
@@ -27,6 +29,9 @@ package org.mycore.common;
  * or an illegal transaction state.</p>
  */
 public class MCRTransactionException extends MCRException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     /**
      * Constructs a new {@code MCRTransactionException} with the specified detail message.

--- a/mycore-base/src/main/java/org/mycore/common/MCRUsageException.java
+++ b/mycore-base/src/main/java/org/mycore/common/MCRUsageException.java
@@ -18,6 +18,8 @@
 
 package org.mycore.common;
 
+import java.io.Serial;
+
 /**
  * Instances of MCRUsageException are thrown when the MyCoRe API is used in an
  * illegal way. For example, this could happen when you provide illegal
@@ -26,6 +28,10 @@ package org.mycore.common;
  * @author Frank Lützenkirchen
  */
 public class MCRUsageException extends MCRException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     /**
      * Creates a new MCRUsageException with an error message
      * 

--- a/mycore-base/src/main/java/org/mycore/common/config/MCRConcurrentHashMap.java
+++ b/mycore-base/src/main/java/org/mycore/common/config/MCRConcurrentHashMap.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -41,6 +42,10 @@ import org.mycore.common.config.MCRConfiguration2.SingletonKey;
  */
 @SuppressWarnings("unchecked")
 class MCRConcurrentHashMap<K extends SingletonKey, V> extends ConcurrentHashMap<K, V> {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     private Map<K, RemappedKey> keyMap = new HashMap<>();
 
     // Disable serialization

--- a/mycore-base/src/main/java/org/mycore/common/config/MCRConfigurationException.java
+++ b/mycore-base/src/main/java/org/mycore/common/config/MCRConfigurationException.java
@@ -20,6 +20,8 @@ package org.mycore.common.config;
 
 import org.mycore.common.MCRException;
 
+import java.io.Serial;
+
 /**
  * Instances of this class represent an exception thrown because of an error in the MyCoRe configuration. Normally this
  * will be the case when a configuration property that is required is not set or has an illegal value.
@@ -29,6 +31,7 @@ import org.mycore.common.MCRException;
  */
 public class MCRConfigurationException extends MCRException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**

--- a/mycore-base/src/main/java/org/mycore/common/config/MCRProperties.java
+++ b/mycore-base/src/main/java/org/mycore/common/config/MCRProperties.java
@@ -20,6 +20,7 @@ package org.mycore.common.config;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Serial;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.util.Collections;
@@ -53,7 +54,8 @@ import org.apache.logging.log4j.LogManager;
  */
 public class MCRProperties extends Properties {
 
-    private static final long serialVersionUID = 8801587133852810123L;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Override
     public synchronized Object put(Object key, Object value) {

--- a/mycore-base/src/main/java/org/mycore/common/digest/MCRDigestValidationException.java
+++ b/mycore-base/src/main/java/org/mycore/common/digest/MCRDigestValidationException.java
@@ -20,10 +20,15 @@ package org.mycore.common.digest;
 
 import org.mycore.common.MCRException;
 
+import java.io.Serial;
+
 /**
  * Exception thrown when an error occurs in digest validation.
  */
 public class MCRDigestValidationException extends MCRException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     /**
      * Constructs a new digest validation exception with the specified detail message.

--- a/mycore-base/src/main/java/org/mycore/common/xml/MCRAttributeValueFilter.java
+++ b/mycore-base/src/main/java/org/mycore/common/xml/MCRAttributeValueFilter.java
@@ -21,10 +21,14 @@ import org.jdom2.Element;
 import org.jdom2.Namespace;
 import org.jdom2.filter.ElementFilter;
 
+import java.io.Serial;
+
 /**
  * A jdom-filter which compares attribute values.
  */
 public class MCRAttributeValueFilter extends ElementFilter {
+
+    @Serial
     private static final long serialVersionUID = 1L;
 
     protected String attrKey;

--- a/mycore-base/src/main/java/org/mycore/common/xsl/MCRXSLInfoServlet.java
+++ b/mycore-base/src/main/java/org/mycore/common/xsl/MCRXSLInfoServlet.java
@@ -21,6 +21,7 @@ package org.mycore.common.xsl;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serial;
 import java.io.UncheckedIOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -64,6 +65,9 @@ import org.xml.sax.SAXException;
  * @author Frank Lützenkirchen
  */
 public final class MCRXSLInfoServlet extends MCRServlet {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRXSLInfoServlet.class);
 

--- a/mycore-base/src/main/java/org/mycore/crypt/MCRCryptCipherConfigurationException.java
+++ b/mycore-base/src/main/java/org/mycore/crypt/MCRCryptCipherConfigurationException.java
@@ -20,8 +20,11 @@ package org.mycore.crypt;
 
 import org.mycore.common.config.MCRConfigurationException;
 
+import java.io.Serial;
+
 public class MCRCryptCipherConfigurationException extends MCRConfigurationException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private String errorCode;

--- a/mycore-base/src/main/java/org/mycore/crypt/MCRCryptKeyFileNotFoundException.java
+++ b/mycore-base/src/main/java/org/mycore/crypt/MCRCryptKeyFileNotFoundException.java
@@ -19,9 +19,11 @@
 package org.mycore.crypt;
 
 import java.io.FileNotFoundException;
+import java.io.Serial;
 
 public class MCRCryptKeyFileNotFoundException extends FileNotFoundException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private String errorCode;

--- a/mycore-base/src/main/java/org/mycore/crypt/MCRCryptKeyNoPermissionException.java
+++ b/mycore-base/src/main/java/org/mycore/crypt/MCRCryptKeyNoPermissionException.java
@@ -20,7 +20,13 @@ package org.mycore.crypt;
 
 import org.mycore.common.MCRCatchException;
 
+import java.io.Serial;
+
 public class MCRCryptKeyNoPermissionException extends MCRCatchException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     private String errorCode;
 
     public MCRCryptKeyNoPermissionException(String errorMessage) {

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/MCRCategLinkReference.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/MCRCategLinkReference.java
@@ -18,6 +18,7 @@
 
 package org.mycore.datamodel.classifications2;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 import org.mycore.datamodel.metadata.MCRObjectID;
@@ -35,7 +36,8 @@ import jakarta.persistence.Embeddable;
 @Embeddable
 public class MCRCategLinkReference implements Serializable {
 
-    private static final long serialVersionUID = -6457722746147666860L;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Basic
     private String objectID;

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/MCRCategoryID.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/MCRCategoryID.java
@@ -18,6 +18,7 @@
 
 package org.mycore.datamodel.classifications2;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.text.MessageFormat;
 import java.util.Locale;
@@ -48,7 +49,8 @@ import jakarta.persistence.Transient;
 @JsonFormat(shape = JsonFormat.Shape.STRING)
 public class MCRCategoryID implements Serializable {
 
-    private static final long serialVersionUID = -5672923571406252855L;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public static final Pattern VALID_ID = Pattern.compile("[^:$\\{\\}]+");
 

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/MCRLabel.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/MCRLabel.java
@@ -18,6 +18,7 @@
 
 package org.mycore.datamodel.classifications2;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Locale;
 import java.util.Objects;
@@ -44,7 +45,8 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 public class MCRLabel implements Cloneable, Serializable, Comparable<MCRLabel> {
 
-    private static final long serialVersionUID = -843799854929361194L;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @XmlAttribute(
         namespace = "http://www.w3.org/XML/1998/namespace")

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRCategLinkServiceImpl.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRCategLinkServiceImpl.java
@@ -27,6 +27,7 @@ import static org.mycore.datamodel.classifications2.impl.MCRCategoryQueryParamet
 import static org.mycore.datamodel.classifications2.impl.MCRCategoryQueryParameter.ROOT_ID;
 import static org.mycore.datamodel.classifications2.impl.MCRCategoryQueryParameter.TYPE;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collection;
@@ -293,6 +294,7 @@ public class MCRCategLinkServiceImpl implements MCRCategLinkService {
 
     private Map<MCRCategoryID, Boolean> hasLinksForClassifications() {
         Map<MCRCategoryID, Boolean> boolMap = new HashMap<>() {
+            @Serial
             private static final long serialVersionUID = 1L;
 
             @Override

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRCategoryChildList.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRCategoryChildList.java
@@ -18,6 +18,7 @@
 
 package org.mycore.datamodel.classifications2.impl;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
@@ -25,7 +26,9 @@ import java.util.Objects;
 import org.mycore.datamodel.classifications2.MCRCategory;
 
 class MCRCategoryChildList extends ArrayList<MCRCategory> {
-    private static final long serialVersionUID = 5844882597476033744L;
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private MCRCategory root;
 

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRCategoryImpl.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRCategoryImpl.java
@@ -18,6 +18,7 @@
 
 package org.mycore.datamodel.classifications2.impl;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.ArrayList;
@@ -139,7 +140,8 @@ import jakarta.persistence.UniqueConstraint;
 @Access(AccessType.PROPERTY)
 public class MCRCategoryImpl extends MCRAbstractCategoryImpl implements Serializable {
 
-    private static final long serialVersionUID = -7431317191711000317L;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRCategoryImpl.class);
 

--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRActiveLinkException.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRActiveLinkException.java
@@ -18,6 +18,7 @@
 
 package org.mycore.datamodel.common;
 
+import java.io.Serial;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,6 +37,7 @@ import org.mycore.common.MCRCatchException;
  */
 public class MCRActiveLinkException extends MCRCatchException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     Map<String, Collection<String>> linkTable = new ConcurrentHashMap<>();

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs/MCRFileNodeServlet.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs/MCRFileNodeServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.datamodel.ifs;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -58,6 +59,8 @@ import jakarta.servlet.http.HttpServletResponse;
  *
  */
 public class MCRFileNodeServlet extends MCRContentServlet {
+
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRFileNodeServlet.class);

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRPathComparator.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRPathComparator.java
@@ -18,12 +18,14 @@
 
 package org.mycore.datamodel.ifs2;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.nio.file.Path;
 import java.util.Comparator;
 
 class MCRPathComparator implements Comparator<Path>, Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @Override

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRStoreAlreadyExistsException.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRStoreAlreadyExistsException.java
@@ -18,8 +18,11 @@
 
 package org.mycore.datamodel.ifs2;
 
+import java.io.Serial;
+
 public class MCRStoreAlreadyExistsException extends Exception {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRStoreAlreadyExistsException(String msg) {

--- a/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRVersionedMetadata.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/ifs2/MCRVersionedMetadata.java
@@ -20,6 +20,7 @@ package org.mycore.datamodel.ifs2;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serial;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -370,6 +371,7 @@ public class MCRVersionedMetadata extends MCRStoredMetadata {
     }
 
     private static final class LastRevisionFoundException extends RuntimeException {
+        @Serial
         private static final long serialVersionUID = 1L;
     }
 

--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/history/MCRMetaHistoryItem.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/history/MCRMetaHistoryItem.java
@@ -18,6 +18,7 @@
 
 package org.mycore.datamodel.metadata.history;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
 
@@ -84,6 +85,9 @@ import jakarta.persistence.Table;
 })
 public class MCRMetaHistoryItem implements Serializable {
 
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long internalid;
@@ -101,8 +105,6 @@ public class MCRMetaHistoryItem implements Serializable {
     private String userID;
 
     private String userIP;
-
-    private static final long serialVersionUID = 1L;
 
     static MCRMetaHistoryItem createdNow(MCRObjectID id) {
         return now(id, MCRMetadataHistoryEventType.CREATE);

--- a/mycore-base/src/main/java/org/mycore/datamodel/niofs/MCRReadOnlyIOException.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/niofs/MCRReadOnlyIOException.java
@@ -19,11 +19,15 @@
 package org.mycore.datamodel.niofs;
 
 import java.io.IOException;
+import java.io.Serial;
 
 /**
  * Thrown to indicate that an operation attempted to modify a read-only file or directory.
  */
 public class MCRReadOnlyIOException extends IOException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     /**
      * Constructs a new read-only exception with the specified detail message.

--- a/mycore-base/src/main/java/org/mycore/frontend/basket/MCRBasketServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/basket/MCRBasketServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.frontend.basket;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.net.URI;
 import java.util.List;
 import java.util.Objects;
@@ -72,6 +73,8 @@ import jakarta.servlet.http.HttpServletResponse;
  * @author Frank L\u00fctzenkirchen
  **/
 public class MCRBasketServlet extends MCRServlet {
+
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRBasketServlet.class);

--- a/mycore-base/src/main/java/org/mycore/frontend/export/MCRExportServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/export/MCRExportServlet.java
@@ -29,6 +29,8 @@ import org.mycore.frontend.servlets.MCRServletJob;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.io.Serial;
+
 /**
  * Provides functionality to export content.
  * The content to export can be selected by specifying one or more
@@ -56,6 +58,8 @@ import jakarta.servlet.http.HttpServletRequest;
  * @author Frank Lützenkirchen
  */
 public class MCRExportServlet extends MCRServlet {
+
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRExportServlet.class);

--- a/mycore-base/src/main/java/org/mycore/frontend/fileupload/MCRUploadViaFormServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/fileupload/MCRUploadViaFormServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.frontend.fileupload;
 
 import java.io.InputStream;
+import java.io.Serial;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Objects;
@@ -53,6 +54,7 @@ import jakarta.servlet.http.Part;
 
 public final class MCRUploadViaFormServlet extends MCRServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRUploadViaFormServlet.class);

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRConfigHelperServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRConfigHelperServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.frontend.servlets;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.io.StringWriter;
 import java.util.Date;
 import java.util.LinkedHashMap;
@@ -44,6 +45,7 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRConfigHelperServlet extends HttpServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public static final String PROPERTIES_INIT_PARAM = "Properties";

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRContainerLoginFormServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRContainerLoginFormServlet.java
@@ -18,6 +18,7 @@
 
 package org.mycore.frontend.servlets;
 
+import java.io.Serial;
 import java.util.Arrays;
 
 import org.mycore.common.MCRSession;
@@ -34,6 +35,7 @@ import org.mycore.services.i18n.MCRTranslation;
  */
 public class MCRContainerLoginFormServlet extends MCRServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final String LOGIN_ATTR = MCRContainerLoginFormServlet.class.getCanonicalName();

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRContainerLoginServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRContainerLoginServlet.java
@@ -18,6 +18,7 @@
 
 package org.mycore.frontend.servlets;
 
+import java.io.Serial;
 import java.security.Principal;
 import java.util.Optional;
 
@@ -37,6 +38,7 @@ import jakarta.servlet.http.HttpServletRequest;
  */
 public class MCRContainerLoginServlet extends MCRServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRContainerLoginServlet.class);

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRDerivateContentTransformerServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRDerivateContentTransformerServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.frontend.servlets;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
 
@@ -43,6 +44,7 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRDerivateContentTransformerServlet extends MCRContentServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final int CACHE_TIME = 24 * 60 * 60;

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRDerivateLinkServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRDerivateLinkServlet.java
@@ -18,6 +18,7 @@
 
 package org.mycore.frontend.servlets;
 
+import java.io.Serial;
 import java.util.Collection;
 import java.util.Map;
 
@@ -38,6 +39,7 @@ import org.mycore.frontend.MCRFrontendUtil;
  */
 public class MCRDerivateLinkServlet extends MCRServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     protected static String derivateLinkErrorPage = "error_derivatelink.xml";

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRDerivateServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRDerivateServlet.java
@@ -22,6 +22,7 @@ import static org.mycore.access.MCRAccessManager.PERMISSION_DELETE;
 import static org.mycore.access.MCRAccessManager.PERMISSION_WRITE;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.nio.file.Files;
 import java.util.Locale;
 import java.util.Objects;
@@ -46,6 +47,7 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRDerivateServlet extends MCRServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public static final String TODO_SMOVFILE = "smovfile";

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRDisplayHideDerivateServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRDisplayHideDerivateServlet.java
@@ -34,10 +34,14 @@ import org.mycore.frontend.MCRFrontendUtil;
 
 import jakarta.servlet.http.HttpServletResponse;
 
+import java.io.Serial;
+
 /**
  * @author shermann
  */
 public class MCRDisplayHideDerivateServlet extends MCRServlet {
+
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRDisplayHideDerivateServlet.class);

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRErrorServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRErrorServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.frontend.servlets;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.util.Enumeration;
 import java.util.Locale;
 import java.util.Objects;
@@ -53,6 +54,7 @@ import jakarta.servlet.http.HttpSession;
  */
 public class MCRErrorServlet extends HttpServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRErrorServlet.class);

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRLockServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRLockServlet.java
@@ -18,6 +18,7 @@
 
 package org.mycore.frontend.servlets;
 
+import java.io.Serial;
 import java.net.URI;
 import java.util.Map;
 import java.util.Set;
@@ -39,6 +40,7 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRLockServlet extends MCRServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final String OBJECT_ID_KEY = MCRLockServlet.class.getCanonicalName() + ".MCRObjectID";

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRLogoutServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRLogoutServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.frontend.servlets;
 
 import java.io.IOException;
+import java.io.Serial;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -36,6 +37,7 @@ import jakarta.servlet.http.HttpSession;
  */
 public class MCRLogoutServlet extends HttpServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final String LOGOUT_REDIRECT_URL_PARAMETER = "url";

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRServlet.java
@@ -21,6 +21,7 @@ package org.mycore.frontend.servlets;
 import static org.mycore.frontend.MCRFrontendUtil.BASE_URL_ATTRIBUTE;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
@@ -78,6 +79,7 @@ public class MCRServlet extends HttpServlet {
 
     public static final String INITIAL_SERVLET_NAME_KEY = "currentServletName";
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger();

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRStaticXMLFileServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRStaticXMLFileServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.frontend.servlets;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -49,9 +50,10 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRStaticXMLFileServlet extends MCRServlet {
 
-    private static final String READ_WEBPAGE_PERMISSION = MCRLayoutUtilities.getPermission2ReadWebpage();
+    @Serial
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -9213353868244605750L;
+    private static final String READ_WEBPAGE_PERMISSION = MCRLayoutUtilities.getPermission2ReadWebpage();
 
     private static final String REDIRECT_GUESTS_PROPERTY = "MCR.StaticXMLFileServlet.NoAccess.RedirectGuestsToLogin";
 

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/persistence/MCRCreateDerivateServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/persistence/MCRCreateDerivateServlet.java
@@ -21,6 +21,7 @@ package org.mycore.frontend.servlets.persistence;
 import static org.mycore.access.MCRAccessManager.PERMISSION_WRITE;
 
 import java.io.IOException;
+import java.io.Serial;
 
 import org.mycore.access.MCRAccessException;
 import org.mycore.access.MCRAccessManager;
@@ -36,7 +37,8 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRCreateDerivateServlet extends MCRPersistenceServlet {
 
-    private static final long serialVersionUID = 4735574336094275787L;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Override
     void handlePersistenceOperation(HttpServletRequest request, HttpServletResponse response)

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/persistence/MCRCreateObjectServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/persistence/MCRCreateObjectServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.frontend.servlets.persistence;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.util.Enumeration;
 import java.util.Properties;
 
@@ -43,7 +44,8 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRCreateObjectServlet extends MCRPersistenceServlet {
 
-    private static final long serialVersionUID = 4143057048219690238L;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private boolean appendDerivate;
 

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/persistence/MCRDeleteDerivateServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/persistence/MCRDeleteDerivateServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.frontend.servlets.persistence;
 
 import java.io.IOException;
+import java.io.Serial;
 
 import org.mycore.access.MCRAccessException;
 import org.mycore.datamodel.metadata.MCRDerivate;
@@ -34,7 +35,8 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRDeleteDerivateServlet extends MCRPersistenceServlet {
 
-    private static final long serialVersionUID = 1581063299429224344L;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Override
     void handlePersistenceOperation(HttpServletRequest request, HttpServletResponse response)

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/persistence/MCRDeleteObjectServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/persistence/MCRDeleteObjectServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.frontend.servlets.persistence;
 
 import java.io.IOException;
+import java.io.Serial;
 
 import org.mycore.access.MCRAccessException;
 import org.mycore.common.config.MCRConfiguration2;
@@ -37,7 +38,8 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRDeleteObjectServlet extends MCRPersistenceServlet {
 
-    private static final long serialVersionUID = 3148314720092349972L;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Override
     void handlePersistenceOperation(HttpServletRequest request, HttpServletResponse response) throws MCRAccessException,

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/persistence/MCRPersistenceServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/persistence/MCRPersistenceServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.frontend.servlets.persistence;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.stream.Collectors;
@@ -48,7 +49,8 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 abstract class MCRPersistenceServlet extends MCRServlet {
 
-    private static final long serialVersionUID = -6776941436009193613L;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     protected static final String OBJECT_ID_KEY = MCRPersistenceServlet.class.getCanonicalName() + ".MCRObjectID";
 

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/persistence/MCRUpdateDerivateServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/persistence/MCRUpdateDerivateServlet.java
@@ -23,6 +23,7 @@ import static org.mycore.common.MCRConstants.XLINK_NAMESPACE;
 import static org.mycore.common.MCRConstants.XSI_NAMESPACE;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.util.Properties;
 
 import org.jdom2.Document;
@@ -47,7 +48,8 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRUpdateDerivateServlet extends MCRPersistenceServlet {
 
-    private static final long serialVersionUID = -8005685456830013040L;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Override
     void handlePersistenceOperation(HttpServletRequest request, HttpServletResponse response) throws MCRAccessException,

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/persistence/MCRUpdateObjectServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/persistence/MCRUpdateObjectServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.frontend.servlets.persistence;
 
 import java.io.IOException;
+import java.io.Serial;
 
 import org.apache.logging.log4j.LogManager;
 import org.jdom2.Document;
@@ -43,7 +44,8 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRUpdateObjectServlet extends MCRPersistenceServlet {
 
-    private static final long serialVersionUID = -7507356414480350102L;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Override
     void handlePersistenceOperation(HttpServletRequest request, HttpServletResponse response) throws MCRAccessException,

--- a/mycore-base/src/main/java/org/mycore/parsers/bool/MCRParseException.java
+++ b/mycore-base/src/main/java/org/mycore/parsers/bool/MCRParseException.java
@@ -20,8 +20,11 @@ package org.mycore.parsers.bool;
 
 import org.mycore.common.MCRException;
 
+import java.io.Serial;
+
 public class MCRParseException extends MCRException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRParseException(String text) {

--- a/mycore-base/src/main/java/org/mycore/resource/MCRDefaultResourceInterceptFilter.java
+++ b/mycore-base/src/main/java/org/mycore/resource/MCRDefaultResourceInterceptFilter.java
@@ -19,6 +19,7 @@
 package org.mycore.resource;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.util.Enumeration;
 
 import org.apache.logging.log4j.LogManager;
@@ -55,6 +56,9 @@ import jakarta.servlet.http.HttpServletResponse;
  * found by a deviating resource lookup strategy, specifically {@link MCRResourceResolver#resolveWebResource(String)}.
  */
 public final class MCRDefaultResourceInterceptFilter extends HttpFilter {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger();
 

--- a/mycore-base/src/main/java/org/mycore/resource/MCRResourceException.java
+++ b/mycore-base/src/main/java/org/mycore/resource/MCRResourceException.java
@@ -20,11 +20,16 @@ package org.mycore.resource;
 
 import org.mycore.common.MCRException;
 
+import java.io.Serial;
+
 /**
  * Instances of {@link MCRResourceException} are thrown when the MyCoRe API is used in an
  * illegal way. For example, this could happen when you provide illegal arguments to a method.
  */
 public class MCRResourceException extends MCRException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     /**
      * Creates a new {@link MCRResourceException} with an error message

--- a/mycore-base/src/main/java/org/mycore/resource/MCRResourceServlet.java
+++ b/mycore-base/src/main/java/org/mycore/resource/MCRResourceServlet.java
@@ -20,6 +20,7 @@ package org.mycore.resource;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.Serial;
 import java.net.URL;
 import java.nio.file.NoSuchFileException;
 import java.util.Optional;
@@ -41,6 +42,9 @@ import jakarta.servlet.http.HttpServletResponse;
  * of the incoming request, using {@link MCRResourceResolver#resolveWebResource(String)}.
  */
 public final class MCRResourceServlet extends HttpServlet {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger();
 

--- a/mycore-base/src/main/java/org/mycore/services/zipper/MCRCompressServlet.java
+++ b/mycore-base/src/main/java/org/mycore/services/zipper/MCRCompressServlet.java
@@ -24,6 +24,7 @@ import static org.mycore.common.MCRConstants.XLINK_NAMESPACE;
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.Serial;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -80,6 +81,7 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public abstract class MCRCompressServlet<T extends AutoCloseable> extends MCRServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final String KEY_OBJECT_ID = MCRCompressServlet.class.getCanonicalName() + ".object";

--- a/mycore-base/src/main/java/org/mycore/services/zipper/MCRTarServlet.java
+++ b/mycore-base/src/main/java/org/mycore/services/zipper/MCRTarServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.services.zipper;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.nio.file.Files;
 import java.nio.file.attribute.BasicFileAttributes;
 
@@ -38,6 +39,8 @@ import jakarta.servlet.ServletOutputStream;
  * @author Thomas Scheffler (yagee)
  */
 public class MCRTarServlet extends MCRCompressServlet<TarArchiveOutputStream> {
+
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRTarServlet.class);

--- a/mycore-base/src/main/java/org/mycore/services/zipper/MCRZipServlet.java
+++ b/mycore-base/src/main/java/org/mycore/services/zipper/MCRZipServlet.java
@@ -20,6 +20,7 @@ package org.mycore.services.zipper;
 
 import java.io.BufferedOutputStream;
 import java.io.IOException;
+import java.io.Serial;
 import java.nio.file.Files;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.zip.Deflater;
@@ -36,6 +37,8 @@ import jakarta.servlet.ServletOutputStream;
  * @author Thomas Scheffler
  */
 public class MCRZipServlet extends MCRCompressServlet<ZipArchiveOutputStream> {
+
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @Override

--- a/mycore-classbrowser/src/main/java/org/mycore/frontend/servlets/MCRClassificationBrowser2.java
+++ b/mycore-classbrowser/src/main/java/org/mycore/frontend/servlets/MCRClassificationBrowser2.java
@@ -19,6 +19,7 @@
 package org.mycore.frontend.servlets;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -56,6 +57,8 @@ import jakarta.servlet.http.HttpServletResponse;
  * @author Frank Lützenkirchen
  */
 public class MCRClassificationBrowser2 extends MCRServlet {
+
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRClassificationBrowser2.class);

--- a/mycore-iiif/src/main/java/org/mycore/iiif/image/impl/MCRIIIFImageNotFoundException.java
+++ b/mycore-iiif/src/main/java/org/mycore/iiif/image/impl/MCRIIIFImageNotFoundException.java
@@ -18,8 +18,11 @@
 
 package org.mycore.iiif.image.impl;
 
+import java.io.Serial;
+
 public class MCRIIIFImageNotFoundException extends Exception {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private String identifier;

--- a/mycore-iiif/src/main/java/org/mycore/iiif/image/impl/MCRIIIFImageProvidingException.java
+++ b/mycore-iiif/src/main/java/org/mycore/iiif/image/impl/MCRIIIFImageProvidingException.java
@@ -18,8 +18,11 @@
 
 package org.mycore.iiif.image.impl;
 
+import java.io.Serial;
+
 public class MCRIIIFImageProvidingException extends Exception {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRIIIFImageProvidingException(String message, Throwable cause, boolean enableSuppression,

--- a/mycore-iiif/src/main/java/org/mycore/iiif/image/impl/MCRIIIFUnsupportedFormatException.java
+++ b/mycore-iiif/src/main/java/org/mycore/iiif/image/impl/MCRIIIFUnsupportedFormatException.java
@@ -18,8 +18,11 @@
 
 package org.mycore.iiif.image.impl;
 
+import java.io.Serial;
+
 public class MCRIIIFUnsupportedFormatException extends Exception {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRIIIFUnsupportedFormatException(String unsupportedFormat) {

--- a/mycore-indexing/src/main/java/org/mycore/frontend/indexbrowser/MCRGoogleSitemapServlet.java
+++ b/mycore-indexing/src/main/java/org/mycore/frontend/indexbrowser/MCRGoogleSitemapServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.frontend.indexbrowser;
 
 import java.io.File;
+import java.io.Serial;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,6 +42,7 @@ import org.mycore.frontend.servlets.MCRServletJob;
  */
 public final class MCRGoogleSitemapServlet extends MCRServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /** The logger */

--- a/mycore-iview2/src/main/java/org/mycore/iview2/frontend/MCRThumbnailServlet.java
+++ b/mycore-iview2/src/main/java/org/mycore/iview2/frontend/MCRThumbnailServlet.java
@@ -70,7 +70,7 @@ import jakarta.servlet.http.HttpServletResponse;
 public class MCRThumbnailServlet extends MCRServlet {
 
     @Serial
-    private static final long serialVersionUID = 1506443527774956290L;
+    private static final long serialVersionUID = 1L;
 
     //stores max png size for byte array buffer of output
     private transient AtomicInteger maxPngSize = new AtomicInteger(64 * 1024);

--- a/mycore-iview2/src/main/java/org/mycore/iview2/frontend/MCRTileCombineServlet.java
+++ b/mycore-iview2/src/main/java/org/mycore/iview2/frontend/MCRTileCombineServlet.java
@@ -72,7 +72,7 @@ public class MCRTileCombineServlet extends MCRServlet {
     protected static final String THUMBNAIL_KEY = MCRTileCombineServlet.class.getName() + ".thumb";
 
     @Serial
-    private static final long serialVersionUID = 7924934677622546958L;
+    private static final long serialVersionUID = 1L;
 
     private static final float QUALITY = 0.75f;
 

--- a/mycore-iview2/src/main/java/org/mycore/iview2/frontend/MCRTileServlet.java
+++ b/mycore-iview2/src/main/java/org/mycore/iview2/frontend/MCRTileServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.iview2.frontend;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -49,7 +50,8 @@ public class MCRTileServlet extends HttpServlet {
      */
     static final int MAX_AGE = 60 * 60 * 24 * 365; // one year
 
-    private static final long serialVersionUID = 3805114872438336791L;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRTileServlet.class);
 

--- a/mycore-mets/src/main/java/org/mycore/mets/servlets/MCRDFGLinkServlet.java
+++ b/mycore-mets/src/main/java/org/mycore/mets/servlets/MCRDFGLinkServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.mets.servlets;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -67,6 +68,7 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRDFGLinkServlet extends MCRServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRDFGLinkServlet.class);

--- a/mycore-mets/src/main/java/org/mycore/mets/servlets/MCRMETSServlet.java
+++ b/mycore-mets/src/main/java/org/mycore/mets/servlets/MCRMETSServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.mets.servlets;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Locale;
@@ -54,6 +55,7 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRMETSServlet extends MCRServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRMETSServlet.class);

--- a/mycore-neo4j/src/main/java/org/mycore/mcr/neo4j/proxy/MCRNeo4JProxyServlet.java
+++ b/mycore-neo4j/src/main/java/org/mycore/mcr/neo4j/proxy/MCRNeo4JProxyServlet.java
@@ -23,6 +23,7 @@ import static org.mycore.mcr.neo4j.datamodel.metadata.neo4jutil.MCRNeo4JConstant
 import static org.mycore.mcr.neo4j.datamodel.metadata.neo4jutil.MCRNeo4JConstants.NEO4J_CONFIG_PREFIX;
 import static org.mycore.mcr.neo4j.datamodel.metadata.neo4jutil.MCRNeo4JUtil.getClassificationLabel;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -56,6 +57,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 public class MCRNeo4JProxyServlet extends MCRServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger();

--- a/mycore-orcid/src/main/java/org/mycore/orcid/MCRORCIDException.java
+++ b/mycore-orcid/src/main/java/org/mycore/orcid/MCRORCIDException.java
@@ -19,6 +19,7 @@
 package org.mycore.orcid;
 
 import java.io.IOException;
+import java.io.Serial;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,7 +34,8 @@ import jakarta.ws.rs.core.Response.StatusType;
  */
 public class MCRORCIDException extends IOException {
 
-    private static final long serialVersionUID = 1846541932326084816L;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private String message;
 

--- a/mycore-orcid/src/main/java/org/mycore/orcid/oauth/MCROAuthServlet.java
+++ b/mycore-orcid/src/main/java/org/mycore/orcid/oauth/MCROAuthServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.orcid.oauth;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.net.URISyntaxException;
 
 import org.apache.logging.log4j.LogManager;
@@ -51,6 +52,7 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCROAuthServlet extends MCRServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCROAuthServlet.class);

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/client/exception/MCRORCIDInvalidScopeException.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/client/exception/MCRORCIDInvalidScopeException.java
@@ -20,11 +20,14 @@ package org.mycore.orcid2.client.exception;
 
 import org.mycore.orcid2.exception.MCRORCIDException;
 
+import java.io.Serial;
+
 /**
  * This class is used if a scope is invalid.
  */
 public class MCRORCIDInvalidScopeException extends MCRORCIDException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/client/exception/MCRORCIDNotFoundException.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/client/exception/MCRORCIDNotFoundException.java
@@ -20,11 +20,14 @@ package org.mycore.orcid2.client.exception;
 
 import jakarta.ws.rs.core.Response;
 
+import java.io.Serial;
+
 /**
  * This class is used if a resource was not found
  */
 public class MCRORCIDNotFoundException extends MCRORCIDRequestException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/client/exception/MCRORCIDRequestException.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/client/exception/MCRORCIDRequestException.java
@@ -22,11 +22,14 @@ import org.mycore.orcid2.exception.MCRORCIDException;
 
 import jakarta.ws.rs.core.Response;
 
+import java.io.Serial;
+
 /**
  * This class is used if a request fails.
  */
 public class MCRORCIDRequestException extends MCRORCIDException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/exception/MCRORCIDException.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/exception/MCRORCIDException.java
@@ -20,11 +20,14 @@ package org.mycore.orcid2.exception;
 
 import org.mycore.common.MCRException;
 
+import java.io.Serial;
+
 /**
  * General mycore-orcid2 exception.
  */
 public class MCRORCIDException extends MCRException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/exception/MCRORCIDTransformationException.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/exception/MCRORCIDTransformationException.java
@@ -18,11 +18,14 @@
 
 package org.mycore.orcid2.exception;
 
+import java.io.Serial;
+
 /**
  * This exception concerns errors when transforming.
  */
 public class MCRORCIDTransformationException extends MCRORCIDException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/exception/MCRORCIDWorkAlreadyExistsException.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/exception/MCRORCIDWorkAlreadyExistsException.java
@@ -18,11 +18,14 @@
 
 package org.mycore.orcid2.exception;
 
+import java.io.Serial;
+
 /**
  * This exception concerns errors when a work already exists in a ORCID profile.
  */
 public class MCRORCIDWorkAlreadyExistsException extends MCRORCIDException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**

--- a/mycore-packer/src/main/java/org/mycore/services/packaging/MCRPackerServlet.java
+++ b/mycore-packer/src/main/java/org/mycore/services/packaging/MCRPackerServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.services.packaging;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -41,6 +42,7 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRPackerServlet extends MCRServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger();

--- a/mycore-pandoc/src/main/java/org/mycore/pandoc/MCRPandocException.java
+++ b/mycore-pandoc/src/main/java/org/mycore/pandoc/MCRPandocException.java
@@ -20,6 +20,8 @@ package org.mycore.pandoc;
 
 import org.mycore.common.MCRException;
 
+import java.io.Serial;
+
 /**
  * Pandoc exception
  *
@@ -27,6 +29,7 @@ import org.mycore.common.MCRException;
  */
 public class MCRPandocException extends MCRException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**

--- a/mycore-pi/src/main/java/org/mycore/pi/backend/MCRPI.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/backend/MCRPI.java
@@ -90,7 +90,7 @@ import jakarta.persistence.UniqueConstraint;
 public class MCRPI implements org.mycore.pi.MCRPIRegistrationInfo {
 
     @Serial
-    private static final long serialVersionUID = 234168232792525611L;
+    private static final long serialVersionUID = 1L;
 
     // unique constraint für identifier type
     @Id

--- a/mycore-pi/src/main/java/org/mycore/pi/exceptions/MCRDatacenterAuthenticationException.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/exceptions/MCRDatacenterAuthenticationException.java
@@ -18,8 +18,11 @@
 
 package org.mycore.pi.exceptions;
 
+import java.io.Serial;
+
 public class MCRDatacenterAuthenticationException extends MCRDatacenterException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRDatacenterAuthenticationException() {

--- a/mycore-pi/src/main/java/org/mycore/pi/exceptions/MCRDatacenterException.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/exceptions/MCRDatacenterException.java
@@ -18,8 +18,11 @@
 
 package org.mycore.pi.exceptions;
 
+import java.io.Serial;
+
 public class MCRDatacenterException extends MCRPersistentIdentifierException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRDatacenterException(String message) {

--- a/mycore-pi/src/main/java/org/mycore/pi/exceptions/MCRIdentifierUnresolvableException.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/exceptions/MCRIdentifierUnresolvableException.java
@@ -18,8 +18,11 @@
 
 package org.mycore.pi.exceptions;
 
+import java.io.Serial;
+
 public class MCRIdentifierUnresolvableException extends MCRDatacenterException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @SuppressWarnings("unused")

--- a/mycore-pi/src/main/java/org/mycore/pi/exceptions/MCRInvalidIdentifierExeption.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/exceptions/MCRInvalidIdentifierExeption.java
@@ -18,10 +18,12 @@
 
 package org.mycore.pi.exceptions;
 
+import java.io.Serial;
 import java.util.Locale;
 
 public class MCRInvalidIdentifierExeption extends MCRPersistentIdentifierException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRInvalidIdentifierExeption(String idString, String type) {

--- a/mycore-pi/src/main/java/org/mycore/pi/exceptions/MCRPersistentIdentifierException.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/exceptions/MCRPersistentIdentifierException.java
@@ -18,12 +18,14 @@
 
 package org.mycore.pi.exceptions;
 
+import java.io.Serial;
 import java.util.Optional;
 
 import org.mycore.common.MCRCatchException;
 
 public class MCRPersistentIdentifierException extends MCRCatchException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private final String translatedAdditionalInformation;

--- a/mycore-pi/src/main/java/org/mycore/pi/handle/MCREpicException.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/handle/MCREpicException.java
@@ -20,8 +20,11 @@ package org.mycore.pi.handle;
 
 import org.mycore.pi.exceptions.MCRPersistentIdentifierException;
 
+import java.io.Serial;
+
 public class MCREpicException extends MCRPersistentIdentifierException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCREpicException(String message) {

--- a/mycore-pi/src/main/java/org/mycore/pi/handle/MCREpicUnauthorizedException.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/handle/MCREpicUnauthorizedException.java
@@ -18,8 +18,11 @@
 
 package org.mycore.pi.handle;
 
+import java.io.Serial;
+
 public class MCREpicUnauthorizedException extends MCREpicException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCREpicUnauthorizedException(String message) {

--- a/mycore-pi/src/main/java/org/mycore/pi/urn/rest/MCRURNGranularRESTService.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/urn/rest/MCRURNGranularRESTService.java
@@ -19,6 +19,7 @@
 package org.mycore.pi.urn.rest;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.MessageFormat;
@@ -344,6 +345,7 @@ public class MCRURNGranularRESTService extends MCRPIService<MCRDNBURN> {
 
     public static class MCRPICreationException extends RuntimeException {
 
+        @Serial
         private static final long serialVersionUID = 1L;
 
         public MCRPICreationException(String message, Throwable cause) {

--- a/mycore-restapi/src/main/java/org/mycore/restapi/v1/errors/MCRRestAPIException.java
+++ b/mycore-restapi/src/main/java/org/mycore/restapi/v1/errors/MCRRestAPIException.java
@@ -18,6 +18,7 @@
 
 package org.mycore.restapi.v1.errors;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,6 +32,7 @@ import jakarta.ws.rs.core.Response.Status;
  */
 public class MCRRestAPIException extends Exception {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private List<MCRRestAPIError> errors = new ArrayList<>();

--- a/mycore-restapi/src/main/java/org/mycore/restapi/v1/utils/MCRPropertiesToJSONTransformer.java
+++ b/mycore-restapi/src/main/java/org/mycore/restapi/v1/utils/MCRPropertiesToJSONTransformer.java
@@ -20,6 +20,7 @@ package org.mycore.restapi.v1.utils;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Serial;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
@@ -66,6 +67,7 @@ public class MCRPropertiesToJSONTransformer implements MessageBodyWriter<Propert
         httpHeaders.putSingle(HttpHeaders.CONTENT_TYPE,
             MediaType.APPLICATION_JSON_TYPE.withCharset(StandardCharsets.UTF_8.name()));
         final Type mapType = new TypeToken<Map<String, String>>() {
+            @Serial
             private static final long serialVersionUID = 1L;
         }.getType();
         Map<String, String> writeMap = t.entrySet()

--- a/mycore-solr/src/main/java/org/mycore/solr/index/file/tika/MCRTikaMappingException.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/index/file/tika/MCRTikaMappingException.java
@@ -18,12 +18,17 @@
 
 package org.mycore.solr.index.file.tika;
 
+import java.io.Serial;
+
 /**
  * An exception that is thrown when an error occurs during the mapping of a Tika response to a Solr document.
  *
  * @author Sebastian Hofmann
  */
 public class MCRTikaMappingException extends Exception {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     public MCRTikaMappingException() {
     }

--- a/mycore-solr/src/main/java/org/mycore/solr/proxy/MCRSolrProxyServlet.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/proxy/MCRSolrProxyServlet.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.io.Serial;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -86,9 +87,10 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRSolrProxyServlet extends MCRServlet {
 
-    private static final Logger LOGGER = LogManager.getLogger();
-
+    @Serial
     private static final long serialVersionUID = 1L;
+    
+    private static final Logger LOGGER = LogManager.getLogger();
 
     /**
      * Attribute key to store Query parameters as <code>Map&lt;String, String[]&gt;</code> for SOLR. This takes

--- a/mycore-solr/src/main/java/org/mycore/solr/search/MCRQLSearchServlet.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/search/MCRQLSearchServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.solr.search;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -42,6 +43,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 public class MCRQLSearchServlet extends MCRServlet {//extends MCRSearchServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRQLSearchServlet.class);

--- a/mycore-sword/src/main/java/org/mycore/sword/servlets/MCRSwordServlet.java
+++ b/mycore-sword/src/main/java/org/mycore/sword/servlets/MCRSwordServlet.java
@@ -30,10 +30,14 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import java.io.Serial;
+
 /**
  * @author Sebastian Hofmann (mcrshofm)
  */
 public class MCRSwordServlet extends HttpServlet {
+
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRSwordServlet.class);

--- a/mycore-user2/src/main/java/org/mycore/user2/MCRRoleServlet.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/MCRRoleServlet.java
@@ -18,6 +18,7 @@
 
 package org.mycore.user2;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -50,6 +51,7 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRRoleServlet extends MCRServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final String LAYOUT_ELEMENT_KEY = MCRRoleServlet.class.getName() + ".layoutElement";

--- a/mycore-user2/src/main/java/org/mycore/user2/MCRTransientUser.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/MCRTransientUser.java
@@ -18,6 +18,7 @@
 
 package org.mycore.user2;
 
+import java.io.Serial;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,6 +35,7 @@ import org.mycore.common.MCRUserInformation;
  */
 public class MCRTransientUser extends MCRUser {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRTransientUser.class);

--- a/mycore-user2/src/main/java/org/mycore/user2/MCRUser.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/MCRUser.java
@@ -18,6 +18,7 @@
 
 package org.mycore.user2;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -86,7 +87,9 @@ import jakarta.xml.bind.annotation.XmlType;
 @XmlType(propOrder = { "ownerId", "realName", "eMail", "lastLogin", "validUntil", "roles", "attributes",
     "password" })
 public class MCRUser implements MCRUserInformation, Cloneable, Serializable {
-    private static final long serialVersionUID = 3378645055646901800L;
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     /** The unique user ID */
     int internalID;
@@ -823,7 +826,8 @@ public class MCRUser implements MCRUserInformation, Cloneable, Serializable {
 
     private static final class Password implements Serializable {
 
-        private static final long serialVersionUID = 8068063832119405080L;
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         @XmlAttribute
         private String hash;
@@ -843,7 +847,8 @@ public class MCRUser implements MCRUserInformation, Cloneable, Serializable {
 
     private static final class UserIdentifier implements Serializable {
 
-        private static final long serialVersionUID = 4654103884660408929L;
+        @Serial
+        private static final long serialVersionUID = 1L;
 
         @XmlAttribute
         public String name;

--- a/mycore-user2/src/main/java/org/mycore/user2/login/MCRCASServlet.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/login/MCRCASServlet.java
@@ -35,6 +35,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import java.io.Serial;
+
 /**
  * Login user with JA-SIG Central Authentication Service (CAS).
  * The servlet validates the ticket returned from CAS and
@@ -63,6 +65,8 @@ import jakarta.servlet.http.HttpServletResponse;
  * @author Frank L\u00fctzenkirchen
  */
 public class MCRCASServlet extends MCRServlet {
+
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /** The logger */

--- a/mycore-user2/src/main/java/org/mycore/user2/login/MCRLoginServlet.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/login/MCRLoginServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.user2.login;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -68,13 +69,16 @@ import jakarta.xml.bind.JAXBException;
  * @author Thomas Scheffler (yagee)
  */
 public class MCRLoginServlet extends MCRServlet {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     protected static final String REALM_URL_PARAMETER = "realm";
 
     static final String HTTPS_ONLY_PROPERTY = MCRUser2Constants.CONFIG_PREFIX + "LoginHttpsOnly";
     protected static final boolean LOCAL_LOGIN_SECURE_ONLY = MCRConfiguration2
         .getOrThrow(HTTPS_ONLY_PROPERTY, Boolean::parseBoolean);
     static final String ALLOWED_ROLES_PROPERTY = MCRUser2Constants.CONFIG_PREFIX + "LoginAllowedRoles";
-    private static final long serialVersionUID = 1L;
     private static final String LOGIN_REDIRECT_URL_PARAMETER = "url";
     private static final String LOGIN_REDIRECT_URL_KEY = "loginRedirectURL";
     private static final List<String> ALLOWED_ROLES = MCRConfiguration2

--- a/mycore-user2/src/main/java/org/mycore/user2/login/MCRServlet3LoginServlet.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/login/MCRServlet3LoginServlet.java
@@ -22,6 +22,7 @@ import static org.mycore.user2.login.MCRLoginServlet.HTTPS_ONLY_PROPERTY;
 import static org.mycore.user2.login.MCRLoginServlet.LOCAL_LOGIN_SECURE_ONLY;
 
 import java.io.IOException;
+import java.io.Serial;
 
 import javax.xml.transform.TransformerException;
 
@@ -47,6 +48,8 @@ import jakarta.xml.bind.JAXBException;
  *
  */
 public class MCRServlet3LoginServlet extends MCRContainerLoginServlet {
+
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger();

--- a/mycore-user2/src/main/java/org/mycore/user2/login/MCRShibbolethLoginServlet.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/login/MCRShibbolethLoginServlet.java
@@ -18,6 +18,7 @@
 
 package org.mycore.user2.login;
 
+import java.io.Serial;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -41,6 +42,7 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRShibbolethLoginServlet extends MCRServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger(MCRShibbolethLoginServlet.class);

--- a/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAValidationException.java
+++ b/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAValidationException.java
@@ -19,6 +19,8 @@ package org.mycore.validation.pdfa;
 
 import org.mycore.common.MCRCatchException;
 
+import java.io.Serial;
+
 /**
  *
  *
@@ -26,6 +28,7 @@ import org.mycore.common.MCRCatchException;
  */
 public class MCRPDFAValidationException extends MCRCatchException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRPDFAValidationException(String message, Throwable cause) {

--- a/mycore-viewer/src/test/java/org/mycore/iview/tests/TestProperties.java
+++ b/mycore-viewer/src/test/java/org/mycore/iview/tests/TestProperties.java
@@ -19,6 +19,7 @@
 package org.mycore.iview.tests;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.util.Properties;
 
 import org.apache.logging.log4j.LogManager;
@@ -27,8 +28,12 @@ import org.apache.logging.log4j.Logger;
 public class TestProperties extends Properties {
 
     public static final String TEST_PROPERTIES = "test.properties";
-    private static final long serialVersionUID = -1135672087633884258L;
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     private static final Logger LOGGER = LogManager.getLogger(TestProperties.class);
+
     private static TestProperties singleton;
 
     private TestProperties() {

--- a/mycore-viewer/src/test/java/org/mycore/iview/tests/image/api/DebugBufferedImageWindow.java
+++ b/mycore-viewer/src/test/java/org/mycore/iview/tests/image/api/DebugBufferedImageWindow.java
@@ -20,11 +20,13 @@ package org.mycore.iview.tests.image.api;
 
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;
+import java.io.Serial;
 
 import javax.swing.JFrame;
 
 public class DebugBufferedImageWindow extends JFrame {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private BufferedImage imageToShow;

--- a/mycore-webtools/src/main/java/org/mycore/webtools/properties/MCRPropertyHelperContentServlet.java
+++ b/mycore-webtools/src/main/java/org/mycore/webtools/properties/MCRPropertyHelperContentServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.webtools.properties;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.util.List;
 import java.util.Map;
 
@@ -37,6 +38,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public class MCRPropertyHelperContentServlet extends MCRContentServlet {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Override
     public MCRContent getContent(HttpServletRequest req, HttpServletResponse resp)

--- a/mycore-webtools/src/main/java/org/mycore/webtools/upload/exception/MCRInvalidFileException.java
+++ b/mycore-webtools/src/main/java/org/mycore/webtools/upload/exception/MCRInvalidFileException.java
@@ -20,11 +20,14 @@ package org.mycore.webtools.upload.exception;
 
 import org.mycore.services.i18n.MCRTranslation;
 
+import java.io.Serial;
+
 /**
  * Should be thrown if the file is not valid. E.g. the size is too big or the file name contains invalid characters.
  */
 public class MCRInvalidFileException extends MCRUploadException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private final String fileName;

--- a/mycore-webtools/src/main/java/org/mycore/webtools/upload/exception/MCRInvalidUploadParameterException.java
+++ b/mycore-webtools/src/main/java/org/mycore/webtools/upload/exception/MCRInvalidUploadParameterException.java
@@ -20,11 +20,14 @@ package org.mycore.webtools.upload.exception;
 
 import org.mycore.services.i18n.MCRTranslation;
 
+import java.io.Serial;
+
 /**
  * Should be thrown if a parameter required by an upload handler is not valid. E.g. a classification does not exist.
  */
 public class MCRInvalidUploadParameterException extends MCRUploadException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private final String parameterName;

--- a/mycore-webtools/src/main/java/org/mycore/webtools/upload/exception/MCRMissingParameterException.java
+++ b/mycore-webtools/src/main/java/org/mycore/webtools/upload/exception/MCRMissingParameterException.java
@@ -18,11 +18,14 @@
 
 package org.mycore.webtools.upload.exception;
 
+import java.io.Serial;
+
 /**
  * Should be thrown if a parameter required by an upload handler is missing.
  */
 public class MCRMissingParameterException extends MCRUploadException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private final String parameterName;

--- a/mycore-webtools/src/main/java/org/mycore/webtools/upload/exception/MCRUploadException.java
+++ b/mycore-webtools/src/main/java/org/mycore/webtools/upload/exception/MCRUploadException.java
@@ -20,8 +20,11 @@ package org.mycore.webtools.upload.exception;
 
 import org.mycore.services.i18n.MCRTranslation;
 
+import java.io.Serial;
+
 public class MCRUploadException extends Exception {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRUploadException(String messageKey) {

--- a/mycore-webtools/src/main/java/org/mycore/webtools/upload/exception/MCRUploadForbiddenException.java
+++ b/mycore-webtools/src/main/java/org/mycore/webtools/upload/exception/MCRUploadForbiddenException.java
@@ -18,8 +18,11 @@
 
 package org.mycore.webtools.upload.exception;
 
+import java.io.Serial;
+
 public class MCRUploadForbiddenException extends MCRUploadException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRUploadForbiddenException(String reason) {

--- a/mycore-webtools/src/main/java/org/mycore/webtools/upload/exception/MCRUploadServerException.java
+++ b/mycore-webtools/src/main/java/org/mycore/webtools/upload/exception/MCRUploadServerException.java
@@ -18,8 +18,11 @@
 
 package org.mycore.webtools.upload.exception;
 
+import java.io.Serial;
+
 public class MCRUploadServerException extends MCRUploadException {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public MCRUploadServerException(String messageKey) {

--- a/mycore-webtools/src/main/java/org/mycore/webtools/vue/MCRVueRootServlet.java
+++ b/mycore-webtools/src/main/java/org/mycore/webtools/vue/MCRVueRootServlet.java
@@ -20,6 +20,7 @@ package org.mycore.webtools.vue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.io.Serial;
 import java.io.StringReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -123,6 +124,7 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRVueRootServlet extends MCRContentServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @Override

--- a/mycore-wfc/src/main/java/org/mycore/wfc/actionmapping/MCRActionMappingServlet.java
+++ b/mycore-wfc/src/main/java/org/mycore/wfc/actionmapping/MCRActionMappingServlet.java
@@ -18,6 +18,7 @@
 
 package org.mycore.wfc.actionmapping;
 
+import java.io.Serial;
 import java.net.URI;
 import java.util.List;
 
@@ -36,6 +37,8 @@ import jakarta.servlet.http.HttpServletResponse;
  *
  */
 public class MCRActionMappingServlet extends MCRServlet {
+
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Splitter PATH_SPLITTER = Splitter.on('/').trimResults().omitEmptyStrings().limit(2);

--- a/mycore-xeditor/src/main/java/org/mycore/frontend/xeditor/MCRStaticXEditorFileServlet.java
+++ b/mycore-xeditor/src/main/java/org/mycore/frontend/xeditor/MCRStaticXEditorFileServlet.java
@@ -19,6 +19,7 @@
 package org.mycore.frontend.xeditor;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.net.URL;
 import java.util.Collections;
 import java.util.HashSet;
@@ -42,6 +43,7 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRStaticXEditorFileServlet extends MCRStaticXMLFileServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /** XML document types that may contain editor forms */

--- a/mycore-xeditor/src/main/java/org/mycore/frontend/xeditor/MCRXEditorServlet.java
+++ b/mycore-xeditor/src/main/java/org/mycore/frontend/xeditor/MCRXEditorServlet.java
@@ -18,6 +18,7 @@
 
 package org.mycore.frontend.xeditor;
 
+import java.io.Serial;
 import java.util.Enumeration;
 import java.util.Locale;
 
@@ -35,6 +36,7 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class MCRXEditorServlet extends MCRServlet {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LogManager.getLogger();

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -241,10 +241,7 @@
   <rule ref="category/java/errorprone.xml/JUnitStaticSuite"/>
   <rule ref="category/java/errorprone.xml/MethodWithSameNameAsEnclosingClass"/>
   <rule ref="category/java/errorprone.xml/MisplacedNullCheck"/>
-  <!-- TODO: Create PR to fix this rule -->
-  <!--
   <rule ref="category/java/errorprone.xml/MissingSerialVersionUID"/>
-  -->
   <rule ref="category/java/errorprone.xml/MissingStaticMethodInNonInstantiatableClass"/>
   <rule ref="category/java/errorprone.xml/MoreThanOneLogger"/>
   <rule ref="category/java/errorprone.xml/NonCaseLabelInSwitch"/>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3269).

Also added missing `@Serial` annotation to each `serialVersionUID` and unified the values to `1L`, since serialization isn't used in MyCoRe (in a way hat needs class versioning), only a hand full of classes had actual values and the values were never updated when implementations changed. 