### PR TITLE
update maven cache handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout
@@ -52,6 +52,14 @@ jobs:
 
         # Selenium wants to run non-ESR FF
         firefox --version
+
+        # Geckodriver
+        find ${GECKOWEBDRIVER}
+
+        # Chromedriver
+        find ${CHROMEWEBDRIVER}
+
+        echo $PATH
 
         ~/geckodriver/geckodriver --version
         echo "${HOME}/geckodriver" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,8 @@ jobs:
 
     - name: Build
       run: |
-        export $(dbus-launch)
-        mkdir ~/tmp
-        export TMPDIR=~/tmp
+        mkdir ${{ runner.temp }}/${{ github.run_id }}.tmp
+        export TMPDIR=${{ runner.temp }}/${{ github.run_id }}.tmp
         export FIREFOX_BIN=$(which firefox)
         export SELENIUM_BROWSER=firefox
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on: [ push, pull_request ]
 
 env:
   MAVEN_OPTS: -Xmx1024M -Xss128M
-  GECKODRIVER_VERSION: 0.27.0
 
 jobs:
   build:
@@ -21,48 +20,21 @@ jobs:
         distribution: temurin
         cache: 'maven'
 
-    - name: Fetch Geckodriver cache
-      id: geckodriver-cache
-      uses: actions/cache@v4
-      with:
-        path: ~/geckodriver
-        key: ${{ env.GECKODRIVER_VERSION }}
-
-    - name: Fetch Geckodriver
-      if: steps.geckodriver-cache.outputs.cache-hit != 'true'
-      run: |
-        mkdir ~/geckodriver
-        curl -L https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz | \
-          tar -C ~/geckodriver/ -xzvf-
-
-    - name: Install Firefox ESR
-      uses: browser-actions/setup-firefox@v1
-      with:
-        firefox-version: 'latest-esr'
-
-    - name: Install Chrome (stable)
-      uses: browser-actions/setup-chrome@v1
-      with:
-        chrome-version: 'stable'
-        install-chromedriver: true
-
     - name: Set up test dependencies
       run: |
-        sudo apt install dbus-x11
-
-        # Selenium wants to run non-ESR FF
         firefox --version
 
         # Geckodriver
-        find ${GECKOWEBDRIVER}
+        echo ${GECKOWEBDRIVER} >> $GITHUB_PATH
 
         # Chromedriver
-        find ${CHROMEWEBDRIVER}
+        echo ${CHROMEWEBDRIVER} >> $GITHUB_PATH
 
         echo $PATH
 
-        ~/geckodriver/geckodriver --version
-        echo "${HOME}/geckodriver" >> $GITHUB_PATH
+        cat /proc/cpuinfo
+
+        ${GECKOWEBDRIVER}/geckodriver --version
 
     - name: Build
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         echo "${HOME}/geckodriver" >> $GITHUB_PATH
 
     - name: Restore Maven cache
-      uses: skjolber/maven-cache-github-action@v1
+      uses: skjolber/maven-cache-github-action@v3.1.1
       with:
         step: restore
 
@@ -82,6 +82,6 @@ jobs:
           ./**/*test.log
 
     - name: Save Maven cache
-      uses: skjolber/maven-cache-github-action@v1
+      uses: skjolber/maven-cache-github-action@v3.1.1
       with:
         step: save

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,20 +20,15 @@ jobs:
         distribution: temurin
         cache: 'maven'
 
-    - name: Set up test dependencies
+    - name: Set up Browser
       run: |
-        firefox --version
-
         # Geckodriver
         echo ${GECKOWEBDRIVER} >> $GITHUB_PATH
 
         # Chromedriver
         echo ${CHROMEWEBDRIVER} >> $GITHUB_PATH
 
-        echo $PATH
-
-        cat /proc/cpuinfo
-
+        firefox --version
         ${GECKOWEBDRIVER}/geckodriver --version
 
     - name: Build
@@ -44,7 +39,7 @@ jobs:
         export FIREFOX_BIN=$(which firefox)
         export SELENIUM_BROWSER=firefox
 
-        mvn -B -Plocal-testing,!standard-with-extra-repos clean install -Dlog4j.configurationFile=$PWD/ci/log4j2.xml -T2
+        mvn -B -Plocal-testing,!standard-with-extra-repos verify -Dlog4j.configurationFile=$PWD/ci/log4j2.xml -T3
         mvn -P!standard-with-extra-repos -B javadoc:javadoc
 
     - name: Upload logs on build failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         export FIREFOX_BIN=$(which firefox)
         export SELENIUM_BROWSER=firefox
 
