### PR TITLE
MCR-3241 enable PMD rule AvoidProtectedMethodInFinalClassNotExtending

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/config/MCRConfigurationBase.java
+++ b/mycore-base/src/main/java/org/mycore/common/config/MCRConfigurationBase.java
@@ -160,7 +160,7 @@ public final class MCRConfigurationBase {
     /**
      * Substitute all %properties%.
      */
-    protected static synchronized void resolveProperties() {
+    private static synchronized void resolveProperties() {
         MCRProperties tmpProperties = MCRProperties.copy(getBaseProperties());
         MCRPropertiesResolver resolver = new MCRPropertiesResolver(tmpProperties);
         resolvedProperties = MCRProperties.copy(resolver.resolveAll(tmpProperties));
@@ -187,15 +187,15 @@ public final class MCRConfigurationBase {
         }
     }
 
-    protected static MCRProperties getResolvedProperties() {
+    static MCRProperties getResolvedProperties() {
         return resolvedProperties;
     }
 
-    protected static MCRProperties getBaseProperties() {
+    private static MCRProperties getBaseProperties() {
         return baseProperties;
     }
 
-    protected static MCRProperties getDeprecatedProperties() {
+    private static MCRProperties getDeprecatedProperties() {
         return deprecatedProperties;
     }
 

--- a/mycore-base/src/main/java/org/mycore/common/xml/MCRURIResolver.java
+++ b/mycore-base/src/main/java/org/mycore/common/xml/MCRURIResolver.java
@@ -19,7 +19,6 @@
 package org.mycore.common.xml;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URI;
@@ -80,7 +79,6 @@ import org.mycore.common.content.MCRByteContent;
 import org.mycore.common.content.MCRContent;
 import org.mycore.common.content.MCRPathContent;
 import org.mycore.common.content.MCRSourceContent;
-import org.mycore.common.content.MCRStreamContent;
 import org.mycore.common.content.transformer.MCRContentTransformer;
 import org.mycore.common.content.transformer.MCRParameterizedTransformer;
 import org.mycore.common.content.transformer.MCRXSLTransformer;
@@ -437,22 +435,6 @@ public final class MCRURIResolver implements URIResolver {
         }
         String msg = "Unsupported scheme type: " + scheme;
         throw new MCRUsageException(msg);
-    }
-
-    /**
-     * Reads xml from an InputStream and returns the parsed root element.
-     *
-     * @param in
-     *            the InputStream that contains the XML document
-     * @return the root element of the parsed input stream
-     */
-    @Deprecated
-    protected Element parseStream(InputStream in) throws JDOMException, IOException {
-        final MCRStreamContent streamContent = new MCRStreamContent(in);
-        return MCRXMLParserFactory
-            .getNonValidatingParser()
-            .parseXML(streamContent)
-            .getRootElement();
     }
 
     /**

--- a/mycore-solr/src/main/java/org/mycore/solr/classification/MCRSolrClassificationUtil.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/classification/MCRSolrClassificationUtil.java
@@ -278,7 +278,7 @@ public final class MCRSolrClassificationUtil {
         return classId.toString().replaceAll(":", "\\\\:");
     }
 
-    protected static void solrDelete(MCRCategoryID id, MCRCategory parent) {
+    static void solrDelete(MCRCategoryID id, MCRCategory parent) {
         try {
             // remove all descendants and itself
             HttpSolrClientBase solrClient = getCore().getClient();
@@ -299,7 +299,7 @@ public final class MCRSolrClassificationUtil {
         }
     }
 
-    protected static void solrMove(MCRCategoryID id, MCRCategoryID newParentID) {
+    static void solrMove(MCRCategoryID id, MCRCategoryID newParentID) {
         try {
             SolrClient solrClient = getCore().getClient();
             List<String> reindexList = MCRSolrSearchUtils.listIDs(solrClient,

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -77,10 +77,7 @@
   <!-- Code Style Rules -->
   <rule ref="category/java/codestyle.xml/AvoidDollarSigns"/>
   <rule ref="category/java/codestyle.xml/AvoidProtectedFieldInFinalClass"/>
-  <!-- TODO: Create PR to fix this rule -->
-  <!--
   <rule ref="category/java/codestyle.xml/AvoidProtectedMethodInFinalClassNotExtending"/>
-  -->
   <rule ref="category/java/codestyle.xml/ControlStatementBraces"/>
   <rule ref="category/java/codestyle.xml/EmptyControlStatement">
     <properties>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3241).

This pull request includes several changes to improve code encapsulation and remove deprecated elements. The changes primarily focus on modifying access levels of methods and cleaning up unused imports and deprecated methods.

Encapsulation improvements:
* [`mycore-base/src/main/java/org/mycore/common/config/MCRConfigurationBase.java`](diffhunk://#diff-0a14be127a9ca1bfc9ace148865746aa36d065ac3aee0e0b4c7d3ce4d95cd479L163-R163): Changed several methods from `protected` to `private` or package-private to improve encapsulation. [[1]](diffhunk://#diff-0a14be127a9ca1bfc9ace148865746aa36d065ac3aee0e0b4c7d3ce4d95cd479L163-R163) [[2]](diffhunk://#diff-0a14be127a9ca1bfc9ace148865746aa36d065ac3aee0e0b4c7d3ce4d95cd479L190-R198)

Code cleanup:
* [`mycore-base/src/main/java/org/mycore/common/xml/MCRURIResolver.java`](diffhunk://#diff-a073b94cdcea741c72b51f59cd59218cd81f815992fac6425733516882e69191L22): Removed unused imports and a deprecated method `parseStream` to clean up the code. [[1]](diffhunk://#diff-a073b94cdcea741c72b51f59cd59218cd81f815992fac6425733516882e69191L22) [[2]](diffhunk://#diff-a073b94cdcea741c72b51f59cd59218cd81f815992fac6425733516882e69191L83) [[3]](diffhunk://#diff-a073b94cdcea741c72b51f59cd59218cd81f815992fac6425733516882e69191L442-L457)
* [`mycore-solr/src/main/java/org/mycore/solr/classification/MCRSolrClassificationUtil.java`](diffhunk://#diff-66be42d3b85b2168b98d8e43217d8772f36ca32f672afe10eb106ea1cb090e40L281-R281): Changed the access level of `solrDelete` and `solrMove` methods from `protected` to package-private. [[1]](diffhunk://#diff-66be42d3b85b2168b98d8e43217d8772f36ca32f672afe10eb106ea1cb090e40L281-R281) [[2]](diffhunk://#diff-66be42d3b85b2168b98d8e43217d8772f36ca32f672afe10eb106ea1cb090e40L302-R302)

Configuration updates:
* [`ruleset.xml`](diffhunk://#diff-a6839fbfcf5024903ed122d22112e9e54011183ccc884da9d1e3a3c2a9d9e04cL80-L83): Removed a commented-out rule related to avoiding protected methods in final classes not extending another class.