### PR TITLE
MCR-3333 Performance Degradation in Xalan Transformer

### DIFF
--- a/mycore-base/pom.xml
+++ b/mycore-base/pom.xml
@@ -409,7 +409,6 @@
     <dependency>
       <groupId>xalan</groupId>
       <artifactId>serializer</artifactId>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>

--- a/mycore-base/pom.xml
+++ b/mycore-base/pom.xml
@@ -394,6 +394,10 @@
     </dependency>
     <dependency>
       <groupId>xalan</groupId>
+      <artifactId>serializer</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>xalan</groupId>
       <artifactId>xalan</artifactId>
     </dependency>
     <dependency>
@@ -405,10 +409,6 @@
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
       <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>serializer</artifactId>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>

--- a/mycore-base/src/main/java/org/mycore/common/xsl/MCRParameterCollector.java
+++ b/mycore-base/src/main/java/org/mycore/common/xsl/MCRParameterCollector.java
@@ -337,6 +337,20 @@ public class MCRParameterCollector {
      *            the Transformer object thats parameters should be set
      */
     public void setParametersTo(Transformer transformer) {
+        /*String name = transformer.getClass().getName();
+        // xalan special case
+        if (name.equals("org.apache.xalan.transformer.TransformerImpl")) {
+            try {
+                Method sp = transformer.getClass().getMethod("setParameter", String.class, String.class, Object.class);
+                for (Map.Entry<String, Object> entry : parameters.entrySet()) {
+                    sp.invoke(transformer, entry.getKey(), null, entry.getValue());
+                }
+            } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+                throw new MCRException("Failed to set parameters to: " + transformer.getClass().getName(), e);
+            }
+            return;
+        }*/
+        // saxon and all other
         for (Map.Entry<String, Object> entry : parameters.entrySet()) {
             transformer.setParameter(entry.getKey(), entry.getValue());
         }

--- a/mycore-base/src/main/java/org/mycore/common/xsl/MCRParameterCollector.java
+++ b/mycore-base/src/main/java/org/mycore/common/xsl/MCRParameterCollector.java
@@ -337,20 +337,6 @@ public class MCRParameterCollector {
      *            the Transformer object thats parameters should be set
      */
     public void setParametersTo(Transformer transformer) {
-        /*String name = transformer.getClass().getName();
-        // xalan special case
-        if (name.equals("org.apache.xalan.transformer.TransformerImpl")) {
-            try {
-                Method sp = transformer.getClass().getMethod("setParameter", String.class, String.class, Object.class);
-                for (Map.Entry<String, Object> entry : parameters.entrySet()) {
-                    sp.invoke(transformer, entry.getKey(), null, entry.getValue());
-                }
-            } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-                throw new MCRException("Failed to set parameters to: " + transformer.getClass().getName(), e);
-            }
-            return;
-        }*/
-        // saxon and all other
         for (Map.Entry<String, Object> entry : parameters.entrySet()) {
             transformer.setParameter(entry.getKey(), entry.getValue());
         }

--- a/mycore-base/src/main/java/org/mycore/common/xsl/MCRXalanTransformerFactory.java
+++ b/mycore-base/src/main/java/org/mycore/common/xsl/MCRXalanTransformerFactory.java
@@ -1,0 +1,145 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.xsl;
+
+import java.util.Properties;
+
+import javax.xml.transform.ErrorListener;
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
+import javax.xml.transform.Templates;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.URIResolver;
+
+import org.apache.xalan.processor.TransformerFactoryImpl;
+import org.apache.xalan.templates.StylesheetRoot;
+import org.apache.xalan.transformer.TransformerImpl;
+import org.xml.sax.ContentHandler;
+
+public class MCRXalanTransformerFactory extends TransformerFactoryImpl {
+
+    @Override
+    public Templates newTemplates(Source source) throws TransformerConfigurationException {
+        return new TemplatesFacade(super.newTemplates(source));
+    }
+
+    private static class TemplatesFacade implements Templates {
+
+        private final Templates delegate;
+
+        public TemplatesFacade(Templates delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Transformer newTransformer() throws TransformerConfigurationException {
+            TransformerImpl transformerImpl = (TransformerImpl) delegate.newTransformer();
+            return new TransformerFacade(transformerImpl, transformerImpl.getStylesheet());
+        }
+
+        @Override
+        public Properties getOutputProperties() {
+            return this.delegate.getOutputProperties();
+        }
+    }
+
+    private static class TransformerFacade extends TransformerImpl {
+
+        private final TransformerImpl delegate;
+
+        private TransformerFacade(TransformerImpl delegate, StylesheetRoot stylesheetRoot) {
+            super(stylesheetRoot);
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void setParameter(String name, Object object) {
+            delegate.setParameter(name, null, object);
+        }
+
+        @Override
+        public void transform(Source source, Result result) throws TransformerException {
+            delegate.transform(source, result);
+        }
+
+        @Override
+        public Object getParameter(String s) {
+            return delegate.getParameter(s);
+        }
+
+        @Override
+        public void clearParameters() {
+            delegate.clearParameters();
+        }
+
+        @Override
+        public void setURIResolver(URIResolver uriResolver) {
+            delegate.setURIResolver(uriResolver);
+        }
+
+        @Override
+        public URIResolver getURIResolver() {
+            return delegate.getURIResolver();
+        }
+
+        @Override
+        public void setOutputProperties(Properties properties) {
+            delegate.setOutputProperties(properties);
+        }
+
+        @Override
+        public Properties getOutputProperties() {
+            return delegate.getOutputProperties();
+        }
+
+        @Override
+        public void setOutputProperty(String s, String s1) throws IllegalArgumentException {
+            delegate.setOutputProperty(s, s1);
+        }
+
+        @Override
+        public String getOutputProperty(String s) throws IllegalArgumentException {
+            return delegate.getOutputProperty(s);
+        }
+
+        @Override
+        public void setErrorListener(ErrorListener errorListener) throws IllegalArgumentException {
+            delegate.setErrorListener(errorListener);
+        }
+
+        @Override
+        public ErrorListener getErrorListener() {
+            return delegate.getErrorListener();
+        }
+
+        @Override
+        public ContentHandler getInputContentHandler(boolean doDocFrag) {
+            return delegate.getInputContentHandler(doDocFrag);
+        }
+
+        @Override
+        public ContentHandler getInputContentHandler() {
+            return delegate.getInputContentHandler();
+        }
+
+    }
+
+}

--- a/mycore-base/src/main/java/org/mycore/common/xsl/MCRXalanTransformerFactory.java
+++ b/mycore-base/src/main/java/org/mycore/common/xsl/MCRXalanTransformerFactory.java
@@ -63,9 +63,9 @@ public class MCRXalanTransformerFactory extends TransformerFactoryImpl {
         return new MyStylesheetHandler(this);
     }
 
-    private static class MyStylesheetHandler extends StylesheetHandler {
+    private static final class MyStylesheetHandler extends StylesheetHandler {
 
-        public MyStylesheetHandler(TransformerFactoryImpl processor) throws TransformerConfigurationException {
+        private MyStylesheetHandler(TransformerFactoryImpl processor) throws TransformerConfigurationException {
             super(processor);
         }
 
@@ -76,11 +76,11 @@ public class MCRXalanTransformerFactory extends TransformerFactoryImpl {
 
     }
 
-    private static class MyTemplates implements Templates {
+    private static final class MyTemplates implements Templates {
 
         StylesheetRoot delegate;
 
-        public MyTemplates(StylesheetRoot delegate) {
+        private MyTemplates(StylesheetRoot delegate) {
             this.delegate = delegate;
         }
 
@@ -96,9 +96,9 @@ public class MCRXalanTransformerFactory extends TransformerFactoryImpl {
 
     }
 
-    private static class MyTransformerImpl extends TransformerImpl {
+    private static final class MyTransformerImpl extends TransformerImpl {
 
-        public MyTransformerImpl(StylesheetRoot stylesheet) {
+        private MyTransformerImpl(StylesheetRoot stylesheet) {
             super(stylesheet);
         }
 

--- a/mycore-base/src/main/java/org/mycore/common/xsl/MCRXalanTransformerFactory.java
+++ b/mycore-base/src/main/java/org/mycore/common/xsl/MCRXalanTransformerFactory.java
@@ -29,6 +29,7 @@ import org.apache.xalan.processor.StylesheetHandler;
 import org.apache.xalan.processor.TransformerFactoryImpl;
 import org.apache.xalan.templates.StylesheetRoot;
 import org.apache.xalan.transformer.TransformerImpl;
+import org.apache.xml.serializer.SerializerTrace;
 
 /**
  * A custom {@code TransformerFactory} implementation for Xalan that improves
@@ -96,7 +97,7 @@ public class MCRXalanTransformerFactory extends TransformerFactoryImpl {
 
     }
 
-    private static final class MyTransformerImpl extends TransformerImpl {
+    private static final class MyTransformerImpl extends TransformerImpl implements SerializerTrace {
 
         private MyTransformerImpl(StylesheetRoot stylesheet) {
             super(stylesheet);

--- a/mycore-base/src/main/resources/config/mycore.properties
+++ b/mycore-base/src/main/resources/config/mycore.properties
@@ -48,7 +48,8 @@ MCR.Filter.UserAgent.AcceptInvalid=false
 ##############################################################################
 
 # Shorthands for implementations of javax.xml.transform.TransformerFactory
-XALAN=org.apache.xalan.processor.TransformerFactoryImpl
+# XALAN=org.apache.xalan.processor.TransformerFactoryImpl
+XALAN=org.mycore.common.xsl.MCRXalanTransformerFactory
 SAXON=net.sf.saxon.TransformerFactoryImpl
 
 # External extentions of MCRURIResolver

--- a/mycore-base/src/main/resources/config/mycore.properties
+++ b/mycore-base/src/main/resources/config/mycore.properties
@@ -48,7 +48,6 @@ MCR.Filter.UserAgent.AcceptInvalid=false
 ##############################################################################
 
 # Shorthands for implementations of javax.xml.transform.TransformerFactory
-# XALAN=org.apache.xalan.processor.TransformerFactoryImpl
 XALAN=org.mycore.common.xsl.MCRXalanTransformerFactory
 SAXON=net.sf.saxon.TransformerFactoryImpl
 

--- a/mycore-base/src/test/java/org/mycore/common/xsl/MCRParameterCollectorTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/xsl/MCRParameterCollectorTest.java
@@ -1,0 +1,179 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.xsl;
+
+import java.security.SecureRandom;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Templates;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.sax.SAXResult;
+import javax.xml.transform.sax.SAXSource;
+import javax.xml.transform.sax.SAXTransformerFactory;
+import javax.xml.transform.sax.TransformerHandler;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mycore.common.MCRClassTools;
+import org.mycore.common.MCRTestCase;
+import org.mycore.common.config.MCRConfigurationException;
+import org.mycore.common.xml.MCRURIResolver;
+import org.xml.sax.SAXException;
+
+public class MCRParameterCollectorTest extends MCRTestCase {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private static final String XSL_RESOURCE = "xsl/copynodes.xsl";
+
+    private static final String XALAN_FACTORY_CLASS = "org.apache.xalan.processor.TransformerFactoryImpl";
+
+    private static final String SAXON_FACTORY_CLASS = "net.sf.saxon.TransformerFactoryImpl";
+
+    private static final String MCR_XALAN_FACTORY_CLASS = "org.mycore.common.xsl.MCRXalanTransformerFactory";
+
+    private Map<String, String> randomParameters10;
+
+    private Map<String, String> randomParameters100;
+
+    private Map<String, String> randomParameters1000;
+
+    private Map<String, String> randomParameters10000;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.randomParameters10 = RandomHashMapFiller.fillWithRandomStrings(10, 8, 8);
+        this.randomParameters100 = RandomHashMapFiller.fillWithRandomStrings(100, 8, 8);
+        this.randomParameters1000 = RandomHashMapFiller.fillWithRandomStrings(1000, 8, 8);
+        this.randomParameters10000 = RandomHashMapFiller.fillWithRandomStrings(10000, 8, 8);
+    }
+
+    @Ignore
+    @Test
+    public void setParametersTo() throws TransformerException, ParserConfigurationException, SAXException {
+        // test xalan
+        SAXTransformerFactory xalanFactory = getTransformerFactory(XALAN_FACTORY_CLASS);
+        TransformerHandler xalanHandler = getTransformerHandler(xalanFactory, XSL_RESOURCE);
+        Transformer xalanTransformer = xalanHandler.getTransformer();
+
+        LOGGER.info("Test xalan:");
+        speedTest(randomParameters10, xalanTransformer);
+        speedTest(randomParameters100, xalanTransformer);
+        speedTest(randomParameters1000, xalanTransformer);
+        speedTest(randomParameters10000, xalanTransformer);
+
+        // test mcr xalan
+        SAXTransformerFactory mcrXalanFactory = getTransformerFactory(MCR_XALAN_FACTORY_CLASS);
+        TransformerHandler mcrXalanHandler = getTransformerHandler(mcrXalanFactory, XSL_RESOURCE);
+        Transformer mcrXalanTransformer = mcrXalanHandler.getTransformer();
+
+        LOGGER.info("Test MCR Xalan:");
+        speedTest(randomParameters10, mcrXalanTransformer);
+        speedTest(randomParameters100, mcrXalanTransformer);
+        speedTest(randomParameters1000, mcrXalanTransformer);
+        speedTest(randomParameters10000, mcrXalanTransformer);
+
+        // test saxon
+        SAXTransformerFactory saxonFactory = getTransformerFactory(SAXON_FACTORY_CLASS);
+        TransformerHandler saxonHandler = getTransformerHandler(saxonFactory, XSL_RESOURCE);
+        Transformer saxonTransformer = saxonHandler.getTransformer();
+
+        LOGGER.info("Test saxon:");
+        speedTest(randomParameters10, saxonTransformer);
+        speedTest(randomParameters100, saxonTransformer);
+        speedTest(randomParameters1000, saxonTransformer);
+        speedTest(randomParameters10000, saxonTransformer);
+    }
+
+    private static void speedTest(Map<String, String> parameters, Transformer transformer) {
+        MCRParameterCollector collector = new MCRParameterCollector();
+
+        collector.setParameters(parameters);
+
+        // clear old
+        collector.setParametersTo(transformer);
+        transformer.clearParameters();
+
+        // performance check for setParametersTo
+        LOGGER.info(() -> "Test time for " + parameters.size() + " parameters...");
+        long startTime = System.currentTimeMillis();
+        collector.setParametersTo(transformer);
+        long endTime = System.currentTimeMillis() - startTime;
+        LOGGER.info(() -> "Took " + endTime + "ms");
+    }
+
+    private static TransformerHandler getTransformerHandler(SAXTransformerFactory tFactory, String resourceName)
+        throws TransformerConfigurationException, SAXException, ParserConfigurationException {
+        MCRTemplatesSource templatesSource = new MCRTemplatesSource(resourceName);
+        Templates templates = tFactory.newTemplates(templatesSource.getSource());
+        return tFactory.newTransformerHandler(templates);
+    }
+
+    private static SAXTransformerFactory getTransformerFactory(String factoryClass) {
+        TransformerFactory transformerFactory = Optional.of(factoryClass)
+            .map(c -> TransformerFactory.newInstance(c, MCRClassTools.getClassLoader()))
+            .orElseGet(TransformerFactory::newInstance);
+        LOGGER.info("Transformer factory: {}", () -> transformerFactory.getClass().getName());
+        transformerFactory.setURIResolver(MCRURIResolver.instance());
+        transformerFactory.setErrorListener(MCRErrorListener.getInstance());
+        if (transformerFactory.getFeature(SAXSource.FEATURE) && transformerFactory.getFeature(SAXResult.FEATURE)) {
+            return (SAXTransformerFactory) transformerFactory;
+        } else {
+            throw new MCRConfigurationException("Transformer Factory " + transformerFactory.getClass().getName()
+                + " does not implement SAXTransformerFactory");
+        }
+    }
+
+    private static class RandomHashMapFiller {
+
+        private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+        private static final Random RANDOM = new SecureRandom();
+
+        public static Map<String, String> fillWithRandomStrings(int numValues, int keyLength, int valueLength) {
+            HashMap<String, String> map = new HashMap<>();
+            for (int i = 0; i < numValues; i++) {
+                String key = generateRandomString(keyLength);
+                String value = generateRandomString(valueLength);
+                map.put(key, value);
+            }
+            return map;
+        }
+
+        private static String generateRandomString(int length) {
+            StringBuilder sb = new StringBuilder(length);
+            for (int i = 0; i < length; i++) {
+                sb.append(CHARACTERS.charAt(RANDOM.nextInt(CHARACTERS.length())));
+            }
+            return sb.toString();
+        }
+    }
+
+}


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3333).

* written TestCase to show problem
* new MCRXalanTransformerFactory to fix setParameter() problem

This pull request includes significant changes to improve the performance of XSL transformations by introducing a custom `TransformerFactory` implementation for Xalan. Additionally, it updates the project dependencies and configuration files accordingly.

### Performance improvements:

* Introduced `MCRXalanTransformerFactory`, a custom `TransformerFactory` implementation for Xalan to enhance performance by disabling namespace support and avoiding the inefficient `m_userParams` vector. (`mycore-base/src/main/java/org/mycore/common/xsl/MCRXalanTransformerFactory.java`)

### Dependency and configuration updates:

* Updated the `pom.xml` file to add the `xalan:serializer` dependency and remove its previous runtime scope entry. (`mycore-base/pom.xml`) [[1]](diffhunk://#diff-200e4352a364cfb8ddece69c34f0425882011dbf0a5ba19fd25a1dfa52ff6019R395-R398) [[2]](diffhunk://#diff-200e4352a364cfb8ddece69c34f0425882011dbf0a5ba19fd25a1dfa52ff6019L409-L413)
* Modified `mycore.properties` to use the new `MCRXalanTransformerFactory` instead of the default Xalan factory. (`mycore-base/src/main/resources/config/mycore.properties`)

### Testing enhancements:

* Added `MCRParameterCollectorTest` to test the performance of the new `MCRXalanTransformerFactory` against the standard Xalan and Saxon factories. (`mycore-base/src/test/java/org/mycore/common/xsl/MCRParameterCollectorTest.java`)

