### PR TITLE
MCR-3511 Zero-length salt causes JVM to crash on Windows (Follow-Up/Clean-Up)

### DIFF
--- a/mycore-user2/src/main/java/org/mycore/user2/hash/MCRPBKDF2Strategy.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/hash/MCRPBKDF2Strategy.java
@@ -19,6 +19,7 @@
 package org.mycore.user2.hash;
 
 import static org.mycore.user2.hash.MCRPasswordCheckUtils.fixedEffortEquals;
+import static org.mycore.user2.hash.MCRPasswordCheckUtils.generateSeed;
 import static org.mycore.user2.hash.MCRPasswordCheckUtils.probeSecretKeyAlgorithm;
 
 import java.security.SecureRandom;
@@ -108,7 +109,7 @@ public class MCRPBKDF2Strategy extends MCRPasswordCheckStrategyBase {
     @Override
     protected PasswordCheckData doCreate(SecureRandom random, String password) throws Exception {
 
-        byte[] salt = random.generateSeed(saltSizeBytes);
+        byte[] salt = generateSeed(random, saltSizeBytes);
         byte[] hash = getHash(salt, hashSizeBytes, password);
 
         return new PasswordCheckData(HEX_FORMAT.formatHex(salt), HEX_FORMAT.formatHex(hash));

--- a/mycore-user2/src/main/java/org/mycore/user2/hash/MCRPasswordCheckUtils.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/hash/MCRPasswordCheckUtils.java
@@ -20,6 +20,7 @@ package org.mycore.user2.hash;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 
 import javax.crypto.SecretKeyFactory;
 
@@ -31,6 +32,10 @@ import org.mycore.common.config.MCRConfigurationException;
 public final class MCRPasswordCheckUtils {
 
     private MCRPasswordCheckUtils() {
+    }
+
+    public static byte[] generateSeed(SecureRandom random, int saltSizeBytes) {
+        return saltSizeBytes == 0 ? new byte[0] : random.generateSeed(saltSizeBytes);
     }
 
     public static boolean fixedEffortEquals(String a, String b) {

--- a/mycore-user2/src/main/java/org/mycore/user2/hash/MCRS2KStrategy.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/hash/MCRS2KStrategy.java
@@ -19,6 +19,7 @@
 package org.mycore.user2.hash;
 
 import static org.mycore.user2.hash.MCRPasswordCheckUtils.fixedEffortEquals;
+import static org.mycore.user2.hash.MCRPasswordCheckUtils.generateSeed;
 import static org.mycore.user2.hash.MCRPasswordCheckUtils.probeHashAlgorithm;
 
 import java.io.ByteArrayOutputStream;
@@ -111,7 +112,7 @@ public class MCRS2KStrategy extends MCRPasswordCheckStrategyBase {
     @Override
     protected PasswordCheckData doCreate(SecureRandom random, String password) throws Exception {
 
-        byte[] salt = random.generateSeed(saltSizeBytes);
+        byte[] salt = generateSeed(random, saltSizeBytes);
         byte[] hash = getHash(salt, hashSizeBytes, password);
 
         return new PasswordCheckData(HEX_FORMAT.formatHex(salt), HEX_FORMAT.formatHex(hash));

--- a/mycore-user2/src/main/java/org/mycore/user2/hash/MCRSaltedHashPasswordCheckStrategyBase.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/hash/MCRSaltedHashPasswordCheckStrategyBase.java
@@ -18,6 +18,8 @@
 
 package org.mycore.user2.hash;
 
+import static org.mycore.user2.hash.MCRPasswordCheckUtils.generateSeed;
+
 import java.security.SecureRandom;
 import java.util.Base64;
 
@@ -41,7 +43,7 @@ public abstract class MCRSaltedHashPasswordCheckStrategyBase extends MCRHashPass
 
     @Override
     protected final PasswordCheckData doCreate(SecureRandom random, String password) throws Exception {
-        byte[] salt = saltSizeBytes == 0 ? new byte[0] : random.generateSeed(saltSizeBytes);
+        byte[] salt = generateSeed(random, saltSizeBytes);
         String encodedSalt = Base64.getEncoder().encodeToString(salt);
         return new PasswordCheckData(encodedSalt, doCreateSaltedHash(salt, password));
     }

--- a/mycore-user2/src/main/java/org/mycore/user2/hash/bouncycastle/MCRArgon2Strategy.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/hash/bouncycastle/MCRArgon2Strategy.java
@@ -19,6 +19,7 @@
 package org.mycore.user2.hash.bouncycastle;
 
 import static org.mycore.user2.hash.MCRPasswordCheckUtils.fixedEffortEquals;
+import static org.mycore.user2.hash.MCRPasswordCheckUtils.generateSeed;
 
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
@@ -130,7 +131,7 @@ public class MCRArgon2Strategy extends MCRPasswordCheckStrategyBase {
     @Override
     protected PasswordCheckData doCreate(SecureRandom random, String password) {
 
-        byte[] salt = random.generateSeed(saltSizeBytes);
+        byte[] salt = generateSeed(random, saltSizeBytes);
         byte[] hash = getHash(salt, hashSizeBytes, password);
 
         return new PasswordCheckData(HEX_FORMAT.formatHex(salt), HEX_FORMAT.formatHex(hash));

--- a/mycore-user2/src/main/java/org/mycore/user2/hash/bouncycastle/MCRBCryptStrategy.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/hash/bouncycastle/MCRBCryptStrategy.java
@@ -20,6 +20,7 @@ package org.mycore.user2.hash.bouncycastle;
 
 import static com.google.common.primitives.Chars.max;
 import static org.mycore.user2.hash.MCRPasswordCheckUtils.fixedEffortEquals;
+import static org.mycore.user2.hash.MCRPasswordCheckUtils.generateSeed;
 
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
@@ -129,7 +130,7 @@ public class MCRBCryptStrategy extends MCRPasswordCheckStrategyBase {
     @Override
     protected PasswordCheckData doCreate(SecureRandom random, String password) {
 
-        byte[] salt = random.generateSeed(16);
+        byte[] salt = generateSeed(random, 16);
         byte[] hash = getHash(cost, salt, password);
 
         return new PasswordCheckData("", compileBCryptMCFString(salt, hash));

--- a/mycore-user2/src/main/java/org/mycore/user2/hash/bouncycastle/MCRSCryptStrategy.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/hash/bouncycastle/MCRSCryptStrategy.java
@@ -19,6 +19,7 @@
 package org.mycore.user2.hash.bouncycastle;
 
 import static org.mycore.user2.hash.MCRPasswordCheckUtils.fixedEffortEquals;
+import static org.mycore.user2.hash.MCRPasswordCheckUtils.generateSeed;
 
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
@@ -123,7 +124,7 @@ public class MCRSCryptStrategy extends MCRPasswordCheckStrategyBase {
     @Override
     protected PasswordCheckData doCreate(SecureRandom random, String password) {
 
-        byte[] salt = random.generateSeed(saltSizeBytes);
+        byte[] salt = generateSeed(random, saltSizeBytes);
         byte[] hash = getHash(salt, hashSizeBytes, password);
 
         return new PasswordCheckData(HEX_FORMAT.formatHex(salt), HEX_FORMAT.formatHex(hash));


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3511).
