### PR TITLE
MCR-3373 fix neo4j display for classifications/string lists

### DIFF
--- a/mycore-neo4j/src/main/java/org/mycore/mcr/neo4j/utils/MCRNeo4JQueryRunner.java
+++ b/mycore-neo4j/src/main/java/org/mycore/mcr/neo4j/utils/MCRNeo4JQueryRunner.java
@@ -18,8 +18,15 @@
 
 package org.mycore.mcr.neo4j.utils;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import static org.mycore.mcr.neo4j.datamodel.metadata.neo4jutil.MCRNeo4JConstants.NEO4J_PARAMETER_SEPARATOR;
+import static org.mycore.mcr.neo4j.datamodel.metadata.neo4jutil.MCRNeo4JUtil.getClassificationLabel;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -37,14 +44,8 @@ import org.neo4j.driver.types.Node;
 import org.neo4j.driver.types.Path;
 import org.neo4j.driver.types.Relationship;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.mycore.mcr.neo4j.datamodel.metadata.neo4jutil.MCRNeo4JConstants.NEO4J_PARAMETER_SEPARATOR;
-import static org.mycore.mcr.neo4j.datamodel.metadata.neo4jutil.MCRNeo4JUtil.getClassificationLabel;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 public class MCRNeo4JQueryRunner {
 
@@ -170,7 +171,7 @@ public class MCRNeo4JQueryRunner {
      * if key is longer than 3 chars and ends with _xy checks if xy equals lang, if true translate else skip this key
      * else case: translate value with corresponding lang
      *
-     * @param map  key-value-pairs, translate the values
+     * @param map key-value-pairs, translate the values
      * @param lang MyCore Language short notation
      * @return List of translated Neo4JMetaData Objects
      */

--- a/mycore-neo4j/src/test/java/org/mycore/mcr/neo4j/utils/MCRNeo4JQueryRunnerTest.java
+++ b/mycore-neo4j/src/test/java/org/mycore/mcr/neo4j/utils/MCRNeo4JQueryRunnerTest.java
@@ -1,0 +1,75 @@
+package org.mycore.mcr.neo4j.utils;
+
+import org.junit.Test;
+import org.mycore.common.MCRStoreTestCase;
+import org.mycore.common.util.MCRTestCaseClassificationUtil;
+import org.mycore.mcr.neo4j.datamodel.metadata.neo4jtojson.Neo4JMetaData;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class MCRNeo4JQueryRunnerTest extends MCRStoreTestCase {
+    @Test
+    public void testTranslateAndMapProperties() {
+        final List<Neo4JMetaData> metaDataList = new ArrayList<>();
+
+        MCRNeo4JQueryRunner.translateAndMapProperties(metaDataList, "key", List.of("value1", "value2"), "de");
+        assertFalse(metaDataList.isEmpty());
+        assertEquals(1, metaDataList.size());
+        assertEquals("key", metaDataList.get(0).title());
+        assertEquals("value1", metaDataList.get(0).content().get(0));
+        assertEquals("value2", metaDataList.get(0).content().get(1));
+        assertEquals(2, metaDataList.get(0).content().size());
+
+        metaDataList.clear();
+        MCRNeo4JQueryRunner.translateAndMapProperties(metaDataList, "key", List.of("value1"), "de");
+        assertFalse(metaDataList.isEmpty());
+        assertEquals(1, metaDataList.size());
+        assertEquals("key", metaDataList.get(0).title());
+        assertEquals("value1", metaDataList.get(0).content().get(0));
+        assertEquals(1, metaDataList.get(0).content().size());
+
+        metaDataList.clear();
+        MCRNeo4JQueryRunner.translateAndMapProperties(metaDataList, "key", List.of("TestClassification_-_junit_1"),
+            "de");
+        assertFalse(metaDataList.isEmpty());
+        assertEquals(1, metaDataList.size());
+        assertEquals("key", metaDataList.get(0).title());
+        assertEquals("junit_1 (de)", metaDataList.get(0).content().get(0));
+        assertEquals(1, metaDataList.get(0).content().size());
+
+        metaDataList.clear();
+        MCRNeo4JQueryRunner.translateAndMapProperties(metaDataList, "key",
+            List.of("TestClassification_-_junit_1", "TestClassification_-_junit_2"),
+            "de");
+        assertFalse(metaDataList.isEmpty());
+        assertEquals(1, metaDataList.size());
+        assertEquals("key", metaDataList.get(0).title());
+        assertEquals("junit_1 (de)", metaDataList.get(0).content().get(0));
+        // second category has no de label
+        assertEquals("", metaDataList.get(0).content().get(1));
+        assertEquals(2, metaDataList.get(0).content().size());
+
+        // check for English labels
+        metaDataList.clear();
+        MCRNeo4JQueryRunner.translateAndMapProperties(metaDataList, "key",
+            List.of("TestClassification_-_junit_1", "TestClassification_-_junit_2"),
+            "en");
+        assertFalse(metaDataList.isEmpty());
+        assertEquals(1, metaDataList.size());
+        assertEquals("key", metaDataList.get(0).title());
+        assertEquals("junit_1 (en)", metaDataList.get(0).content().get(0));
+        assertEquals("junit_2 (en)", metaDataList.get(0).content().get(1));
+        assertEquals(2, metaDataList.get(0).content().size());
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        MCRTestCaseClassificationUtil.addClassification("/classification/TestClassification.xml");
+    }
+}


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3373).


Neo4J display does not work properly with multiple categories as node labels and ignores string-lists with size of 1 when no category is used.