### PR TITLE
MCR-3349 add support for JUnit 5.x

### DIFF
--- a/mycore-base/src/test/java/org/mycore/datamodel/classifications2/impl/MCRAbstractCategoryImplTest.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/classifications2/impl/MCRAbstractCategoryImplTest.java
@@ -18,34 +18,29 @@
 
 package org.mycore.datamodel.classifications2.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Map;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mycore.common.MCRSession;
 import org.mycore.common.MCRSessionMgr;
-import org.mycore.common.MCRTestCase;
+import org.mycore.common.MCRTestConfiguration;
+import org.mycore.common.MCRTestProperty;
 import org.mycore.datamodel.classifications2.MCRCategory;
 import org.mycore.datamodel.classifications2.MCRLabel;
+import org.mycore.test.MyCoReTest;
 
-public class MCRAbstractCategoryImplTest extends MCRTestCase {
-
-    @Override
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-        System.setProperty("MCR.Metadata.DefaultLang.foo", "true");
-    }
-
-    @After
-    public void clean() {
-        System.setProperty("MCR.Metadata.DefaultLang.foo", "false");
-    }
+@MyCoReTest
+@MCRTestConfiguration(
+    properties = {
+        @MCRTestProperty(key = "MCR.Metadata.DefaultLang.foo", string = "true")
+    })
+public class MCRAbstractCategoryImplTest {
 
     @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "MCR.Metadata.DefaultLang", string = "at")
+        })
     public void getCurrentLabel() {
         MCRCategory cat = new MCRSimpleAbstractCategoryImpl();
         MCRLabel label1 = new MCRLabel("de", "german", null);
@@ -56,19 +51,12 @@ public class MCRAbstractCategoryImplTest extends MCRTestCase {
         cat.getLabels().add(label3);
         MCRSession session = MCRSessionMgr.getCurrentSession();
         session.setCurrentLanguage("en");
-        assertEquals("German label expected", label3, cat.getCurrentLabel().get());
+        assertEquals(label3, cat.getCurrentLabel().get(), "German label expected");
         cat.getLabels().clear();
         cat.getLabels().add(label2);
         cat.getLabels().add(label3);
         cat.getLabels().add(label1);
-        assertEquals("German label expected", label3, cat.getCurrentLabel().get());
-    }
-
-    @Override
-    protected Map<String, String> getTestProperties() {
-        Map<String, String> testProperties = super.getTestProperties();
-        testProperties.put("MCR.Metadata.DefaultLang", "at");
-        return testProperties;
+        assertEquals(label3, cat.getCurrentLabel().get(), "German label expected");
     }
 
 }

--- a/mycore-base/src/test/java/org/mycore/datamodel/classifications2/impl/MCRCategoryImplTest.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/classifications2/impl/MCRCategoryImplTest.java
@@ -17,7 +17,7 @@
  */
 package org.mycore.datamodel.classifications2.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -27,21 +27,22 @@ import java.util.List;
 
 import org.jdom2.Document;
 import org.jdom2.JDOMException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mycore.common.MCRException;
-import org.mycore.common.MCRTestCase;
 import org.mycore.common.content.MCRURLContent;
 import org.mycore.common.xml.MCRXMLParserFactory;
 import org.mycore.datamodel.classifications2.MCRCategory;
 import org.mycore.datamodel.classifications2.MCRCategoryID;
 import org.mycore.datamodel.classifications2.utils.MCRXMLTransformer;
+import org.mycore.test.MyCoReTest;
 import org.xml.sax.SAXParseException;
 
 /**
  * @author Thomas Scheffler (yagee)
  *
  */
