### PR TITLE
MCR-3508 remove CSS compression

### DIFF
--- a/mycore-sass/pom.xml
+++ b/mycore-sass/pom.xml
@@ -31,10 +31,6 @@
   <description>SASS on-the-fly compiler resource</description>
   <dependencies>
     <dependency>
-      <groupId>com.google.closure-stylesheets</groupId>
-      <artifactId>closure-stylesheets</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>

--- a/mycore-sass/src/main/java/org/mycore/sass/MCRSassCompilerManager.java
+++ b/mycore-sass/src/main/java/org/mycore/sass/MCRSassCompilerManager.java
@@ -29,12 +29,6 @@ import org.mycore.common.MCRException;
 import org.mycore.common.MCRUtils;
 import org.mycore.common.config.MCRConfiguration2;
 
-import com.google.common.css.SourceCode;
-import com.google.common.css.compiler.ast.GssParser;
-import com.google.common.css.compiler.ast.GssParserException;
-import com.google.common.css.compiler.passes.CompactPrinter;
-import com.google.common.css.compiler.passes.NullGssSourceMapGenerator;
-
 import de.larsgrefer.sass.embedded.SassCompilationFailedException;
 import de.larsgrefer.sass.embedded.connection.ConnectionFactory;
 import de.larsgrefer.sass.embedded.importer.Importer;
@@ -117,18 +111,10 @@ public final class MCRSassCompilerManager {
             css = compileSuccess.getCss();
         }
 
-        boolean compress = name.endsWith(".min.css");
-        if (compress) {
-            try {
-                GssParser parser = new GssParser(new SourceCode(null, css));
-                final CompactPrinter cp = new CompactPrinter(parser.parse(), new NullGssSourceMapGenerator());
-                cp.setPreserveMarkedComments(true);
-                cp.runPass();
-                css = cp.getCompactPrintedString();
-            } catch (GssParserException e) {
-                throw new MCRException("Error while parsing result css with compressor (" + name + ")", e);
-            }
-        }
+        //boolean compress = name.endsWith(".min.css");
+        //if (compress) {
+        // […] // css = MCRSassCompressor.compress(css);
+        //}
 
         this.fileCompiledContentMap.put(name, css);
         this.fileLastCompileDateMap.put(name, new Date());

--- a/pom.xml
+++ b/pom.xml
@@ -975,17 +975,6 @@ Applications based on MyCoRe use a common core, which provides the functionality
         <version>${jackson.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.google.closure-stylesheets</groupId>
-        <artifactId>closure-stylesheets</artifactId>
-        <version>1.5.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.javascript</groupId>
-            <artifactId>closure-compiler-unshaded</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>2.13.1</version>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3508).

This pull request removes support for the Closure Stylesheets CSS compression library from the `mycore-sass` module. The changes include cleaning up dependencies and related code, and commenting out the CSS compression logic that relied on Closure Stylesheets.

**Dependency cleanup:**

* Removed the `closure-stylesheets` dependency from both `mycore-sass/pom.xml` and the main `pom.xml` file, ensuring it is no longer included in the build. [[1]](diffhunk://#diff-6ed315ac8e2aab1832e8e6b1e6ba0bd117449a0934f53334425bafedbfe8fdccL33-L36) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L977-L987)

**Codebase simplification:**

* Removed all imports related to Closure Stylesheets from `MCRSassCompilerManager.java`, eliminating unused code.
* Commented out the CSS compression logic in the `compile` method of `MCRSassCompilerManager.java`, which previously used Closure Stylesheets for minification.