### PR TITLE
MCR-3428 MCRIView2XSLFunctionsAdapter does not initialize

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/config/MCRConfigurableInstanceHelper.java
+++ b/mycore-base/src/main/java/org/mycore/common/config/MCRConfigurableInstanceHelper.java
@@ -375,6 +375,7 @@ class MCRConfigurableInstanceHelper {
 
             List<Method> singletonFactoryMethods = factoryMethods.stream()
                 .filter(method -> method.getName().equals("getInstance"))
+                .filter(method -> method.getAnnotation(Deprecated.class) == null)
                 .toList();
 
             if (singletonFactoryMethods.size() > 1) {


### PR DESCRIPTION
Due to idiosyncrasies of PMD, we have decided to follow the convention that only true singletons are allowed to have a method called `getInstance`. The naming of all static factory methods was adjusted (see MCR-3348) to follow, among others, this rule. These methods can now be used preferentially to obtain a singleton instance (see MCR-3368). However, we still have a lot of faux singleton factory methods, all of which are now annotated as `@Deprecated` and will be removed after the release of 2025.06. For now these methods need to be ignored when searching for singleton factory methods.

[Link to jira](https://mycore.atlassian.net/browse/MCR-3428).
