### PR TITLE
MCR-3442 use write without result in neo4j

### DIFF
--- a/mycore-neo4j/src/main/java/org/mycore/mcr/neo4j/utils/MCRNeo4JQueryRunner.java
+++ b/mycore-neo4j/src/main/java/org/mycore/mcr/neo4j/utils/MCRNeo4JQueryRunner.java
@@ -34,7 +34,6 @@ import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.mcr.neo4j.datamodel.metadata.neo4jtojson.Neo4JMetaData;
 import org.mycore.mcr.neo4j.datamodel.metadata.neo4jtojson.Neo4JNodeJsonRecord;
 import org.neo4j.driver.Driver;
-import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
@@ -68,10 +67,7 @@ public class MCRNeo4JQueryRunner {
             return;
         }
         try (Session session = driver.session()) {
-            session.executeWrite(tx -> {
-                Query query = new Query(queryString);
-                return tx.run(query);
-            });
+            session.executeWriteWithoutResult(tx -> tx.run(queryString));
         }
     }
 


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3442).

We return a result object in a write operation, which is not allowed in neo4j (anymore).

I did as AI said and it worked: https://chatgpt.com/share/68246ad4-536c-8001-970f-3618997225bb