### PR TITLE
MCR-3264 fix MCRMeta class names

### DIFF
--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetaAccessRule.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetaAccessRule.java
@@ -27,14 +27,12 @@ import org.mycore.common.MCRException;
  * This class implements all method for handling with the MCRMetaAccessRule part
  * of a metadata object. The MCRMetaAccessRule class present a single item,
  * which hold an ACL condition for a defined permission.
- * 
+ *
  * @author Jens Kupferschmidt
  */
 public class MCRMetaAccessRule extends MCRMetaDefault {
 
     private static final Logger LOGGER = LogManager.getLogger();
-
-    public static final String CLASS_NAME = "MCRMetaAccessRule";
 
     private static final String ELEMENT_CONDITION = "condition";
 
@@ -84,7 +82,7 @@ public class MCRMetaAccessRule extends MCRMetaDefault {
 
     /**
      * This method set the permission and the condition.
-     * 
+     *
      * @param permission the format string, if it is empty 'READ' will be set.
      * @param condition
      *            the JDOM Element included the condition tree
@@ -98,7 +96,7 @@ public class MCRMetaAccessRule extends MCRMetaDefault {
 
     /**
      * This method set the condition.
-     * 
+     *
      * @param condition
      *            the JDOM Element included the condition tree
      * @exception MCRException
@@ -113,7 +111,7 @@ public class MCRMetaAccessRule extends MCRMetaDefault {
 
     /**
      * This method set the permission attribute.
-     * 
+     *
      * @param permission
      *            the new permission string.
      */
@@ -123,7 +121,7 @@ public class MCRMetaAccessRule extends MCRMetaDefault {
 
     /**
      * This method get the condition.
-     * 
+     *
      * @return the condition as JDOM Element
      */
     public final Element getCondition() {
@@ -132,7 +130,7 @@ public class MCRMetaAccessRule extends MCRMetaDefault {
 
     /**
      * This method get the permission attribute.
-     * 
+     *
      * @return the permission attribute
      */
     public final String getPermission() {
@@ -142,7 +140,7 @@ public class MCRMetaAccessRule extends MCRMetaDefault {
     /**
      * This method read the XML input stream part from a DOM part for the
      * metadata of the document.
-     * 
+     *
      * @param element
      *            a relevant JDOM element for the metadata
      */
@@ -157,7 +155,7 @@ public class MCRMetaAccessRule extends MCRMetaDefault {
     /**
      * This method create a XML stream for all data in this class, defined by
      * the MyCoRe XML MCRMetaAccessRule definition for the given subtag.
-     * 
+     *
      * @exception MCRException
      *                if the content of this class is not valid
      * @return a JDOM Element with the XML MCRMetaAccessRule part
@@ -179,7 +177,7 @@ public class MCRMetaAccessRule extends MCRMetaDefault {
      * <li>the condition is null</li>
      * <li>the permission is null or empty</li>
      * </ul>
-     * 
+     *
      * @throws MCRException the MCRMetaAccessRule is invalid
      */
     @Override

--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetaClassification.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetaClassification.java
@@ -43,8 +43,6 @@ public class MCRMetaClassification extends MCRMetaDefault {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    public static final String CLASS_NAME = "MCRMetaClassification";
-
     // MCRMetaClassification data
     protected MCRCategoryID category;
 

--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetaDateLangText.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetaDateLangText.java
@@ -35,8 +35,6 @@ import com.google.gson.JsonObject;
  */
 public class MCRMetaDateLangText extends MCRMetaLangText {
 
-    public static final String CLASS_NAME = "MCRMetaDateLangText";
-
     protected MCRISO8601Date isoDate;
 
     /**

--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetaIFS.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetaIFS.java
@@ -39,8 +39,6 @@ import com.google.gson.JsonObject;
  */
 public final class MCRMetaIFS extends MCRMetaDefault {
 
-    public static final String CLASS_NAME = "MCRMetaIFS";
-
     // MCRMetaIFS data
     private String sourcePath;
 

--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetaISO8601Date.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetaISO8601Date.java
@@ -49,8 +49,6 @@ public final class MCRMetaISO8601Date extends MCRMetaDefault {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    public static final String CLASS_NAME = "MCRMetaISO8601Date";
-
     private Element export;
 
     private boolean changed = true;

--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetaLangText.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetaLangText.java
@@ -41,8 +41,6 @@ public class MCRMetaLangText extends MCRMetaDefault {
 
     private static final String FORM_PLAIN = "plain";
 
-    public static final String CLASS_NAME = "MCRMetaLangText";
-
     protected String text;
 
     protected String form;

--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetaLink.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetaLink.java
@@ -49,8 +49,6 @@ public class MCRMetaLink extends MCRMetaDefault {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    public static final String CLASS_NAME = "MCRMetaLink";
-
     // MetaLink data
     protected String href;
     protected String label;

--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetaLinkID.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetaLinkID.java
@@ -45,6 +45,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 @JsonClassDescription("Links to other objects or derivates")
 public class MCRMetaLinkID extends MCRMetaLink {
+
     /**
      * initializes with empty values.
      */

--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRObjectDerivate.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRObjectDerivate.java
@@ -391,7 +391,7 @@ public class MCRObjectDerivate {
         }
         Element elm = new Element(XML_NAME);
         Element linkmetas = new Element(ELEMENT_LINKMETAS);
-        linkmetas.setAttribute(CLASS, MCRMetaLinkID.CLASS_NAME);
+        linkmetas.setAttribute(CLASS, MCRMetaLinkID.class.getSimpleName());
         linkmetas.setAttribute(HERITABLE, MCRXMLConstants.FALSE);
         linkmetas.addContent(linkmeta.createXML());
         elm.addContent(linkmetas);
@@ -420,7 +420,7 @@ public class MCRObjectDerivate {
 
     private Element createExternalsElement() {
         Element extEl = new Element(ELEMENT_EXTERNALS);
-        extEl.setAttribute(CLASS, MCRMetaLink.CLASS_NAME);
+        extEl.setAttribute(CLASS, MCRMetaLink.class.getSimpleName());
         extEl.setAttribute(HERITABLE, MCRXMLConstants.FALSE);
         for (MCRMetaLink external : externals) {
             extEl.addContent(external.createXML());
@@ -430,7 +430,7 @@ public class MCRObjectDerivate {
 
     private Element createInternalsElement() {
         Element intEl = new Element(ELEMENT_INTERNALS);
-        intEl.setAttribute(CLASS, MCRMetaIFS.CLASS_NAME);
+        intEl.setAttribute(CLASS, MCRMetaIFS.class.getSimpleName());
         intEl.setAttribute(HERITABLE, MCRXMLConstants.FALSE);
         intEl.addContent(internals.createXML());
         return intEl;
@@ -438,7 +438,7 @@ public class MCRObjectDerivate {
 
     private Element createTitleElement() {
         Element titEl = new Element(ELEMENT_TITLES);
-        titEl.setAttribute(CLASS, MCRMetaLangText.CLASS_NAME);
+        titEl.setAttribute(CLASS, MCRMetaLangText.class.getSimpleName());
         titEl.setAttribute(HERITABLE, MCRXMLConstants.FALSE);
         titles.stream()
             .map(MCRMetaLangText::createXML)
@@ -448,7 +448,7 @@ public class MCRObjectDerivate {
 
     private Element createClassificationElement() {
         Element clazzElement = new Element(ELEMENT_CLASSIFICATIONS);
-        clazzElement.setAttribute(CLASS, MCRMetaClassification.CLASS_NAME);
+        clazzElement.setAttribute(CLASS, MCRMetaClassification.class.getSimpleName());
         clazzElement.setAttribute(HERITABLE, MCRXMLConstants.FALSE);
 
         classifications.stream()

--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRObjectService.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRObjectService.java
@@ -697,16 +697,16 @@ public class MCRObjectService {
         Element elm = new Element(XML_NAME);
 
         // Create XML elements for each list
-        addContentIfNotEmpty(elm, dates, ELEMENT_SERVDATES, MCRMetaISO8601Date.CLASS_NAME);
-        addContentIfNotEmpty(elm, rules, ELEMENT_SERVACLS, MCRMetaAccessRule.CLASS_NAME);
-        addContentIfNotEmpty(elm, flags, ELEMENT_SERVFLAGS, MCRMetaLangText.CLASS_NAME);
-        addContentIfNotEmpty(elm, messages, ELEMENT_SERVMESSAGES, MCRMetaDateLangText.CLASS_NAME);
-        addContentIfNotEmpty(elm, classifications, ELEMENT_SERVCLASSES, MCRMetaClassification.CLASS_NAME);
+        addContentIfNotEmpty(elm, dates, ELEMENT_SERVDATES, MCRMetaISO8601Date.class.getSimpleName());
+        addContentIfNotEmpty(elm, rules, ELEMENT_SERVACLS, MCRMetaAccessRule.class.getSimpleName());
+        addContentIfNotEmpty(elm, flags, ELEMENT_SERVFLAGS, MCRMetaLangText.class.getSimpleName());
+        addContentIfNotEmpty(elm, messages, ELEMENT_SERVMESSAGES, MCRMetaDateLangText.class.getSimpleName());
+        addContentIfNotEmpty(elm, classifications, ELEMENT_SERVCLASSES, MCRMetaClassification.class.getSimpleName());
 
         // Handle the state separately
         if (state != null) {
             Element servStates = new Element(ELEMENT_SERVSTATES);
-            servStates.setAttribute(MCRXMLConstants.CLASS, MCRMetaClassification.CLASS_NAME);
+            servStates.setAttribute(MCRXMLConstants.CLASS, MCRMetaClassification.class.getSimpleName());
             MCRMetaClassification stateClass = new MCRMetaClassification(ELEMENT_SERVSTATE, 0, null, state);
             servStates.addContent(stateClass.createXML());
             elm.addContent(servStates);


### PR DESCRIPTION
MCRMetaLinkID is a sub class of MCRMetaLink and had no CLASS_NAME field so CLASS_NAME contained "MCRMetaLink" which causes problems with derivate validation

[Link to jira](https://mycore.atlassian.net/browse/MCR-3264).

This pull request includes several changes to the `mycore-base` package, specifically focusing on the removal of redundant `CLASS_NAME` constants and updating code to dynamically retrieve class names using `getSimpleName()`. These changes aim to simplify the codebase and ensure consistency in how class names are handled.

### Removal of `CLASS_NAME` Constants:
* Removed the `CLASS_NAME` constants from multiple classes, including `MCRMetaAccessRule`, `MCRMetaClassification`, `MCRMetaDateLangText`, `MCRMetaIFS`, `MCRMetaISO8601Date`, `MCRMetaLangText`, and `MCRMetaLink`. [[1]](diffhunk://#diff-db3b973b06f67bd9216e003a3ed3d9dce894898f7ad2c2c9ab1aaeb04210b65aL37-L38) [[2]](diffhunk://#diff-f798b26e67c8834a29bcb748b6bd3df5029083b56b94feb1adab0a1ae305e15dL46-L47) [[3]](diffhunk://#diff-e68c0965286ff74197ab0a17ab724798a9bdb00a891a0914e2f4683995e30400L38-L39) [[4]](diffhunk://#diff-47f03708a32f4f42250dc63037a145885057121521f67d738f64683c97f6088aL42-L43) [[5]](diffhunk://#diff-a346e4304afaf4ab6d8c10a87d5c36a94bd5807291b872a3e51b5c1fde8e372aL52-L53) [[6]](diffhunk://#diff-a9ba7155e8f9f6e2f53176fdd27bac31a9c93aa31c15d9d8bccbf230d5c0a8aaL44-L45) [[7]](diffhunk://#diff-1fdffb64dde1628b71ba379f8349f93409967becd84cd51ff14f4e5ad0096dcaL52-L53)

### Code Updates to Use `getSimpleName()`:
* Updated `MCRObjectDerivate` to use `getSimpleName()` for setting class attributes in XML elements instead of using the removed `CLASS_NAME` constants. [[1]](diffhunk://#diff-c1e84121ee1f918830b95ebbb95733f34fdb265a94c8a980c7b2b988f8ccd9eaL394-R394) [[2]](diffhunk://#diff-c1e84121ee1f918830b95ebbb95733f34fdb265a94c8a980c7b2b988f8ccd9eaL423-R423) [[3]](diffhunk://#diff-c1e84121ee1f918830b95ebbb95733f34fdb265a94c8a980c7b2b988f8ccd9eaL433-R441) [[4]](diffhunk://#diff-c1e84121ee1f918830b95ebbb95733f34fdb265a94c8a980c7b2b988f8ccd9eaL451-R451)
* Updated `MCRObjectService` to use `getSimpleName()` for setting class attributes in XML elements instead of using the removed `CLASS_NAME` constants.
