### PR TITLE
MCR-3283 implement MCRScopedSession.computeIfAbsent()

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/MCRScopedSession.java
+++ b/mycore-base/src/main/java/org/mycore/common/MCRScopedSession.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.mycore.common.config.MCRConfiguration2;
@@ -184,6 +185,16 @@ public final class MCRScopedSession extends MCRSession {
             super.deleteObject(key);
         } else {
             values.map.remove(key);
+        }
+    }
+
+    @Override
+    public Object computeIfAbsent(Object key, Function<Object, Object> mappingFunction) {
+        ScopedValues values = scopedValues.get();
+        if (values == null) {
+            return super.computeIfAbsent(key, mappingFunction);
+        } else {
+            return values.map.computeIfAbsent(key, mappingFunction);
         }
     }
 


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3283).

This pull request includes changes to the `MCRScopedSession` class to simplify the handling of scoped values by introducing a new method, `withScopedValues`. The main goal is to reduce code duplication and improve readability.

Key changes include:

* **Introduction of `withScopedValues` method:**
  - Added a new private method `withScopedValues` to handle operations within a scoped context or with default behavior. This method takes a `Function` for scoped actions and a `Supplier` for default actions.

* **Refactoring methods to use `withScopedValues`:**
  - Replaced direct checks for `scopedValues` with calls to `withScopedValues` in several methods such as `getLocale`, `setUserInformation`, `get`, `put`, `getCurrentIP`, `getUserInformation`, `getObjectsKeyList`, `getMapEntries`, and `deleteObject`. [[1]](diffhunk://#diff-721941c88595043fb5677da49ce0b3faf905f38c2a87739888b606d90c0ed863L102-R129) [[2]](diffhunk://#diff-721941c88595043fb5677da49ce0b3faf905f38c2a87739888b606d90c0ed863L155-R183)

* **New method for computing values if absent:**
  - Added a new method `computeIfAbsent` that uses `withScopedValues` to compute a value if it is absent in the scoped map.