-        mvn -B -Plocal-testing,!standard-with-extra-repos install -Dlog4j.configurationFile=$PWD/ci/log4j2.xml -T3
+        mvn -B -Plocal-testing,!standard-with-extra-repos install -Dlog4j.configurationFile=$PWD/ci/log4j2.xml -T2
         mvn -P!standard-with-extra-repos -B javadoc:javadoc -T1C
 
     - name: Upload logs on build failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
         export FIREFOX_BIN=$(which firefox)
         export SELENIUM_BROWSER=firefox
 
-        mvn -B -Plocal-testing,!standard-with-extra-repos verify -Dlog4j.configurationFile=$PWD/ci/log4j2.xml -T3
-        mvn -P!standard-with-extra-repos -B javadoc:javadoc
+        mvn -B -Plocal-testing,!standard-with-extra-repos install -Dlog4j.configurationFile=$PWD/ci/log4j2.xml -T3
+        mvn -P!standard-with-extra-repos -B javadoc:javadoc -T1C
 
     - name: Upload logs on build failure
       if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,20 +35,22 @@ jobs:
         curl -L https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz | \
           tar -C ~/geckodriver/ -xzvf-
 
+    - name: Install Firefox ESR
+      uses: browser-actions/setup-firefox@v1
+      with:
+        firefox-version: 'latest-esr'
+
+    - name: Install Chrome (stable)
+      uses: browser-actions/setup-chrome@v1
+      with:
+        chrome-version: 'stable'
+        install-chromedriver: true
+
     - name: Set up test dependencies
       run: |
-        # PPA by Mozilla for ESR releases
-        # replace 'sudo add-apt-repository ppa:mozillateam/ppa' with simple commands as workaround for https://github.com/orgs/community/discussions/69720
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0AB215679C571D1C8325275B9BDB3D89CE49EC21
-        sudo add-apt-repository "deb https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/ focal main"
-
-        sudo apt update
-        sudo apt install firefox-esr chromium-browser chromium-chromedriver dbus-x11
+        sudo apt install dbus-x11
 
         # Selenium wants to run non-ESR FF
-        sudo rm -rf /usr/lib/firefox/
-        sudo ln -s firefox-esr /usr/lib/firefox
-        sudo ln -s firefox-esr /usr/lib/firefox/firefox
         firefox --version
 
         ~/geckodriver/geckodriver --version
@@ -59,7 +61,7 @@ jobs:
         export $(dbus-launch)
         mkdir ~/tmp
         export TMPDIR=~/tmp
-        export FIREFOX_BIN=$(which firefox-esr)
+        export FIREFOX_BIN=$(which firefox)
         export SELENIUM_BROWSER=firefox
 
         mvn -B -Plocal-testing,!standard-with-extra-repos clean install -Dlog4j.configurationFile=$PWD/ci/log4j2.xml -T2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,18 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: 17
         distribution: temurin
+        cache: 'maven'
 
     - name: Fetch Geckodriver cache
       id: geckodriver-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/geckodriver
         key: ${{ env.GECKODRIVER_VERSION }}
@@ -53,11 +54,6 @@ jobs:
         ~/geckodriver/geckodriver --version
         echo "${HOME}/geckodriver" >> $GITHUB_PATH
 
-    - name: Restore Maven cache
-      uses: skjolber/maven-cache-github-action@v3.1.1
-      with:
-        step: restore
-
     - name: Build
       run: |
         export $(dbus-launch)
@@ -80,8 +76,3 @@ jobs:
           ./**/screenshots
           ./**/*error*.log
           ./**/*test.log
-
-    - name: Save Maven cache
-      uses: skjolber/maven-cache-github-action@v3.1.1
-      with:
-        step: save

--- a/mycore-mets/pom.xml
+++ b/mycore-mets/pom.xml
@@ -161,7 +161,7 @@
               <webAppSourceDirectory>${basedir}/target/</webAppSourceDirectory>
               <scanIntervalSeconds>10</scanIntervalSeconds>
               <stopKey>foo</stopKey>
-              <stopPort>9202</stopPort>
+              <stopPort>9302</stopPort>
               <webApp>
                 <webInfIncludeJarPattern>doNotIncludeAnyJarsPattern</webInfIncludeJarPattern>
               </webApp>


### PR DESCRIPTION
Hopefully fixes warnings about https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