-public class MCRCategoryImplTest extends MCRTestCase {
+@MyCoReTest
+public class MCRCategoryImplTest {
     static final String WORLD_CLASS_RESOURCE_NAME = "/worldclass.xml";
 
     private MCRCategoryImpl category;
@@ -76,14 +77,14 @@ public class MCRCategoryImplTest extends MCRTestCase {
         MCRCategory europe = category.getChildren().get(0);
         MCRCategoryImpl asia = (MCRCategoryImpl) category.getChildren().get(1);
         MCRCategoryImpl germany = (MCRCategoryImpl) europe.getChildren().getFirst();
-        assertEquals("Did not get Europe as left sibling of Asia", europe.getId(),
-            asia.getLeftSiblingOrOfAncestor().getId());
-        assertEquals("Did not get World as left sibling or ancestor of Germany", category.getId(),
-            germany.getLeftSiblingOrOfAncestor().getId());
+        assertEquals(europe.getId(), asia.getLeftSiblingOrOfAncestor().getId(),
+            "Did not get Europe as left sibling of Asia");
+        assertEquals(category.getId(), germany.getLeftSiblingOrOfAncestor().getId(),
+            "Did not get World as left sibling or ancestor of Germany");
         MCRCategoryImpl america = buildNode(new MCRCategoryID(category.getRootID(), "America"));
         category.getChildren().addFirst(america);
-        assertEquals("Did not get America as left sibling or ancestor of Germany", america.getId(),
-            germany.getLeftSiblingOrOfAncestor().getId());
+        assertEquals(america.getId(), germany.getLeftSiblingOrOfAncestor().getId(),
+            "Did not get America as left sibling or ancestor of Germany");
     }
 
     @Test
@@ -92,10 +93,10 @@ public class MCRCategoryImplTest extends MCRTestCase {
         MCRCategory europe = category.getChildren().get(0);
         MCRCategoryImpl asia = (MCRCategoryImpl) category.getChildren().get(1);
         MCRCategoryImpl germany = (MCRCategoryImpl) europe.getChildren().getFirst();
-        assertEquals("Did not get Europe as left sibling of Asia", europe.getId(),
-            asia.getLeftSiblingOrParent().getId());
-        assertEquals("Did not get Europa as left sibling or ancestor of Germany", europe.getId(),
-            germany.getLeftSiblingOrParent().getId());
+        assertEquals(europe.getId(), asia.getLeftSiblingOrParent().getId(),
+            "Did not get Europe as left sibling of Asia");
+        assertEquals(europe.getId(), germany.getLeftSiblingOrParent().getId(),
+            "Did not get Europa as left sibling or ancestor of Germany");
     }
 
     @Test
@@ -104,12 +105,12 @@ public class MCRCategoryImplTest extends MCRTestCase {
         MCRCategoryImpl europe = (MCRCategoryImpl) category.getChildren().get(0);
         MCRCategoryImpl asia = (MCRCategoryImpl) category.getChildren().get(1);
         MCRCategoryImpl spain = (MCRCategoryImpl) europe.getChildren().get(3);
-        assertEquals("Did not get Asia as right sibling of Europe", asia.getId(),
-            europe.getRightSiblingOrOfAncestor().getId());
-        assertEquals("Did not get Asia as right sibling or ancestor of Spain", asia.getId(),
-            spain.getRightSiblingOrOfAncestor().getId());
-        assertEquals("Did not get World as right sibling or ancestor of Asia", category.getId(),
-            asia.getRightSiblingOrOfAncestor().getId());
+        assertEquals(asia.getId(), europe.getRightSiblingOrOfAncestor().getId(),
+            "Did not get Asia as right sibling of Europe");
+        assertEquals(asia.getId(), spain.getRightSiblingOrOfAncestor().getId(),
+            "Did not get Asia as right sibling or ancestor of Spain");
+        assertEquals(category.getId(), asia.getRightSiblingOrOfAncestor().getId(),
+            "Did not get World as right sibling or ancestor of Asia");
     }
 
     @Test
@@ -118,16 +119,16 @@ public class MCRCategoryImplTest extends MCRTestCase {
         MCRCategoryImpl europe = (MCRCategoryImpl) category.getChildren().get(0);
         MCRCategoryImpl asia = (MCRCategoryImpl) category.getChildren().get(1);
         MCRCategoryImpl spain = (MCRCategoryImpl) europe.getChildren().get(3);
-        assertEquals("Did not get Asia as right sibling of Europe", asia.getId(),
-            europe.getRightSiblingOrParent().getId());
-        assertEquals("Did not get Europa as right sibling or ancestor of Spain", europe.getId(),
-            spain.getRightSiblingOrParent().getId());
+        assertEquals(asia.getId(), europe.getRightSiblingOrParent().getId(),
+            "Did not get Asia as right sibling of Europe");
+        assertEquals(europe.getId(), spain.getRightSiblingOrParent().getId(),
+            "Did not get Europa as right sibling or ancestor of Spain");
     }
 
     /**
      * @throws URISyntaxException
-     * @throws SAXParseException 
-     * @throws MCRException 
+     * @throws SAXParseException
+     * @throws MCRException
      */
     private void loadWorldClassification() throws URISyntaxException, MCRException, IOException, JDOMException {
         URL worlClassUrl = this.getClass().getResource(WORLD_CLASS_RESOURCE_NAME);

--- a/mycore-base/src/test/java/org/mycore/frontend/MCRURLTest.java
+++ b/mycore-base/src/test/java/org/mycore/frontend/MCRURLTest.java
@@ -18,6 +18,8 @@
 
 package org.mycore.frontend;
 
+import org.junit.jupiter.api.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -25,10 +27,8 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
-import org.mycore.common.MCRTestCase;
 
-public class MCRURLTest extends MCRTestCase {
+public class MCRURLTest {
 
     @Test
     public void getParameter() throws Exception {

--- a/mycore-base/src/test/java/org/mycore/frontend/fileupload/MCRUploadHelperTest.java
+++ b/mycore-base/src/test/java/org/mycore/frontend/fileupload/MCRUploadHelperTest.java
@@ -21,21 +21,19 @@ package org.mycore.frontend.fileupload;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mycore.common.MCRException;
 import org.mycore.common.MCRStreamUtils;
-import org.mycore.common.MCRTestCase;
+import org.mycore.test.MyCoReTest;
 
 /**
  * @author Thomas Scheffler (yagee)
  *
  */
-@RunWith(Parameterized.class)
-public class MCRUploadHelperTest extends MCRTestCase {
+@MyCoReTest
+public class MCRUploadHelperTest {
     static String prefix = "junit";
 
     static String suffix = "test..file";
@@ -49,16 +47,9 @@ public class MCRUploadHelperTest extends MCRTestCase {
     private static final String[] RESERVED_NAMES = { "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8",
         "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9", "con", "nul", "prn", "aux" };
 
-    @Parameter(0)
-    public String path;
-
-    @Parameter(1)
-    public Class<? extends Exception> expectedException;
-
-    @Parameters
-    public static Iterable<Object[]> data() {
+    static Stream<Object[]> testData() {
         return Stream.concat(toParameter(validNames(), null),
-            toParameter(invalidNames(), MCRException.class))::iterator;
+            toParameter(invalidNames(), MCRException.class));
     }
 
     private static Stream<String> invalidNames() {
@@ -81,19 +72,13 @@ public class MCRUploadHelperTest extends MCRTestCase {
         return input.map(s -> new Object[] { s, exp });
     }
 
-    @Test
-    public void checkPathName() {
-        try {
-            MCRUploadHelper.checkPathName(path);
-            if (expectedException != null) {
-                throw new AssertionError(
-                    "Expected test to throw instance of " + expectedException.getName() + " for path=\"" + path + "\"");
-            }
-        } catch (RuntimeException e) {
-            if (expectedException == null || !expectedException.isAssignableFrom(e.getClass())) {
-                throw e;
-            }
+    @ParameterizedTest
+    @MethodSource("testData")
+    public void checkPathName(String path, Class<? extends Exception> expectedException) {
+        if (expectedException == null) {
+            Assertions.assertDoesNotThrow(() -> MCRUploadHelper.checkPathName(path));
+        } else {
+            Assertions.assertThrows(expectedException, () -> MCRUploadHelper.checkPathName(path));
         }
     }
-
 }

--- a/mycore-base/src/test/java/org/mycore/frontend/jersey/resources/MCRJerseyResourceTest.java
+++ b/mycore-base/src/test/java/org/mycore/frontend/jersey/resources/MCRJerseyResourceTest.java
@@ -22,9 +22,9 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Set;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -34,13 +34,13 @@ public class MCRJerseyResourceTest {
 
     private MCRJerseyTestFeature jersey;
 
-    @Before
+    @BeforeEach
     public void setUpJersey() throws Exception {
         jersey = new MCRJerseyTestFeature();
         jersey.setUp(Set.of(TestCase.class));
     }
 
-    @After
+    @AfterEach
     public void tearDownJersey() throws Exception {
         jersey.tearDown();
     }

--- a/mycore-base/src/test/java/org/mycore/frontend/jersey/resources/MCRLocaleResourceTest.java
+++ b/mycore-base/src/test/java/org/mycore/frontend/jersey/resources/MCRLocaleResourceTest.java
@@ -21,29 +21,33 @@ package org.mycore.frontend.jersey.resources;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.mycore.common.MCRTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mycore.common.MCRTestConfiguration;
+import org.mycore.common.MCRTestProperty;
 import org.mycore.frontend.jersey.filter.MCRSessionHookFilter;
 import org.mycore.services.i18n.MCRTranslationTest;
+import org.mycore.test.MyCoReTest;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonParser;
 
 import jakarta.ws.rs.core.MediaType;
 
-public class MCRLocaleResourceTest extends MCRTestCase {
+@MyCoReTest
+@MCRTestConfiguration(
+    properties = {
+        @MCRTestProperty(key = "MCR.Metadata.Languages", string = "de,en,it")
+    })
+public class MCRLocaleResourceTest {
 
     private MCRJerseyTestFeature jersey;
 
-    @Override
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         jersey = new MCRJerseyTestFeature();
         jersey.setUp(Set.of(
             MCRSessionHookFilter.class,
@@ -51,21 +55,9 @@ public class MCRLocaleResourceTest extends MCRTestCase {
         MCRTranslationTest.reInit();
     }
 
-    @Override
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
-        try {
-            jersey.tearDown();
-        } finally {
-            super.tearDown();
-        }
-    }
-
-    @Override
-    protected Map<String, String> getTestProperties() {
-        Map<String, String> map = super.getTestProperties();
-        map.put("MCR.Metadata.Languages", "de,en,it");
-        return map;
+        jersey.tearDown();
     }
 
     @Test

--- a/mycore-base/src/test/java/org/mycore/test/MCRJPAExtension.java
+++ b/mycore-base/src/test/java/org/mycore/test/MCRJPAExtension.java
@@ -1,0 +1,239 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.test;
+
+import static org.mycore.test.MCRJPATestHelper.beginTransaction;
+import static org.mycore.test.MCRJPATestHelper.endTransaction;
+import static org.mycore.test.MCRJPATestHelper.getDefaultSchema;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hibernate.Session;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mycore.backend.hibernate.MCRHibernateConfigHelper;
+import org.mycore.backend.jpa.MCREntityManagerProvider;
+import org.mycore.backend.jpa.MCRJPABootstrapper;
+import org.mycore.backend.jpa.MCRPersistenceProvider;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.Persistence;
+import jakarta.persistence.Query;
+
+/**
+ * JUnit 5 extension for JPA testing in the MyCoRe framework.
+ * <p>
+ * This extension handles the setup and teardown of JPA entities and database transactions
+ * for testing. It creates an in-memory H2 database, sets up the schema, manages transactions,
+ * and cleans up after tests.
+ * <p>
+ * Use this extension with {@code @ExtendWith(MCRJPAExtension.class)} on your test class.
+ */
+public class MCRJPAExtension
+    implements Extension, BeforeEachCallback, AfterEachCallback, AfterAllCallback, BeforeAllCallback {
+    public static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(MCRJPAExtension.class);
+    private static final String SCHEMA_INITIALIZED = "schemaInitialized";
+    private static final Logger LOGGER = LogManager.getLogger();
+    //name of current component or application module under test
+    private String componentName;
+    private EntityManager entityManager;
+
+    public MCRJPAExtension() {
+        this.componentName = MCRTestExtensionConfigurationHelper.detectCurrentComponentName();
+    }
+
+    /**
+     * Initializes JPA configuration before all tests in the class are executed.
+     * Sets up H2 in-memory database properties for the current component.
+     *
+     * @param context the extension context
+     */
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        addJPAProperties(MCRTestExtension.getClassProperties(context));
+    }
+
+    private void addJPAProperties(Map<String, String> classProperties) {
+        String emPropertyPrefix = MCRPersistenceProvider.JPA_PERSISTENCE_UNIT_PROPERTY_NAME + componentName;
+        classProperties.put(emPropertyPrefix + ".Class", "org.mycore.backend.jpa.MCRPersistenceUnitDescriptor");
+        classProperties.put(emPropertyPrefix + ".Properties.jakarta.persistence.jdbc.url", "jdbc:h2:mem:" +
+            componentName);
+        classProperties.put(emPropertyPrefix + ".Properties.jakarta.persistence.jdbc.driver", "org.h2.Driver");
+        classProperties.put(emPropertyPrefix + ".Properties.jakarta.persistence.jdbc.user", "postgres");
+        classProperties.put(emPropertyPrefix + ".Properties.jakarta.persistence.jdbc.password", "junit");
+        classProperties.put(emPropertyPrefix + ".Properties.hibernate.default_schema", "junit");
+        classProperties.put(
+            emPropertyPrefix + ".Properties.hibernate.globally_quoted_identifiers_skip_column_definitions", "true");
+        classProperties.put(emPropertyPrefix + ".Properties.hibernate.globally_quoted_identifiers", "true");
+    }
+
+    /**
+     * Cleans up after all tests in the class have been executed.
+     * Drops the schema unless this is a nested test class.
+     *
+     * @param context the extension context
+     * @throws IOException if cleanup fails
+     */
+    @Override
+    public void afterAll(ExtensionContext context) throws IOException {
+        if (!MCRJunit5ExtensionHelper.isNestedTestClass(context)) {
+            dropSchema();
+            context.getRoot().getStore(NAMESPACE).put(SCHEMA_INITIALIZED, Boolean.FALSE);
+        }
+    }
+
+    /**
+     * Cleans up after each test method.
+     * Ends the transaction, truncates all tables, and closes the EntityManager.
+     *
+     * @param context the extension context
+     */
+    @Override
+    public void afterEach(ExtensionContext context) {
+        try {
+            endTransaction();
+        } finally {
+            if (entityManager != null) {
+                truncateAllTables();
+                entityManager.close();
+            }
+        }
+    }
+
+    /**
+     * Prepares the test environment before each test method.
+     * Initializes JPA if needed and begins a new transaction.
+     *
+     * @param context the extension context
+     * @throws IOException if preparation fails
+     */
+    @Override
+    public void beforeEach(ExtensionContext context) throws IOException {
+        if (!context.getStore(NAMESPACE).getOrDefault(SCHEMA_INITIALIZED, Boolean.class, Boolean.FALSE)
+            || MCREntityManagerProvider.getEntityManagerFactory() == null) {
+            LogManager.getLogger().info("Setup JPA");
+            MCRJPABootstrapper.initializeJPA(componentName);
+            exportSchema();
+            MCRHibernateConfigHelper
+                .checkEntityManagerFactoryConfiguration(MCREntityManagerProvider.getEntityManagerFactory());
+            context.getRoot().getStore(NAMESPACE).put(SCHEMA_INITIALIZED, Boolean.TRUE);
+        }
+
+        try {
+            LogManager.getLogger().debug("Prepare hibernate test", new RuntimeException());
+            entityManager = MCREntityManagerProvider.getCurrentEntityManager();
+            beginTransaction();
+            entityManager.clear();
+        } catch (RuntimeException e) {
+            LogManager.getLogger().error("Error while setting up JPA JUnit test.", e);
+            entityManager = null;
+            throw e;
+        }
+    }
+
+    protected Optional<EntityManager> getEntityManager() {
+        return Optional.ofNullable(entityManager);
+    }
+
+    /**
+     * Truncates all tables in the current schema to clean the database state.
+     * Temporarily disables referential integrity to allow truncating tables with foreign keys.
+     */
+    protected void truncateAllTables() {
+        LOGGER.debug("Truncate all tables");
+        entityManager.unwrap(Session.class).getSessionFactory().getSchemaManager().truncateMappedObjects();
+    }
+
+    /**
+     * Executes schema generation with the specified action.
+     *
+     * @param action the schema generation action ("create" or "drop")
+     * @throws IOException if schema generation fails
+     */
+    private void generateSchema(String action) throws IOException {
+        Map<String, Object> schemaProperties = new HashMap<>();
+        schemaProperties.put("jakarta.persistence.schema-generation.database.action", action);
+        try (StringWriter output = new StringWriter()) {
+            if (LogManager.getLogger().isDebugEnabled()) {
+                schemaProperties.put("jakarta.persistence.schema-generation.scripts.action", action);
+                schemaProperties.put("jakarta.persistence.schema-generation.scripts." + action + "-target", output);
+            }
+            Persistence.generateSchema(componentName, schemaProperties);
+            LogManager.getLogger().debug(() -> "invoked '" + action + "' sql script:\n" + output);
+        }
+    }
+
+    /**
+     * Creates the database schema for testing.
+     *
+     * @throws IOException if schema creation fails
+     */
+    public void exportSchema() throws IOException {
+        executeSQLSchemaOperation(schema -> "create schema " + schema);
+        generateSchema("create");
+    }
+
+    /**
+     * Executes a schema operation like creating or dropping a schema.
+     *
+     * @param schemaFunction a function that takes a schema name and returns an SQL statement
+     */
+    private void executeSQLSchemaOperation(Function<String, String> schemaFunction) {
+        EntityManager currentEntityManager = MCREntityManagerProvider.getCurrentEntityManager();
+        EntityTransaction transaction = currentEntityManager.getTransaction();
+        try {
+            transaction.begin();
+            getDefaultSchema().ifPresent(
+                schemaFunction
+                    .andThen(currentEntityManager::createNativeQuery)
+                    .andThen(Query::executeUpdate)::apply);
+        } finally {
+            if (transaction.isActive()) {
+                if (transaction.getRollbackOnly()) {
+                    transaction.rollback();
+                } else {
+                    transaction.commit();
+                }
+            }
+        }
+    }
+
+    /**
+     * Drops the database schema.
+     *
+     * @throws IOException if schema dropping fails
+     */
+    public void dropSchema() throws IOException {
+        generateSchema("drop");
+        executeSQLSchemaOperation(schema -> "drop schema " + schema);
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/test/MCRJPATestHelper.java
+++ b/mycore-base/src/test/java/org/mycore/test/MCRJPATestHelper.java
@@ -1,0 +1,239 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.test;
+
+import java.io.PrintStream;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hibernate.Session;
+import org.mycore.backend.jpa.MCREntityManagerProvider;
+import org.mycore.common.Table;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.RollbackException;
+
+/**
+ * Helper class for JPA-related testing in the MyCoRe framework.
+ * <p>
+ * This utility class provides methods for database interaction during tests,
+ * including result set printing, schema handling, and SQL execution helpers.
+ * It is designed to work alongside the {@link MCRJPAExtension} for JPA testing.
+ */
+public class MCRJPATestHelper {
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    /**
+     * Prints a ResultSet to the specified PrintStream in a tabular format.
+     *
+     * @param resultSet the ResultSet to print
+     * @param out the PrintStream to print to (e.g., System.out)
+     * @throws SQLException if a database access error occurs
+     */
+    public static void printResultSet(ResultSet resultSet, PrintStream out) throws SQLException {
+        ResultSetMetaData metaData = resultSet.getMetaData();
+        int columns = metaData.getColumnCount();
+        Table t = new Table(columns);
+        for (int i = 1; i <= columns; i++) {
+            t.addValue(metaData.getColumnName(i));
+        }
+        while (resultSet.next()) {
+            for (int i = 1; i <= columns; i++) {
+                String value = resultSet.getString(i);
+                t.addValue(value != null ? value : "null");
+            }
+        }
+        t.print(out);
+    }
+
+    /**
+     * Gets the default schema name from Hibernate properties.
+     * <p>
+     * The schema name will be quoted if Hibernate's globally_quoted_identifiers is enabled.
+     *
+     * @return an Optional containing the schema name or empty if none is defined
+     */
+    public static Optional<String> getDefaultSchema() {
+        return Optional.ofNullable(MCREntityManagerProvider
+            .getEntityManagerFactory()
+            .getProperties()
+            .get("hibernate.default_schema"))
+            .map(Object::toString)
+            .map(schema -> shouldQuoteSchemaIdentifieres() ? '"' + schema + '"' : schema);
+    }
+
+    /**
+     * Determines whether schema identifiers should be quoted based on Hibernate configuration.
+     *
+     * @return true if schema identifiers should be quoted, false otherwise
+     */
+    private static boolean shouldQuoteSchemaIdentifieres() {
+        return Optional.ofNullable(MCREntityManagerProvider
+            .getEntityManagerFactory()
+            .getProperties()
+            .get("hibernate.globally_quoted_identifiers"))
+            .map(Object::toString)
+            .map(Boolean::parseBoolean)
+            .orElse(Boolean.FALSE);
+    }
+
+    /**
+     * Quotes a schema identifier if needed based on JPA configuration.
+     *
+     * @param identifier the schema identifier to quote, for example a column name
+     * @return the quoted schema identifier if needed
+     */
+    public static String quoteSchemaIdentifierIfNeeded(String identifier) {
+        return shouldQuoteSchemaIdentifieres() ? '"' + identifier + '"' : identifier;
+    }
+
+    /**
+     * Gets the fully qualified table name including schema if available.
+     *
+     * @param table the base table name
+     * @return the fully qualified table name with schema if available
+     */
+    public static String getTableName(String table) {
+        String tableName = shouldQuoteSchemaIdentifieres() ? '"' + table + '"' : table;
+        return getDefaultSchema().map(s -> s + ".").orElse("") + tableName;
+    }
+
+    /**
+     * Prints the contents of a database table to System.out.
+     *
+     * @param table the name of the table to print
+     */
+    public static void printTable(String table) {
+        queryTable(table, (resultSet) -> {
+            try {
+                printResultSet(resultSet, System.out);
+            } catch (SQLException e) {
+                LogManager.getLogger().warn("Error while printing result set for table " + table, e);
+            }
+        });
+    }
+
+    public static void queryTable(String table, Consumer<ResultSet> consumer) {
+        executeQuery("SELECT * FROM " + getTableName(table), consumer);
+    }
+
+    private static void executeQuery(String query, Consumer<ResultSet> consumer) {
+        EntityManager em = MCREntityManagerProvider.getCurrentEntityManager();
+        em.unwrap(Session.class).doWork(connection -> {
+            try (Statement statement = connection.createStatement()) {
+                ResultSet resultSet = statement.executeQuery(query);
+                consumer.accept(resultSet);
+            } catch (SQLException e) {
+                LogManager.getLogger().warn("Error while querying '" + query + "'", e);
+            }
+        });
+    }
+
+    /**
+     * Executes a SQL update statement without processing the result.
+     *
+     * @param sql the SQL update statement to execute
+     */
+    public static void executeUpdate(String sql, Object... args) {
+        executeUpdate(sql, (ignore) -> {
+        }, args);
+    }
+
+    /**
+     * Executes a SQL update statement and processes the update count with the provided consumer.
+     *
+     * @param sql the SQL update statement to execute
+     * @param consumer a consumer function that processes the update count
+     */
+    public static void executeUpdate(String sql, Consumer<Integer> consumer, Object... args) {
+        EntityManager em = MCREntityManagerProvider.getCurrentEntityManager();
+        em.unwrap(Session.class).doWork(connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(sql)) {
+                for (int i = 0; i < args.length; i++) {
+                    statement.setObject(i + 1, args[i]);
+                }
+                int updateCount = statement.executeUpdate();
+                consumer.accept(updateCount);
+            } catch (SQLException e) {
+                LogManager.getLogger().warn(() -> "Error while update '" + sql + "'", e);
+            }
+        });
+    }
+
+    /**
+     * Begins a new transaction on the current EntityManager.
+     */
+    public static void beginTransaction() {
+        MCREntityManagerProvider.getCurrentEntityManager().getTransaction().begin();
+    }
+
+    /**
+     * Ends the current transaction on the current EntityManager.
+     * <p>
+     * If the transaction is marked for rollback, it will be rolled back.
+     * If the transaction is active, it will be committed.
+     * If the commit fails, the transaction will be rolled back.
+     *
+     * @throws RollbackException if the transaction commit fails
+     */
+    public static void endTransaction() {
+        EntityManager em = MCREntityManagerProvider.getCurrentEntityManager();
+        EntityTransaction tx = em.getTransaction();
+        if (tx != null && tx.isActive()) {
+            if (tx.getRollbackOnly()) {
+                tx.rollback();
+                LOGGER.debug("Transaction rolled back (was marked for rollback)");
+            } else {
+                try {
+                    tx.commit();
+                    LOGGER.debug("Transaction committed successfully");
+                } catch (RollbackException e) {
+                    LOGGER.error("Transaction commit failed", e);
+                    if (tx.isActive()) {
+                        try {
+                            tx.rollback();
+                        } catch (Exception ex) {
+                            LOGGER.error("Secondary rollback attempt failed", ex);
+                        }
+                    }
+                    throw e;
+                }
+            }
+        }
+    }
+
+    /**
+     * Starts a new transaction and clears the current EntityManager cache.
+     */
+    public static void startNewTransaction() {
+        endTransaction();
+        beginTransaction();
+        // clear from cache
+        MCREntityManagerProvider.getCurrentEntityManager().clear();
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/test/MCRJunit5ExtensionHelper.java
+++ b/mycore-base/src/test/java/org/mycore/test/MCRJunit5ExtensionHelper.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.test;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Helper class for JUnit 5 extensions.
+ */
+public class MCRJunit5ExtensionHelper {
+
+    /**
+     * Check if the current test class is a nested test class.
+     *
+     * @param context the current extension context
+     * @return true if the current test class is a nested test class
+     */
+    public static boolean isNestedTestClass(ExtensionContext context) {
+        Optional<Class<?>> testClass = context.getTestClass();
+        return testClass.map(clazz -> {
+            return clazz.isAnnotationPresent(Nested.class) ||
+                clazz.isMemberClass();
+        }).orElse(false);
+    }
+}

--- a/mycore-base/src/test/java/org/mycore/test/MCRMetadataExtension.java
+++ b/mycore-base/src/test/java/org/mycore/test/MCRMetadataExtension.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;

--- a/mycore-base/src/test/java/org/mycore/test/MCRMetadataExtension.java
+++ b/mycore-base/src/test/java/org/mycore/test/MCRMetadataExtension.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.datamodel.common.MCRXMLMetadataManager;
+
+public class MCRMetadataExtension implements Extension, BeforeAllCallback, BeforeEachCallback,
+    AfterEachCallback, AfterAllCallback {
+
+    private static final String STORE_BASE_DIR_KEY = "MCRMetadataExtension.storeBaseDir";
+    private static final String SVN_BASE_DIR_KEY = "MCRMetadataExtension.svnBaseDir";
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        Path baseDirPath = MCRTestExtensionConfigurationHelper.getBaseDir();
+        if (!baseDirPath.toFile().isDirectory()) {
+            Files.createDirectories(baseDirPath);
+        }
+        // Create temp directories programmatically
+        Path storeBaseDir = Files.createTempDirectory(baseDirPath, "mcr-store-");
+        Path svnBaseDir = Files.createTempDirectory(baseDirPath, "mcr-svn-");
+
+        // Store paths in the extension context store
+        context.getStore(MCRTestExtension.NAMESPACE).put(STORE_BASE_DIR_KEY, storeBaseDir);
+        context.getStore(MCRTestExtension.NAMESPACE).put(SVN_BASE_DIR_KEY, svnBaseDir);
+
+        // Set up properties in class properties
+        Map<String, String> classProperties = MCRTestExtension.getClassProperties(context);
+        classProperties.put("MCR.Metadata.Store.BaseDir", storeBaseDir.toAbsolutePath().toString());
+        classProperties.put("MCR.Metadata.Store.SVNBase", svnBaseDir.toUri().toString());
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        MCRConfiguration2.getSubPropertiesMap("MCR.Metadata.Store.").forEach(
+            (key, value) -> LOGGER.debug("MCR Metadata Store Property: {}={}", key, value));
+        Files.createDirectories(getStoreBaseDir(context));
+        Files.createDirectories(getSvnBaseDir(context));
+        MCRXMLMetadataManager.getInstance().reload();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        // Clean up temp directories
+        Path storeBaseDir = getStoreBaseDir(context);
+        Path svnBaseDir = getSvnBaseDir(context);
+
+        MCRTestHelper.deleteRecursively(storeBaseDir, svnBaseDir);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+    }
+
+    /**
+     * Returns the store base directory.
+     * @param context the current extension context
+     * @return Path to store base directory
+     */
+    public static Path getStoreBaseDir(ExtensionContext context) {
+        return context.getStore(MCRTestExtension.NAMESPACE).get(STORE_BASE_DIR_KEY, Path.class);
+    }
+
+    /**
+     * Returns the SVN base directory.
+     * @param context the current extension context
+     * @return Path to SVN base directory
+     */
+    public static Path getSvnBaseDir(ExtensionContext context) {
+        return context.getStore(MCRTestExtension.NAMESPACE).get(SVN_BASE_DIR_KEY, Path.class);
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/test/MCRMetadataExtension.java
+++ b/mycore-base/src/test/java/org/mycore/test/MCRMetadataExtension.java
@@ -33,8 +33,20 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.datamodel.common.MCRXMLMetadataManager;
 
+/**
+ * JUnit 5 extension for setting up and tearing down the MCR metadata store and SVN directories.
+ * This extension creates temporary directories for the metadata store and SVN base directory,
+ * and cleans them up after each test.
+ *
+ * Sets the following properties in the class properties:
+ * <dl>
+ * <dt><code>MCR.Metadata.Store.BaseDir</code></dt><dd>Path to the metadata store base directory</dd>
+ * <dt><code>MCR.Metadata.Store.SVNBase</code></dt><dd>URI of the SVN base directory</dd>
+ * </dl>
+ *
+ */
 public class MCRMetadataExtension implements Extension, BeforeAllCallback, BeforeEachCallback,
-    AfterEachCallback, AfterAllCallback {
+    AfterEachCallback {
 
     private static final String STORE_BASE_DIR_KEY = "MCRMetadataExtension.storeBaseDir";
     private static final String SVN_BASE_DIR_KEY = "MCRMetadataExtension.svnBaseDir";
@@ -76,10 +88,6 @@ public class MCRMetadataExtension implements Extension, BeforeAllCallback, Befor
         Path svnBaseDir = getSvnBaseDir(context);
 
         MCRTestHelper.deleteRecursively(storeBaseDir, svnBaseDir);
-    }
-
-    @Override
-    public void afterAll(ExtensionContext context) throws Exception {
     }
 
     /**

--- a/mycore-base/src/test/java/org/mycore/test/MCRTestExtension.java
+++ b/mycore-base/src/test/java/org/mycore/test/MCRTestExtension.java
@@ -1,0 +1,181 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mycore.common.MCRSession;
+import org.mycore.common.MCRSessionMgr;
+import org.mycore.common.config.MCRConfigurationBase;
+import org.mycore.common.config.MCRConfigurationLoader;
+
+/**
+ * JUnit 5 extension for MyCoRe tests.
+ * <p>
+ * This extension provides a temporary folder for each test and loads the configuration properties from the
+ * {@link MCRConfigurationLoader}.
+ * </p>
+ */
+public class MCRTestExtension implements Extension, BeforeEachCallback, AfterEachCallback, BeforeAllCallback,
+    AfterAllCallback {
+
+    public static final String CLASS_PROPERTIES_MAP_PROPERTY = "classProperties";
+    private static final String PROPERTIES_MAP_PROPERTY = "properties";
+    private static final String PROPERTIES_LOADED_PROPERTY = "propertiesLoaded";
+    private static final String FIRST_EACH_CALLBACK_PROPERTY = "firstEachCallback";
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public static final ExtensionContext.Namespace NAMESPACE =
+        ExtensionContext.Namespace.create(MCRTestExtension.class);
+
+    private Path testFolder;
+
+    private MCRConfigurationLoader configurationLoader;
+
+    private Map<String, String> mycoreProperties;
+
+    MCRTestExtension() throws IOException {
+        testFolder = createTempDirectory();
+        MCRTestExtensionConfigurationHelper.initializeTestEnvironment(testFolder);
+        configurationLoader = MCRTestExtensionConfigurationHelper.getConfigurationLoader();
+        LOGGER.debug(() -> testFolder);
+        mycoreProperties = new HashMap<>(configurationLoader.load());
+    }
+
+    /**
+     * Prepares property that are defined by the test class.
+     * If a extensions wants to add properties to the configuration, it should use the
+     * {@link #getClassProperties(ExtensionContext)} method to get the properties map.
+     * <p>
+     * The properties are finally collected in the {@link #beforeEach(ExtensionContext)} method.
+     * Class-level properties a cached between the test methods.
+     */
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        Map<String, String> configProperties = getConfigProperties(context);
+        configProperties.putAll(mycoreProperties);
+        configProperties.putAll(MCRTestExtensionConfigurationHelper.getAnnotatedProperties(context));
+        context.getStore(ExtensionContext.Namespace.create(context.getRequiredTestClass()))
+            .put(FIRST_EACH_CALLBACK_PROPERTY, (Runnable) () -> {
+                //collect properties defined by beforeAll of other extensions, see JPATestExtension
+                Map<String, String> classProperties = getClassProperties(context);
+                LOGGER.debug(() -> "Collect extension properties:\n" + classProperties
+                    .entrySet()
+                    .stream()
+                    .map(e -> e.getKey() + ": " + e.getValue())
+                    .reduce((a, b) -> a + "\n" + b)
+                    .orElse(""));
+                configProperties.putAll(classProperties);
+            });
+    }
+
+    private Map<String, String> getConfigProperties(ExtensionContext context) {
+        return context.getRoot().getStore(NAMESPACE)
+            .getOrComputeIfAbsent(MCRTestExtension.PROPERTIES_MAP_PROPERTY, k -> {
+                LOGGER.debug(() -> context.getElement().get() + " creating new properties map");
+                return new HashMap<>();
+            }, Map.class);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws IOException {
+        try {
+            MCRTestHelper.deleteRecursively(testFolder);
+            LogManager.getLogger().debug(() -> "Deleted test folder: " + testFolder);
+        } finally {
+            context.getRoot().getStore(NAMESPACE).put(PROPERTIES_LOADED_PROPERTY, Boolean.FALSE);
+        }
+    }
+
+    /**
+     * Loads the configuration properties from the {@link MCRConfigurationLoader} and the test class
+     * and also applies any properties defined by the test method.
+     * <p>
+     * The current thread is unlocked for MCRSessionMgr.
+     */
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        ExtensionContext.Namespace testClassNS = ExtensionContext.Namespace.create(context.getRequiredTestClass());
+        if (!Boolean.TRUE
+            .equals(context.getParent().get().getStore(testClassNS).get(PROPERTIES_LOADED_PROPERTY, Boolean.class))) {
+            LOGGER.debug("First each callback");
+            Runnable firstEachCallback =
+                context.getStore(testClassNS).get(FIRST_EACH_CALLBACK_PROPERTY, Runnable.class);
+            firstEachCallback.run();
+            context.getParent().get().getStore(testClassNS).put(PROPERTIES_LOADED_PROPERTY, Boolean.TRUE);
+        }
+        HashMap<String, String> combinedProperties = new HashMap<>(getConfigProperties(context));
+        Map<String, String> annotatedProperties = MCRTestExtensionConfigurationHelper.getAnnotatedProperties(context);
+        combinedProperties.putAll(annotatedProperties);
+        MCRConfigurationBase.initialize(configurationLoader.loadDeprecated(), combinedProperties, true);
+        MCRSessionMgr.unlock();
+    }
+
+    /**
+     * Closes the current session and locks the current thread for MCRSessionMgr.
+     *
+     * @see MCRTestExtensionConfigurationHelper#resetConfiguration(MCRConfigurationLoader, Map)
+     */
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        if (MCRSessionMgr.hasCurrentSession()) {
+            MCRSession currentSession = MCRSessionMgr.getCurrentSession();
+            MCRSessionMgr.releaseCurrentSession();
+            currentSession.close();
+            MCRSessionMgr.lock();
+        }
+        MCRTestExtensionConfigurationHelper.resetConfiguration(configurationLoader, getConfigProperties(context));
+    }
+
+    /**
+     * Returns a map of properties that could be enhanced by other extensions in
+     * {@link BeforeAllCallback#beforeAll(ExtensionContext)}.
+     *
+     * @param context the current extension context
+     * @return the properties map for the current test class
+     */
+    public static Map<String, String> getClassProperties(ExtensionContext context) {
+        //check if context is for a class
+        if (context.getTestMethod().isPresent()) {
+            throw new IllegalStateException("This method should only be called for class-level extensions.");
+        }
+        return context.getRoot().getStore(NAMESPACE)
+            .getOrComputeIfAbsent(MCRTestExtension.CLASS_PROPERTIES_MAP_PROPERTY, k -> {
+                LOGGER.debug("Creating empty extension properties");
+                return new HashMap<>();
+            }, Map.class);
+    }
+
+    private Path createTempDirectory() throws IOException {
+        return Files.createTempDirectory("junit-");
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/test/MCRTestExtensionConfigurationHelper.java
+++ b/mycore-base/src/test/java/org/mycore/test/MCRTestExtensionConfigurationHelper.java
@@ -1,0 +1,172 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.LogManager;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mycore.common.MCRTestConfiguration;
+import org.mycore.common.MCRTestProperty;
+import org.mycore.common.config.MCRComponent;
+import org.mycore.common.config.MCRConfigurationBase;
+import org.mycore.common.config.MCRConfigurationLoader;
+import org.mycore.common.config.MCRConfigurationLoaderFactory;
+import org.mycore.common.config.MCRRuntimeComponentDetector;
+import org.mycore.common.xsl.MCRParameterCollector;
+
+public class MCRTestExtensionConfigurationHelper {
+
+    public static final String MCR_HOME_PROPERTY = "MCR.Home";
+    public static final String MCR_APP_NAME_PROPERTY = "MCR.AppName";
+
+    static void initializeTestEnvironment(Path junitFolder) throws IOException {
+        if (junitFolder == null) {
+            throw new IllegalArgumentException("junitFolder must not be null");
+        }
+        if (System.getProperties().getProperty(MCR_HOME_PROPERTY) == null) {
+            Path baseDir = junitFolder.resolve("mcrhome");
+            Files.createDirectories(baseDir);
+            System.out.println("Setting MCR.Home=" + baseDir.toAbsolutePath().toString());
+            System.getProperties().setProperty(MCR_HOME_PROPERTY, baseDir.toAbsolutePath().toString());
+        }
+        if (System.getProperties().getProperty(MCR_APP_NAME_PROPERTY) == null) {
+            String currentComponentName = detectCurrentComponentName();
+            System.out.println("Setting MCR.AppName=" + currentComponentName);
+            System.getProperties().setProperty(MCR_APP_NAME_PROPERTY, detectCurrentComponentName());
+        }
+        Path mcrHome = getMCRHomeDirPath();
+        Path configDir = mcrHome.resolve(System.getProperty(MCR_APP_NAME_PROPERTY));
+        System.out.println("Creating config directory: " + configDir);
+        Files.createDirectories(configDir);
+    }
+
+    /**
+     * Clears the cache and reloads the configuration from the loader.
+     *
+     * @param configurationLoader The loader to use for loading configuration
+     * @param baseProperties class-level configuration properties
+     */
+    static void resetConfiguration(MCRConfigurationLoader configurationLoader, Map<String, String> baseProperties) {
+        MCRParameterCollector.clearCache();
+        LogManager.getLogger().info("Reloading configuration");
+        MCRConfigurationBase.initialize(configurationLoader.loadDeprecated(), baseProperties, true);
+    }
+
+    private static Path getMCRHomeDirPath() {
+        Path mcrHome = null;
+        try {
+            URI homeUri = new URI(System.getProperty(MCR_HOME_PROPERTY));
+            if (homeUri.isAbsolute()) {
+                mcrHome = Paths.get(homeUri);
+            }
+        } catch (URISyntaxException e) {
+            //fallback to default later
+        }
+        if (mcrHome == null) {
+            mcrHome = Paths.get(System.getProperty(MCR_HOME_PROPERTY));
+        }
+        return mcrHome;
+    }
+
+    static Map<String, String> getAnnotatedProperties(ExtensionContext extensionContext) {
+        return findTestConfiguration(extensionContext).stream()
+            .flatMap(conf -> Stream.of(conf.properties()))
+            .collect(Collectors.toMap(
+                MCRTestProperty::key,
+                p -> {
+                    if (p.empty()) {
+                        return "";
+                    }
+                    if (!p.classNameOf().equals(Void.class)) {
+                        return p.classNameOf().getName();
+                    }
+                    return p.string();
+                },
+                (sub, sup) -> sub));
+    }
+
+    private static List<MCRTestConfiguration> findTestConfiguration(ExtensionContext context) {
+        return context.getElement()
+            .map(element -> {
+                // If the element is a method, first check the method itself
+                if (element instanceof java.lang.reflect.Method method) {
+                    return Optional.ofNullable(method.getAnnotation(MCRTestConfiguration.class))
+                        .map(List::of)
+                        .orElseGet(List::of);
+                } else if (element instanceof Class<?>) {
+                    // If the element is a class, traverse its hierarchy
+                    return findTestConfigurationInHierarchy((Class<?>) element);
+                }
+                return List.<MCRTestConfiguration>of();
+            })
+            .orElseGet(List::of);
+    }
+
+    // Traverse the class hierarchy to find @MyAnnotation on the class or any of its superclasses.
+    private static List<MCRTestConfiguration> findTestConfigurationInHierarchy(Class<?> clazz) {
+        List<MCRTestConfiguration> annotations = new ArrayList<>();
+        for (Class<?> current = clazz; current != null; current = current.getSuperclass()) {
+            MCRTestConfiguration annotation = current.getAnnotation(MCRTestConfiguration.class);
+            if (annotation != null) {
+                annotations.add(annotation);
+            }
+        }
+        return annotations;
+    }
+
+    static MCRConfigurationLoader getConfigurationLoader() {
+        System.setProperty("MCRRuntimeComponentDetector.underTesting", detectCurrentComponentName());
+        String mcrComp = MCRRuntimeComponentDetector.getMyCoReComponents().stream().map(MCRComponent::toString).collect(
+            Collectors.joining(", "));
+        String appMod = MCRRuntimeComponentDetector.getApplicationModules()
+            .stream()
+            .map(MCRComponent::toString)
+            .collect(Collectors.joining(", "));
+        System.out.printf("MyCoRe components detected: %s\nApplications modules detected: %s\n",
+            mcrComp.isEmpty() ? "'none'" : mcrComp, appMod.isEmpty() ? "'none'" : appMod);
+        MCRConfigurationLoader configurationLoader = MCRConfigurationLoaderFactory.getConfigurationLoader();
+        return configurationLoader;
+    }
+
+    static String detectCurrentComponentName() {
+        String userDir = System.getProperty("user.dir");
+        return Paths.get(userDir).getFileName().toString();
+    }
+
+    public static Path getBaseDir() {
+        String baseDir = System.getProperties().getProperty(MCRTestExtensionConfigurationHelper.MCR_HOME_PROPERTY);
+        if (baseDir == null || baseDir.isEmpty()) {
+            throw new IllegalStateException(MCRTestExtensionConfigurationHelper.MCR_HOME_PROPERTY + " must be set");
+        }
+        return Paths.get(baseDir);
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/test/MCRTestHelper.java
+++ b/mycore-base/src/test/java/org/mycore/test/MCRTestHelper.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Helper class for tests.
+ */
+public class MCRTestHelper {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    /**
+     * Deletes the given paths recursively.
+     *
+     * @param paths the paths to delete
+     * @throws IOException if a file or directory could not be deleted
+     */
+    public static void deleteRecursively(Path... paths) throws IOException {
+        //use deleteRecursively(Path path) method and ensure that all exceptions are thrown as suppressed exceptions
+        List<Exception> suppressed = new ArrayList<>();
+        for (Path path : paths) {
+            try {
+                deleteRecursively(path);
+            } catch (Exception e) {
+                suppressed.add(e);
+            }
+        }
+        if (!suppressed.isEmpty()) {
+            if (suppressed.size() == 1 && suppressed.getFirst() instanceof IOException ioe) {
+                throw ioe;
+            }
+            IOException mainIOException = new IOException("Error deleting: " + Arrays.toString(paths));
+            suppressed.forEach(mainIOException::addSuppressed);
+            throw mainIOException;
+        }
+    }
+
+    /**
+     * Deletes the given path recursively.
+     *
+     * @param path the path to delete
+     * @throws IOException if a file or directory could not be deleted
+     */
+    private static void deleteRecursively(Path path) throws IOException {
+
+        if (path == null || !Files.exists(path)) {
+            return;
+        }
+
+        List<IOException> suppressed = new ArrayList<>();
+        try (Stream<Path> pathStream = Files.walk(path)) {
+            pathStream
+                .sorted(Comparator.reverseOrder())
+                .forEach(p -> {
+                    try {
+                        LOGGER.debug(() -> "Deleting: " + p);
+                        Files.delete(p);
+                    } catch (IOException e) {
+                        suppressed.add(e);
+                    }
+                });
+        } catch (IOException e) {
+            suppressed.add(e);
+        }
+        if (!suppressed.isEmpty()) {
+            if (suppressed.size() == 1) {
+                throw suppressed.getFirst();
+            }
+            IOException mainIOException = new IOException("Error deleting: " + path);
+            suppressed.forEach(mainIOException::addSuppressed);
+            throw mainIOException;
+        }
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/test/MyCoReTest.java
+++ b/mycore-base/src/test/java/org/mycore/test/MyCoReTest.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MCRTestExtension.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Tag("org.mycore.test.MyCoReTest")
+public @interface MyCoReTest {
+}

--- a/mycore-base/src/test/java/org/mycore/test/tests/MCRJPAExtensionTest.java
+++ b/mycore-base/src/test/java/org/mycore/test/tests/MCRJPAExtensionTest.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.test.tests;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mycore.backend.jpa.MCREntityManagerProvider;
+import org.mycore.test.MCRJPAExtension;
+import org.mycore.test.MyCoReTest;
+
+@MyCoReTest
+@ExtendWith(MCRJPAExtension.class)
+public class MCRJPAExtensionTest {
+
+    @Test
+    public void testEntityManagerAvailable() {
+        Assertions.assertNotNull(MCREntityManagerProvider.getCurrentEntityManager(),
+            "EntityManager should be available");
+    }
+
+    @Nested
+    class MCRJPAExtensionTest1 {
+        @Test
+        public void testEntityManagerAvailableInNested() {
+            Assertions.assertNotNull(MCREntityManagerProvider.getCurrentEntityManager(),
+                "EntityManager should be available");
+        }
+    }
+}

--- a/mycore-base/src/test/java/org/mycore/test/tests/MCRMetadataExtensionTest.java
+++ b/mycore-base/src/test/java/org/mycore/test/tests/MCRMetadataExtensionTest.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.test.tests;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mycore.common.MCRTestConfiguration;
+import org.mycore.common.MCRTestProperty;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.datamodel.common.MCRXMLMetadataManager;
+import org.mycore.datamodel.metadata.MCRObjectID;
+import org.mycore.test.MCRJPAExtension;
+import org.mycore.test.MCRMetadataExtension;
+import org.mycore.test.MyCoReTest;
+
+@MyCoReTest
+@ExtendWith(MCRJPAExtension.class)
+@ExtendWith(MCRMetadataExtension.class)
+@MCRTestConfiguration(
+    properties = {
+        @MCRTestProperty(key = "MCR.Metadata.Type.test", string = "true")
+    })
+public class MCRMetadataExtensionTest {
+
+    @Test
+    public void testXMLMetadataManagerAvailable() {
+        Path storeBaseDir = MCRConfiguration2.getOrThrow("MCR.Metadata.Store.BaseDir", Paths::get);
+        System.out.println("Store BaseDir=" + storeBaseDir.toAbsolutePath());
+        Assertions.assertTrue(Files.isDirectory(storeBaseDir), "Store base dir should be a directory");
+        Assertions.assertTrue(storeBaseDir.getFileName().toString().startsWith("mcr-store"),
+            "Store base dir should start with 'mcr-store'");
+        Assertions.assertFalse(
+            MCRXMLMetadataManager.getInstance().exists(MCRObjectID.getInstance("MyCoRe_test_00004711")),
+            "MCRXMLMetadataManager should be available but the object should not exist");
+    }
+
+    @Nested
+    class MCRMetadataExtensionTest1 {
+        @Test
+        public void testXMLMetadataManagerAvailableInNested() {
+            testXMLMetadataManagerAvailable();
+        }
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/test/tests/MCRTestExtensionTest.java
+++ b/mycore-base/src/test/java/org/mycore/test/tests/MCRTestExtensionTest.java
@@ -61,7 +61,8 @@ public class MCRTestExtensionTest {
     @MCRTestConfiguration(
         properties = {
             @MCRTestProperty(key = "foo", string = "foo"),
-            @MCRTestProperty(key = "bar", string = "bar")
+            @MCRTestProperty(key = "bar", string = "bar"),
+            @MCRTestProperty(key = "hello", classNameOf = SayHello.class)
         })
     class MCRTestExtensionTest1 {
         @Test
@@ -78,12 +79,25 @@ public class MCRTestExtensionTest {
             Assertions.assertEquals("foo2", MCRConfiguration2.getStringOrThrow("foo2"));
         }
 
+        @Test
+        public void testSayHello() {
+            //Checks implementation of the class SayHello or subclasses.
+            MCRConfiguration2.getInstanceOf(SayHello.class, "hello").ifPresent(sayHello -> {
+                String name = "Junit";
+                String helloResponse = sayHello.sayHello(name);
+                Assertions.assertNotNull(helloResponse, "Hello response should not be null");
+                System.out.println(helloResponse);
+                Assertions.assertTrue(helloResponse.contains(name),
+                    "Could not find name '" + name + "' in response: " + helloResponse);
+            });
+        }
     }
 
     @Nested
     @MCRTestConfiguration(
         properties = {
-            @MCRTestProperty(key = "bar", string = "foo")
+            @MCRTestProperty(key = "bar", string = "foo"),
+            @MCRTestProperty(key = "hello", classNameOf = SagHallo.class)
         })
     class MCRTestExtensionTest2 extends MCRTestExtensionTest1 {
         @Test
@@ -96,4 +110,18 @@ public class MCRTestExtensionTest {
             Assertions.assertEquals("foo", MCRConfiguration2.getStringOrThrow("bar"));
         }
     }
+
+    public static class SayHello {
+        public String sayHello(String name) {
+            return "Hello " + name + "!";
+        }
+    }
+
+    public static class SagHallo extends SayHello {
+        @Override
+        public String sayHello(String name) {
+            return "Hallo " + name + "!";
+        }
+    }
+
 }

--- a/mycore-base/src/test/java/org/mycore/test/tests/MCRTestExtensionTest.java
+++ b/mycore-base/src/test/java/org/mycore/test/tests/MCRTestExtensionTest.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.test.tests;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mycore.common.MCRTestConfiguration;
+import org.mycore.common.MCRTestProperty;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.common.config.MCRConfigurationBase;
+import org.mycore.common.config.MCRConfigurationException;
+import org.mycore.test.MyCoReTest;
+
+@MyCoReTest
+public class MCRTestExtensionTest {
+
+    @Test
+    public void testPropertyFromFile() {
+        Assertions.assertEquals("MyCoRe", MCRConfiguration2.getStringOrThrow("MCR.NameOfProject"));
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "junit", classNameOf = MCRTestExtensionTest.class)
+        })
+    public void testClassValue() {
+        Assertions.assertEquals(MCRTestExtensionTest.class.getName(), MCRConfiguration2.getStringOrThrow("junit"));
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "junit", empty = true)
+        })
+    public void testEmptyValue() {
+        Assertions.assertTrue(MCRConfigurationBase.getString("junit").isPresent());
+        Assertions.assertTrue(MCRConfigurationBase.getString("junit").get().isEmpty());
+        Assertions.assertThrowsExactly(MCRConfigurationException.class,
+            () -> MCRConfiguration2.getStringOrThrow("junit"));
+    }
+
+    @Nested
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "foo", string = "foo"),
+            @MCRTestProperty(key = "bar", string = "bar")
+        })
+    class MCRTestExtensionTest1 {
+        @Test
+        public void testClassProperty() {
+            Assertions.assertEquals("foo", MCRConfiguration2.getStringOrThrow("foo"));
+        }
+
+        @Test
+        @MCRTestConfiguration(
+            properties = {
+                @MCRTestProperty(key = "foo2", string = "foo2")
+            })
+        public void testMethodProperty() {
+            Assertions.assertEquals("foo2", MCRConfiguration2.getStringOrThrow("foo2"));
+        }
+
+    }
+
+    @Nested
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "bar", string = "foo")
+        })
+    class MCRTestExtensionTest2 extends MCRTestExtensionTest1 {
+        @Test
+        public void testClassProperty() {
+            Assertions.assertEquals("foo", MCRConfiguration2.getStringOrThrow("foo"));
+        }
+
+        @Test
+        public void testClassPropertyOverwrite() {
+            Assertions.assertEquals("foo", MCRConfiguration2.getStringOrThrow("bar"));
+        }
+    }
+}

--- a/mycore-ifs/pom.xml
+++ b/mycore-ifs/pom.xml
@@ -39,10 +39,6 @@
       <artifactId>h2</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
     </dependency>
@@ -54,6 +50,11 @@
       <groupId>org.mycore</groupId>
       <artifactId>mycore-base</artifactId>
       <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/mycore-ifs/src/test/java/org/mycore/common/MCRDerivateTest.java
+++ b/mycore-ifs/src/test/java/org/mycore/common/MCRDerivateTest.java
@@ -18,7 +18,8 @@
 
 package org.mycore.common;
 
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.mycore.datamodel.metadata.MCRDerivate;
 import org.mycore.datamodel.metadata.MCRMetadataManager;
 import org.mycore.datamodel.metadata.MCRObject;
@@ -37,11 +38,10 @@ public class MCRDerivateTest extends MCRIFSTest {
         MCRMetadataManager.create(derivate);
     }
 
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         MCRMetadataManager.delete(derivate);
         MCRMetadataManager.delete(root);
-        super.tearDown();
     }
 
 }

--- a/mycore-ifs/src/test/java/org/mycore/common/MCRFileNameCheckTest.java
+++ b/mycore-ifs/src/test/java/org/mycore/common/MCRFileNameCheckTest.java
@@ -18,11 +18,13 @@
 
 package org.mycore.common;
 
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mycore.access.MCRAccessException;
 import org.mycore.datamodel.metadata.MCRDerivate;
 import org.mycore.datamodel.metadata.MCRMetadataManager;
@@ -33,7 +35,7 @@ public class MCRFileNameCheckTest extends MCRIFSTest {
 
     private MCRDerivate derivate;
 
-    @Before
+    @BeforeEach
     public void setup() throws MCRAccessException {
         MCRObject root = createObject();
         derivate = createDerivate(root.getId());
@@ -41,22 +43,22 @@ public class MCRFileNameCheckTest extends MCRIFSTest {
         MCRMetadataManager.create(derivate);
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void checkIllegalWindowsFileName() throws IOException {
         final MCRPath aux = MCRPath.getPath(derivate.toString(), "aux");
-        Files.createFile(aux);
+        assertThrowsExactly(IOException.class, () -> Files.createFile(aux));
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void checkIllegalFileName() throws IOException {
         final MCRPath info = MCRPath.getPath(derivate.toString(), "info@mycore.de");
-        Files.createFile(info);
+        assertThrowsExactly(IOException.class, () -> Files.createFile(info));
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void checkIllegalDirectoryName() throws IOException {
         final MCRPath dirName = MCRPath.getPath(derivate.toString(), "Nur ein \"Test\"");
-        Files.createDirectory(dirName);
+        assertThrowsExactly(IOException.class, () -> Files.createDirectory(dirName));
     }
 
 }

--- a/mycore-ifs/src/test/java/org/mycore/common/MCRIFSTest.java
+++ b/mycore-ifs/src/test/java/org/mycore/common/MCRIFSTest.java
@@ -18,42 +18,51 @@
 
 package org.mycore.common;
 
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mycore.access.MCRAccessBaseImpl;
 import org.mycore.access.strategies.MCRAccessCheckStrategy;
 import org.mycore.common.events.MCREvent;
 import org.mycore.common.events.MCREventManager;
+import org.mycore.datamodel.common.MCRLinkTableInterface;
 import org.mycore.datamodel.common.MCRXMLMetadataEventHandler;
+import org.mycore.datamodel.ifs2.MCRMetadataStore;
 import org.mycore.datamodel.metadata.MCRDerivate;
 import org.mycore.datamodel.metadata.MCRMetaIFS;
 import org.mycore.datamodel.metadata.MCRMetaLinkID;
 import org.mycore.datamodel.metadata.MCRMetadataManager;
 import org.mycore.datamodel.metadata.MCRObject;
 import org.mycore.datamodel.metadata.MCRObjectID;
+import org.mycore.test.MCRMetadataExtension;
+import org.mycore.test.MyCoReTest;
 
-public abstract class MCRIFSTest extends MCRStoreTestCase {
+@MyCoReTest
+@ExtendWith(MCRMetadataExtension.class)
+@MCRTestConfiguration(
+    properties = {
+        @MCRTestProperty(key = "MCR.Metadata.Type.object", string = "true"),
+        @MCRTestProperty(key = "MCR.Metadata.Type.derivate", string = "true"),
+        @MCRTestProperty(key = "MCR.Access.Class", classNameOf = MCRAccessBaseImpl.class),
+        @MCRTestProperty(key = "MCR.Access.Strategy.Class", classNameOf = MCRIFSTest.AlwaysTrueStrategy.class),
+        @MCRTestProperty(key = "MCR.Persistence.LinkTable.Store.Class",
+            classNameOf = MCRIFSTest.FakeLinkTableStore.class),
+        @MCRTestProperty(key = "MCR.Metadata.Store.DefaultClass", classNameOf = MCRMetadataStore.class)
+    })
+public abstract class MCRIFSTest {
 
-    @Override
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    @TempDir
+    static Path tempDir;
+
+    @BeforeEach
+    public void prepareEventHandler() throws Exception {
         MCREventManager.getInstance().clear().addEventHandler(MCREvent.ObjectType.OBJECT,
             new MCRXMLMetadataEventHandler());
-    }
-
-    @Override
-    protected Map<String, String> getTestProperties() {
-        Map<String, String> testProperties = super.getTestProperties();
-        testProperties.put("MCR.datadir", "%MCR.basedir%/data");
-        testProperties
-            .put("MCR.Persistence.LinkTable.Store.Class", "org.mycore.backend.hibernate.MCRHIBLinkTableStore");
-        testProperties.put("MCR.Access.Class", MCRAccessBaseImpl.class.getName());
-        testProperties.put("MCR.Access.Strategy.Class", AlwaysTrueStrategy.class.getName());
-        testProperties.put("MCR.Metadata.Type.object", "true");
-        testProperties.put("MCR.Metadata.Type.derivate", "true");
-        return testProperties;
     }
 
     public static MCRObject createObject() {
@@ -84,6 +93,38 @@ public abstract class MCRIFSTest extends MCRStoreTestCase {
             return true;
         }
 
+    }
+
+    public static class FakeLinkTableStore implements MCRLinkTableInterface {
+        @Override
+        public void create(String from, String to, String type, String attr) {
+
+        }
+
+        @Override
+        public void delete(String from, String to, String type) {
+
+        }
+
+        @Override
+        public int countTo(String fromtype, String to, String type, String restriction) {
+            return 0;
+        }
+
+        @Override
+        public Map<String, Number> getCountedMapOfMCRTO(String mcrtoPrefix) {
+            return Map.of();
+        }
+
+        @Override
+        public Collection<String> getSourcesOf(String to, String type) {
+            return List.of();
+        }
+
+        @Override
+        public Collection<String> getDestinationsOf(String from, String type) {
+            return List.of();
+        }
     }
 
 }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3349).

Adds support for JUnit with `@MyCoReTest` annotation and JUnit extensions `MCRJPAExtension` and `MCRMetadataExtension`. For reference a few JUnit 4 test are already migrated to Junit 5 using annotations instead of inheritance from `MCRTestCase`.

Documentation is handled by https://github.com/MyCoRe-Org/mycore-website/pull/90 