### PR TITLE
MCR-3505 clear properties map in ExtensionContext in @BeforeAll

### DIFF
--- a/mycore-base/src/test/java/org/mycore/test/MCRTestExtension.java
+++ b/mycore-base/src/test/java/org/mycore/test/MCRTestExtension.java
@@ -111,7 +111,9 @@ public class MCRTestExtension implements Extension, BeforeEachCallback, AfterEac
         try {
             MCRTestHelper.deleteRecursively(testFolder);
             LogManager.getLogger().debug(() -> "Deleted test folder: " + testFolder);
-            MCRConfigurationBase.initialize(configurationLoader.loadDeprecated(), mycoreProperties, true);
+            if (!MCRJunit5ExtensionHelper.isNestedTestClass(context)) {
+                MCRTestExtensionConfigurationHelper.resetConfiguration(configurationLoader, mycoreProperties);
+            }
         } finally {
             context.getRoot().getStore(NAMESPACE).put(PROPERTIES_LOADED_PROPERTY, Boolean.FALSE);
         }

--- a/mycore-base/src/test/java/org/mycore/test/MCRTestExtension.java
+++ b/mycore-base/src/test/java/org/mycore/test/MCRTestExtension.java
@@ -81,6 +81,7 @@ public class MCRTestExtension implements Extension, BeforeEachCallback, AfterEac
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
         Map<String, String> configProperties = getConfigProperties(context);
+        configProperties.clear(); //clear properties from previous test classes
         configProperties.putAll(mycoreProperties);
         configProperties.putAll(MCRTestExtensionConfigurationHelper.getAnnotatedProperties(context));
         context.getStore(ExtensionContext.Namespace.create(context.getRequiredTestClass()))
@@ -110,6 +111,7 @@ public class MCRTestExtension implements Extension, BeforeEachCallback, AfterEac
         try {
             MCRTestHelper.deleteRecursively(testFolder);
             LogManager.getLogger().debug(() -> "Deleted test folder: " + testFolder);
+            MCRConfigurationBase.initialize(configurationLoader.loadDeprecated(), mycoreProperties, true);
         } finally {
             context.getRoot().getStore(NAMESPACE).put(PROPERTIES_LOADED_PROPERTY, Boolean.FALSE);
         }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3505).

This pull request introduces a minor improvement to the test extension setup process. The main change ensures that configuration properties from previous test classes do not interfere with the current test run.

* Testing reliability:
  * In `MCRTestExtension.beforeAll`, the `configProperties` map is now cleared before loading new properties, preventing leftover configuration from previous tests from affecting the current test class.