### PR TITLE
MCR-3474 Zero-length salt causes JVM to crash on Windows

### DIFF
--- a/mycore-user2/src/main/java/org/mycore/user2/hash/MCRSaltedHashPasswordCheckStrategy.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/hash/MCRSaltedHashPasswordCheckStrategy.java
@@ -41,7 +41,7 @@ public abstract class MCRSaltedHashPasswordCheckStrategy extends MCRHashPassword
 
     @Override
     protected final PasswordCheckData doCreate(SecureRandom random, String password) throws Exception {
-        byte[] salt = random.generateSeed(saltSizeBytes);
+        byte[] salt = saltSizeBytes == 0 ? new byte[0] : random.generateSeed(saltSizeBytes);
         String encodedSalt = Base64.getEncoder().encodeToString(salt);
         return new PasswordCheckData(encodedSalt, doCreateSaltedHash(salt, password));
     }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3474).
