### PR TITLE
MCR-3523 Add command "migrate svn store to normalized versioned objects"

### DIFF
--- a/mycore-migration/pom.xml
+++ b/mycore-migration/pom.xml
@@ -34,6 +34,10 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
     </dependency>
@@ -49,7 +53,6 @@
       <groupId>org.jdom</groupId>
       <artifactId>jdom2</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.mycore</groupId>
       <artifactId>mycore-base</artifactId>
@@ -62,6 +65,10 @@
     <dependency>
       <groupId>org.mycore</groupId>
       <artifactId>mycore-iview2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.tmatesoft.svnkit</groupId>
+      <artifactId>svnkit</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>

--- a/mycore-migration/src/main/java/org/mycore/migration/objectversion/MCRMigrationStore.java
+++ b/mycore-migration/src/main/java/org/mycore/migration/objectversion/MCRMigrationStore.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.migration.objectversion;
+
+import java.nio.file.Path;
+
+import org.mycore.datamodel.ifs2.MCRMetadataStore;
+
+/**
+ * This class exists only to make the protected method getSlot of MCRMetadataStore accessible.
+ * 
+ * <p>
+ *     Do not use this class outside of the migration component!
+ * </p>    
+ * @author Thomas Scheffler (yagee)
+ */
+public class MCRMigrationStore extends MCRMetadataStore {
+    @Override
+    protected Path getSlot(int id) {
+        return super.getSlot(id);
+    }
+}

--- a/mycore-migration/src/main/java/org/mycore/migration/objectversion/MCRObjectMigratorHelper.java
+++ b/mycore-migration/src/main/java/org/mycore/migration/objectversion/MCRObjectMigratorHelper.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.migration.objectversion;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.mycore.common.MCRConstants;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.datamodel.metadata.MCRExpandedObjectStructure;
+import org.mycore.datamodel.metadata.MCRMetadataManager;
+import org.mycore.datamodel.metadata.MCRObject;
+import org.mycore.datamodel.metadata.MCRObjectID;
+import org.mycore.datamodel.metadata.MCRObjectStructure;
+import org.mycore.migration.cli.MCRMigrationCommands;
+import org.mycore.migration.strategy.MCRChildrenOrderMigrationStrategy;
+import org.mycore.migration.strategy.MCRNeverAddChildrenOrderStrategy;
+
+public class MCRObjectMigratorHelper {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    /**
+     * Get the configured strategy for migrating &lt;children&gt; to &lt;childrenOrder&gt;.
+     * If no strategy is configured, a default strategy is returned that never migrates &lt;children&gt; to &lt;childrenOrder&gt;.
+     *
+     * @return the configured strategy or a default strategy
+     */
+    public static MCRChildrenOrderMigrationStrategy getChildrenOrderMigrationStrategy() {
+        return MCRConfiguration2
+            .getSingleInstanceOf(MCRChildrenOrderMigrationStrategy.class,
+                MCRMigrationCommands.CHILDREN_ORDER_STRATEGY_PROPERTY)
+            .orElseGet(() -> {
+                LOGGER.info("No strategy configured for '{}', using default: NeverAddChildrenOrderStrategy",
+                    MCRMigrationCommands.CHILDREN_ORDER_STRATEGY_PROPERTY);
+                return new MCRNeverAddChildrenOrderStrategy();
+            });
+    }
+
+    /**
+     * Migrate the given document representing an object to the latest structure version.
+     * This includes:
+     * <ul>
+     *   <li>Optionally migrating &lt;children&gt; to &lt;childrenOrder&gt; based on the given strategy</li>
+     *   <li>Repairing derivate links if requested</li>
+     *   <li>Validating the object after migration if requested</li>
+     *   <li>Normalizing the object structure</li>
+     * </ul>
+     *
+     * @param objectID the ID of the object being migrated
+     * @param document the XML document of the object to migrate
+     * @param strategy the strategy to decide whether to migrate &lt;children&gt; to &lt;childrenOrder&gt;
+     * @param repairDerivateLinks whether to repair derivate links
+     * @param validate whether to validate the object after migration
+     * @return the migrated XML document
+     * @throws JDOMException if there is an error parsing or manipulating the XML
+     * @throws IOException if there is an I/O error during processing
+     */
+    public static Document migrateObject(MCRObjectID objectID, Document document,
+        MCRChildrenOrderMigrationStrategy strategy, boolean repairDerivateLinks, boolean validate)
+        throws JDOMException, IOException {
+        Element rootElement = document.getRootElement();
+
+        Element structureElement = rootElement.getChild(MCRObjectStructure.XML_NAME);
+        if (structureElement != null) {
+
+            Element derivatesElement = structureElement.getChild(MCRObjectStructure.ELEMENT_DERIVATE_OBJECTS);
+
+            if (derivatesElement != null && repairDerivateLinks) {
+                // trigger repair on all derivates to recreate the derivate links in the right direction
+                List<Element> derObjects = derivatesElement.getChildren("derobject");
+                derObjects.stream()
+                    .map(derObject -> derObject.getAttributeValue("href", MCRConstants.XLINK_NAMESPACE))
+                    .map(MCRObjectID::getInstance)
+                    .map(MCRMetadataManager::retrieveMCRDerivate)
+                    .forEach(MCRMetadataManager::fireRepairEvent);
+            }
+
+            Element childrenElement = structureElement.getChild(MCRExpandedObjectStructure.CHILDREN_ELEMENT_NAME);
+            if (childrenElement != null) {
+                if (strategy.shouldAddChildrenOrder(objectID, document)) {
+                    LOGGER.info("Migrating <children> to <childrenOrder> for object {} based on strategy {}",
+                        () -> objectID, () -> strategy.getClass().getSimpleName());
+                    childrenElement.setName(MCRObjectStructure.CHILDREN_ORDER_ELEMENT_NAME);
+                    List<Element> children = childrenElement.getChildren(MCRObjectStructure.CHILD_ELEMENT_NAME);
+
+                    for (Element child : children) {
+                        child.removeAttribute("title", MCRConstants.XLINK_NAMESPACE);
+                        child.removeAttribute("inherited");
+                    }
+                } else {
+                    LOGGER.info("Skipping <children> migration for object {} based on strategy {}",
+                        () -> objectID, () -> strategy.getClass().getSimpleName());
+                    // Remove the old <children> element as it's not needed in the normalized structure
+                    // and the strategy decided against migrating it to <childrenOrder>.
+                    // MCRMetadataManager.normalizeObject will handle the structure correctly later.
+                    // However, explicitly removing it here makes the intent clearer for this migration step.
+                    structureElement.removeChild(MCRExpandedObjectStructure.CHILDREN_ELEMENT_NAME);
+                }
+            }
+        }
+
+        MCRObject object = new MCRObject(document);
+
+        if (validate) {
+            MCRMetadataManager.validateObject(object);
+        }
+        MCRMetadataManager.normalizeObject(object);
+
+        return object.createXML();
+    }
+}

--- a/mycore-migration/src/main/java/org/mycore/migration/objectversion/MCRObjectModificationElementFilter.java
+++ b/mycore-migration/src/main/java/org/mycore/migration/objectversion/MCRObjectModificationElementFilter.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.migration.objectversion;
+
+import java.io.Serial;
+
+import org.jdom2.Element;
+import org.jdom2.filter.AbstractFilter;
+import org.mycore.datamodel.metadata.MCRObjectService;
+
+/**
+ * A filter that filters for modification related elements, i.e. <servflag type="modifiedBy"> and
+ * <servdate type="modifyDate">.
+ *
+ * @author Thomas Scheffler (yagee)
+ */
+class MCRObjectModificationElementFilter extends AbstractFilter<Element> {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private static boolean isModifiedBy(Element element) {
+        return element.getName().equals(MCRObjectService.ELEMENT_SERVFLAG) &&
+            MCRObjectService.FLAG_TYPE_MODIFIEDBY.equals(element.getAttributeValue("type"));
+    }
+
+    private static boolean isModifiedServDate(Element element) {
+        return element.getName().equals(MCRObjectService.ELEMENT_SERVDATE) &&
+            MCRObjectService.DATE_TYPE_MODIFYDATE.equals(element.getAttributeValue("type"));
+    }
+
+    @Override
+    public Element filter(Object content) {
+        if (content instanceof Element element && (isModifiedServDate(element) || isModifiedBy(element))) {
+            return element;
+        }
+        return null;
+    }
+}

--- a/mycore-migration/src/main/java/org/mycore/migration/objectversion/MCRVersioningMetadataStoreMigrator.java
+++ b/mycore-migration/src/main/java/org/mycore/migration/objectversion/MCRVersioningMetadataStoreMigrator.java
@@ -1,0 +1,236 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.migration.objectversion;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jdom2.Document;
+import org.jdom2.JDOMException;
+import org.mycore.common.MCRException;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.common.content.MCRByteContent;
+import org.mycore.common.content.MCRContent;
+import org.mycore.common.content.MCRJDOMContent;
+import org.mycore.common.content.streams.MCRByteArrayOutputStream;
+import org.mycore.datamodel.ifs2.MCRStoredMetadata;
+import org.mycore.datamodel.ifs2.MCRVersioningMetadataStore;
+import org.mycore.datamodel.metadata.MCRObjectID;
+import org.mycore.migration.strategy.MCRChildrenOrderMigrationStrategy;
+import org.tmatesoft.svn.core.SVNException;
+import org.tmatesoft.svn.core.SVNLogEntry;
+import org.tmatesoft.svn.core.SVNLogEntryPath;
+import org.tmatesoft.svn.core.SVNNodeKind;
+import org.tmatesoft.svn.core.SVNProperties;
+import org.tmatesoft.svn.core.SVNPropertyValue;
+import org.tmatesoft.svn.core.SVNRevisionProperty;
+import org.tmatesoft.svn.core.SVNURL;
+import org.tmatesoft.svn.core.io.SVNRepository;
+import org.tmatesoft.svn.core.io.SVNRepositoryFactory;
+
+/**
+ * Migrates a versioning store to a new format.
+ *
+ * @author Thomas Scheffler (yagee)
+ */
+public class MCRVersioningMetadataStoreMigrator {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+    private final MCRVersioningMetadataStore versioningStore;
+    private final MCRChildrenOrderMigrationStrategy strategy;
+
+    public MCRVersioningMetadataStoreMigrator(MCRVersioningMetadataStore versioningStore) {
+        this.versioningStore = versioningStore;
+        this.strategy = MCRObjectMigratorHelper.getChildrenOrderMigrationStrategy();
+    }
+
+    /**
+     * Migrate the versioning store to the new format.
+     *
+     * @throws SVNException if an SVN error occurs during migration
+     * @throws IOException if an I/O error occurs during migration
+     * @throws JDOMException if a JDOM error occurs during XML processing
+     */
+    public void migrate() throws SVNException, IOException, JDOMException {
+        Map<String, String> subPropertiesMap = MCRConfiguration2.getSubPropertiesMap(
+            "MCR.IFS2.Store." + versioningStore.getID() + ".");
+        LOGGER.info(subPropertiesMap);
+        String svnUrl = subPropertiesMap.get("SVNRepositoryURL");
+        MCRMigrationStore newStore =
+            MCRVersioningMetadataStoreMigratorHelper.getMigrationStore(versioningStore.getID(), subPropertiesMap);
+        if (newStore == null) {
+            return;
+        }
+        SVNURL repURL;
+        URI repositoryURI = URI.create(svnUrl);
+        repURL = SVNURL.create(repositoryURI.getScheme(), repositoryURI.getUserInfo(), repositoryURI.getHost(),
+            repositoryURI.getPort(), repositoryURI.getPath(), true);
+        LOGGER.info("repURL: {}", repURL);
+        SVNRepository repository = SVNRepositoryFactory.create(repURL);
+        SVNRepository fileRepository = SVNRepositoryFactory.create(repURL);
+        SVNRepository newRepository = MCRVersioningMetadataStoreMigratorHelper.initializeSVNRepository(
+            MCRVersioningMetadataStoreMigratorHelper.toMigrationPath(svnUrl));
+
+        long latestRevision = repository.getLatestRevision();
+        int highestStoredID = versioningStore.getHighestStoredID();
+        PathDateModifiedUpdate[] pathUpdates = new PathDateModifiedUpdate[highestStoredID + 1];
+        try (ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor()) {
+            repository.log(new String[] { "" }, 0, latestRevision, true, false, logEntry -> {
+                processRevision(logEntry, latestRevision, newStore, pathUpdates, fileRepository, newRepository,
+                    executorService);
+            });
+        } catch (MCRException ignoredForKnownCause) {
+            switch (ignoredForKnownCause.getCause()) {
+                case SVNException se -> throw se;
+                case IOException ioe -> throw ioe;
+                case JDOMException je -> throw je;
+                default -> throw ignoredForKnownCause;
+            }
+        }
+
+        MCRVersioningMetadataStoreMigratorHelper.setLastModifiedDates(pathUpdates);
+        //migration done, now switch store paths
+        replaceStoreDirs(newStore, repository, newRepository);
+        repository.closeSession();
+        fileRepository.closeSession();
+        newRepository.closeSession();
+    }
+
+    /**
+     * Process a single revision of the SVN repository.
+     *
+     * @param logEntry the SVN log entry representing the revision
+     * @param latestRevision the latest revision number in the repository
+     * @param newStore the new migration store to update
+     * @param pathUpdates an array to track path updates and their modification dates
+     * @param fileRepository the SVN repository for file access
+     * @param newRepository the new SVN repository for committing changes
+     * @param executorService the executor service for concurrent tasks
+     */
+    private void processRevision(SVNLogEntry logEntry, long latestRevision, MCRMigrationStore newStore,
+        PathDateModifiedUpdate[] pathUpdates, SVNRepository fileRepository, SVNRepository newRepository,
+        ExecutorService executorService) throws SVNException {
+        long revision = logEntry.getRevision();
+        LOGGER.info("Processing revision: {}/{}", revision, latestRevision);
+        SVNProperties revisionProperties = logEntry.getRevisionProperties();
+        if (logEntry.getRevision() == 0) {
+            SVNPropertyValue date = logEntry.getRevisionProperties()
+                .getSVNPropertyValue(SVNRevisionProperty.DATE);
+            MCRVersioningMetadataStoreMigratorHelper.updateRevisionDate(newRepository, 0, date);
+        }
+        for (Map.Entry<String, SVNLogEntryPath> entry : logEntry.getChangedPaths().entrySet()) {
+            String path = entry.getKey();
+            SVNLogEntryPath logEntryPath = entry.getValue();
+            LOGGER.debug(logEntryPath);
+            if (!path.endsWith(".xml") || !logEntryPath.getKind().equals(SVNNodeKind.FILE)) {
+                LOGGER.debug("Not an xml file: {}", path);
+                continue;
+            }
+            try {
+                if (logEntryPath.getType() == 'D') {
+                    try {
+                        MCRVersioningMetadataStoreMigratorHelper.deleteFile(newStore, pathUpdates, path);
+                        MCRVersioningMetadataStoreMigratorHelper.deleteFile(newRepository, path, revisionProperties,
+                            executorService);
+                    } catch (NoSuchFileException e) {
+                        LOGGER.warn("File to delete not found in new store, ignoring: {}, id: {}", () -> path,
+                            () -> MCRVersioningMetadataStoreMigratorHelper.getId(path));
+                    }
+                    continue;
+                }
+                try (MCRByteArrayOutputStream baos = new MCRByteArrayOutputStream()) {
+                    fileRepository.getFile(path, revision, null, baos);
+                    MCRContent content =
+                        new MCRByteContent(baos.getBuffer(), 0, baos.size(), logEntry.getDate().getTime());
+                    MCRContent migratedContent = migrateXML(content);
+                    MCRByteContent migratedContentBytes = new MCRByteContent(migratedContent.asByteArray());
+                    int id = MCRVersioningMetadataStoreMigratorHelper.getId(path);
+                    MCRStoredMetadata storedMetadata = newStore.retrieve(id);
+                    if (storedMetadata != null) {
+                        MCRContent existingContent = storedMetadata.getMetadata();
+                        if (MCRVersioningMetadataStoreMigratorHelper.objectsAreSemanticalEqual(existingContent.asXML(),
+                            migratedContent.asXML())) {
+                            LOGGER.info("File content unchanged, not updating, id: {}", id);
+                            continue;
+                        }
+                        storedMetadata.update(migratedContentBytes);
+                    } else {
+                        newStore.create(migratedContentBytes, id);
+                    }
+                    LOGGER.debug("File {} content size changed from {} to {} bytes, id: {}", () -> path, baos::size,
+                        migratedContentBytes::length, () -> id);
+                    Path localPath = newStore.getSlot(id);
+                    pathUpdates[id] = new PathDateModifiedUpdate(localPath, logEntry.getDate());
+                    String[] paths =
+                        MCRVersioningMetadataStoreMigratorHelper.getPaths(newStore.getBaseDirectory(), localPath);
+                    MCRVersioningMetadataStoreMigratorHelper.commit(newRepository, paths, migratedContentBytes,
+                        revisionProperties, executorService);
+                }
+            } catch (IOException | JDOMException e) {
+                throw new MCRException(e);
+            }
+        }
+    }
+
+    /**
+     * Replace the old store directories with the new store directories after migration.
+     *
+     * @param newStore the new migration store
+     * @param repository the original SVN repository
+     * @param newRepository the new SVN repository
+     * @throws IOException if an I/O error occurs during directory replacement
+     */
+    private void replaceStoreDirs(MCRMigrationStore newStore, SVNRepository repository, SVNRepository newRepository)
+        throws IOException {
+        Path oldBaseDir = versioningStore.getBaseDirectory();
+        Path newBaseDir = newStore.getBaseDirectory();
+        Path backUpDir = oldBaseDir.getParent().resolve(oldBaseDir.getFileName() + ".backup");
+        Path oldSvnDir = Path.of(URI.create(repository.getLocation().toString()));
+        Path newSvnDir = Path.of(URI.create(newRepository.getLocation().toString()));
+        Path backUpSvnDir = oldSvnDir.getParent().resolve(oldSvnDir.getFileName() + ".backup");
+        MCRVersioningMetadataStoreMigratorHelper.replaceDirectories(oldBaseDir, backUpDir, newBaseDir);
+        MCRVersioningMetadataStoreMigratorHelper.replaceDirectories(oldSvnDir, backUpSvnDir, newSvnDir);
+        LOGGER.info("Migration of store {} done", versioningStore::getID);
+        LOGGER.info("Old store data moved to {}", backUpDir);
+        LOGGER.info("Old store SVN data moved to {}", backUpSvnDir);
+    }
+
+    /**
+     * Migrate the XML content of an old versioned object to the new format.
+     *
+     * @param oldVersionedXML the old versioned XML content
+     * @return the migrated XML content
+     * @throws IOException if an I/O error occurs during migration
+     * @throws JDOMException if a JDOM error occurs during XML processing
+     */
+    private MCRContent migrateXML(MCRContent oldVersionedXML) throws IOException, JDOMException {
+        Document oldDocument = oldVersionedXML.asXML();
+        MCRObjectID objectID = MCRObjectID.getInstance(oldDocument.getRootElement().getAttributeValue("ID"));
+        Document newDocument = MCRObjectMigratorHelper.migrateObject(objectID, oldDocument, strategy, false, false);
+        return new MCRJDOMContent(newDocument);
+    }
+
+}

--- a/mycore-migration/src/main/java/org/mycore/migration/objectversion/MCRVersioningMetadataStoreMigrator.java
+++ b/mycore-migration/src/main/java/org/mycore/migration/objectversion/MCRVersioningMetadataStoreMigrator.java
@@ -97,7 +97,7 @@ public class MCRVersioningMetadataStoreMigrator {
         long latestRevision = repository.getLatestRevision();
         int highestStoredID = versioningStore.getHighestStoredID();
         PathDateModifiedUpdate[] pathUpdates = new PathDateModifiedUpdate[highestStoredID + 1];
-        try (ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor()) {
+        try (ExecutorService executorService = Executors.newSingleThreadExecutor()) {
             repository.log(new String[] { "" }, 0, latestRevision, true, false, logEntry -> {
                 processRevision(logEntry, latestRevision, newStore, pathUpdates, fileRepository, newRepository,
                     executorService);

--- a/mycore-migration/src/main/java/org/mycore/migration/objectversion/MCRVersioningMetadataStoreMigratorHelper.java
+++ b/mycore-migration/src/main/java/org/mycore/migration/objectversion/MCRVersioningMetadataStoreMigratorHelper.java
@@ -1,0 +1,370 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.migration.objectversion;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutorService;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.mycore.common.MCRException;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.common.content.MCRContent;
+import org.mycore.common.xml.MCRXMLHelper;
+import org.mycore.datamodel.ifs2.MCRStoreManager;
+import org.mycore.datamodel.metadata.MCRObjectService;
+import org.tmatesoft.svn.core.SVNCommitInfo;
+import org.tmatesoft.svn.core.SVNException;
+import org.tmatesoft.svn.core.SVNNodeKind;
+import org.tmatesoft.svn.core.SVNProperties;
+import org.tmatesoft.svn.core.SVNProperty;
+import org.tmatesoft.svn.core.SVNPropertyValue;
+import org.tmatesoft.svn.core.SVNRevisionProperty;
+import org.tmatesoft.svn.core.SVNURL;
+import org.tmatesoft.svn.core.auth.BasicAuthenticationManager;
+import org.tmatesoft.svn.core.auth.ISVNAuthenticationManager;
+import org.tmatesoft.svn.core.auth.SVNAuthentication;
+import org.tmatesoft.svn.core.auth.SVNUserNameAuthentication;
+import org.tmatesoft.svn.core.internal.io.fs.FSRepositoryFactory;
+import org.tmatesoft.svn.core.io.ISVNEditor;
+import org.tmatesoft.svn.core.io.SVNRepository;
+import org.tmatesoft.svn.core.io.SVNRepositoryFactory;
+import org.tmatesoft.svn.core.io.diff.SVNDeltaGenerator;
+import org.tmatesoft.svn.core.wc.SVNWCUtil;
+import org.tmatesoft.svn.core.wc.admin.SVNAdminClient;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+class MCRVersioningMetadataStoreMigratorHelper {
+    private static final Pattern LAST_PATH_SEGMENT = Pattern.compile("([^\\\\/]+)([\\\\/]?)$");
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static final Pattern INT_ID_PATTERN = Pattern.compile("(\\d+)(?=\\.xml$)");
+    private static final LoadingCache<String, ISVNAuthenticationManager> AUTHENTICATION_MANAGER_CACHE =
+        CacheBuilder.<String, ISVNAuthenticationManager>newBuilder()
+            .build(new CacheLoader<>() {
+
+                @Override
+                public ISVNAuthenticationManager load(String user) throws Exception {
+                    SVNAuthentication[] auth = { SVNUserNameAuthentication.newInstance(user, false, null, false) };
+                    return new BasicAuthenticationManager(auth);
+                }
+            });
+    private static final String MIGRATION_STORE_SUFFIX = ".new";
+
+    /**
+     * Update the last modified dates of the given paths to the given dates.
+     * Errors are logged but do not stop the process.
+     *
+     * @param pathUpdates array of path and date pairs to update
+     */
+    static void setLastModifiedDates(PathDateModifiedUpdate[] pathUpdates) {
+        LOGGER.info("Updating last modified dates in store");
+        Stream.of(pathUpdates)
+            .filter(Objects::nonNull)
+            .forEach(update -> {
+                try {
+                    update.update();
+                } catch (IOException e) {
+                    //not critical, just log
+                    LOGGER.warn(() -> "Error updating last modified date of " + update.path() + " to "
+                        + update.dateModified(), e);
+                }
+            });
+    }
+
+    /**
+     * Replace the old base directory with the new base directory, backing up the old base directory.
+     *
+     * @param oldBaseDir the old base directory
+     * @param backUpDir the backup directory
+     * @param newBaseDir the new base directory
+     * @throws IOException if an I/O error occurs
+     */
+    static void replaceDirectories(Path oldBaseDir, Path backUpDir, Path newBaseDir) throws IOException {
+        Files.move(oldBaseDir, backUpDir);
+        Files.move(newBaseDir, oldBaseDir);
+    }
+
+    /**
+     * Initialize a new SVN repository at the given URL.
+     *
+     * @param svnUrl the URL of the SVN repository
+     * @return the initialized SVN repository
+     * @throws SVNException if an error occurs while initializing the repository
+     */
+    static SVNRepository initializeSVNRepository(String svnUrl) throws SVNException {
+        URI repositoryURI = URI.create(svnUrl);
+        FSRepositoryFactory.setup();
+        File repoDir = new File(repositoryURI);
+        SVNAdminClient admin =
+            new SVNAdminClient((ISVNAuthenticationManager) null, SVNWCUtil.createDefaultOptions(true));
+        boolean enableRevisionProperties = true; //required to set svn:date and svn:author
+        SVNURL repURL =
+            admin.doCreateRepository(repoDir, null, enableRevisionProperties, false,
+                false,
+                false,
+                false,
+                false,
+                true,
+                false); //subversion 1.10+ with lz4 compression and performance improvements
+        LOGGER.info("Creating new SVN repository at: {}", repURL);
+        return SVNRepositoryFactory.create(repURL);
+    }
+
+    /**
+     * Commit the given content to the SVN repository at the given paths with the given revision properties.
+     * Creates intermediate directories as needed.
+     *
+     * @param repository the SVN repository
+     * @param paths the paths to commit to, with intermediate directories
+     * @param input the content to commit
+     * @param revProps the revision properties
+     * @param executorService executor service to run post-commit tasks
+     * @throws IOException if an I/O error occurs
+     */
+    static void commit(SVNRepository repository, String[] paths, MCRContent input,
+        SVNProperties revProps, ExecutorService executorService) throws IOException, SVNException {
+
+        SVNCommitInfo info = commitFile(repository, paths, input, revProps);
+        updateMissingRevisionUpdates(repository, revProps, executorService, info);
+    }
+
+    private static void updateMissingRevisionUpdates(SVNRepository repository, SVNProperties revProps,
+        ExecutorService executorService,
+        SVNCommitInfo info) {
+        long revision = info.getNewRevision();
+        SVNPropertyValue date = revProps.getSVNPropertyValue(SVNRevisionProperty.DATE);
+        //run in executor to not block main thread
+        executorService.execute(() -> updateRevisionDate(repository, revision, date));
+    }
+
+    static void updateRevisionDate(SVNRepository repository, long revision, SVNPropertyValue date) {
+        LOGGER.debug("Change commit date {}", date::getString);
+        try {
+            repository.setRevisionPropertyValue(revision, SVNRevisionProperty.DATE, date);
+        } catch (SVNException e) {
+            throw new MCRException(e);
+        }
+    }
+
+    static SVNCommitInfo deleteFile(SVNRepository repository, String path, SVNProperties revProps,
+        ExecutorService executorService)
+        throws SVNException {
+        String user = revProps.getStringValue(SVNRevisionProperty.AUTHOR);
+        // Start commit editor
+        repository.setAuthenticationManager(AUTHENTICATION_MANAGER_CACHE.getUnchecked(user));
+        ISVNEditor editor = repository.getCommitEditor(revProps.getStringValue(SVNRevisionProperty.LOG), null);
+        editor.openRoot(-1);
+        editor.deleteEntry(path, -1);
+        editor.closeDir(); // root
+        SVNCommitInfo svnCommitInfo = editor.closeEdit();
+        updateMissingRevisionUpdates(repository, revProps, executorService, svnCommitInfo);
+        return svnCommitInfo;
+    }
+
+    private static SVNCommitInfo commitFile(SVNRepository repository, String[] paths, MCRContent input,
+        SVNProperties revProps) throws SVNException, IOException {
+        String filePath = paths[paths.length - 1];
+        // Check which paths already exist in SVN
+        int existing = paths.length - 1;
+        for (; existing >= 0; existing--) {
+            if (!repository.checkPath(paths[existing], -1).equals(SVNNodeKind.NONE)) {
+                break;
+            }
+        }
+
+        String user = revProps.getStringValue(SVNRevisionProperty.AUTHOR);
+        // Start commit editor
+        repository.setAuthenticationManager(AUTHENTICATION_MANAGER_CACHE.getUnchecked(user));
+        ISVNEditor editor = repository.getCommitEditor(revProps.getStringValue(SVNRevisionProperty.LOG), null);
+        editor.openRoot(-1);
+
+        existing += 1;
+        // Create directories in SVN that do not exist yet
+        for (int i = existing; i < paths.length - 1; i++) {
+            LOGGER.debug("SVN create directory {}", paths[i]);
+            editor.addDir(paths[i], null, -1);
+            editor.closeDir();
+        }
+
+        // Commit file changes
+        LOGGER.debug("Commit file {}", filePath);
+        if (existing < paths.length) {
+            editor.addFile(filePath, null, -1);
+        } else {
+            editor.openFile(filePath, -1);
+        }
+
+        editor.applyTextDelta(filePath, null);
+        SVNDeltaGenerator deltaGenerator = new SVNDeltaGenerator();
+
+        String checksum;
+        try (InputStream in = input.getInputStream()) {
+            checksum = deltaGenerator.sendDelta(filePath, in, editor, true);
+        }
+
+        editor.changeFileProperty(filePath, SVNProperty.MIME_TYPE, SVNPropertyValue.create("text/xml"));
+
+        editor.closeFile(filePath, checksum);
+        editor.closeDir(); // root
+
+        return editor.closeEdit();
+    }
+
+    /**
+     * Extract the integer ID to use with a {@link org.mycore.datamodel.ifs2.MCRStore} from the given path.
+     *
+     * @param path the path to extract the ID from
+     * @return the extracted ID, or -1 if no ID could be extracted
+     */
+    static int getId(String path) {
+        //pattern to match last integer before file extension
+        Matcher m = INT_ID_PATTERN.matcher(path);
+        if (!m.find()) {
+            return -1;
+        }
+        return Integer.parseInt(m.group(1));
+    }
+
+    /**
+     * Create a new migration store based on the given original store ID and properties.
+     * The new store ID and properties are derived from the original ones by appending ".new" to paths.
+     *
+     * @param origStoreId the original store ID
+     * @param subPropertiesMap the original store properties
+     * @return the created migration store
+     */
+    static MCRMigrationStore getMigrationStore(String origStoreId, Map<String, String> subPropertiesMap) {
+        Map<String, String> storeProperties = new TreeMap<>(subPropertiesMap);
+        storeProperties.replaceAll((k, v) -> switch (k) {
+            case "BaseDir", "SVNRepositoryURL" -> {
+                String newV = toMigrationPath(v);
+                LOGGER.info("New {}: {}", k, newV);
+                yield newV;
+            }
+            case "Class" -> MCRMigrationStore.class.getName();
+            default -> v;
+        });
+        storeProperties.putIfAbsent("Prefix", origStoreId + "_");
+        String newId = toMigrationPath(origStoreId);
+        storeProperties.forEach((k, v) -> {
+            LOGGER.info("Copy property MCR.IFS2.Store.{}.{} = {}", newId, k, v);
+            MCRConfiguration2.set("MCR.IFS2.Store." + newId + "." + k, v);
+        });
+        return MCRStoreManager.computeStoreIfAbsent(newId, () -> {
+            try {
+                return MCRStoreManager.buildStore(newId, MCRMigrationStore.class);
+            } catch (ReflectiveOperationException e) {
+                throw new MCRException(e);
+            }
+        });
+    }
+
+    /**
+     * Convert the given path to a migration path by appending {@link #MIGRATION_STORE_SUFFIX}.
+     *
+     * @param path the original path either with or without trailing path separator
+     * @return the migration path
+     */
+    static String toMigrationPath(String path) {
+        return LAST_PATH_SEGMENT.matcher(path).replaceAll("$1" + MIGRATION_STORE_SUFFIX + "$2");
+    }
+
+    static String[] getPaths(Path baseDirectory, Path path) {
+        Path relativized = baseDirectory.relativize(path);
+        int nameCount = relativized.getNameCount();
+        String[] paths = new String[nameCount];
+        StringBuilder component = new StringBuilder();
+
+        for (int i = 0; i < nameCount; i++) {
+            if (i > 0) {
+                component.append('/');
+            }
+            component.append(relativized.getName(i));
+            paths[i] = component.toString();
+        }
+        return paths;
+    }
+
+    /**
+     * Check if two MyCoRe objects are semantically equal, ignoring revision data such as modification dates and
+     * modifiedBy flags.
+     *
+     * @param oldDocument the old MyCoRe object
+     * @param newDocument the new MyCoRe object
+     * @return true if the objects are semantically equal, false otherwise
+     */
+    static boolean objectsAreSemanticalEqual(Document oldDocument, Document newDocument) {
+        Document oldCopy = oldDocument.clone();
+        Document newCopy = newDocument.clone();
+        removeRevisionData(oldCopy);
+        removeRevisionData(newCopy);
+        return MCRXMLHelper.deepEqual(oldCopy, newCopy);
+    }
+
+    /**
+     * Remove revision data such as modification dates and modifiedBy flags from the given MyCoRe object document.
+     *
+     * @param mycoreObject the MyCoRe object document to remove revision data from
+     */
+    private static void removeRevisionData(Document mycoreObject) {
+        Element service = mycoreObject.getRootElement().getChild(MCRObjectService.XML_NAME);
+        List<Element> toRemove = new ArrayList<>();
+        for (Element e : service.getDescendants(new MCRObjectModificationElementFilter())) {
+            toRemove.add(e);
+        }
+        toRemove.forEach(e -> {
+            LOGGER.debug("Removing {} of type {}", e::getName, () -> e.getAttributeValue("type"));
+            e.detach();
+        });
+    }
+
+    /**
+     * Delete a file from the new store and mark its path update as null.
+     *
+     * @param store the new migration store
+     * @param pathUpdates an array to track path updates and their modification dates
+     * @param path the path of the file to delete
+     * @throws IOException if an I/O error occurs during deletion
+     */
+    static void deleteFile(MCRMigrationStore store, PathDateModifiedUpdate[] pathUpdates, String path)
+        throws IOException {
+        int id = getId(path);
+        LOGGER.debug("File deleted: {}, id: {}", path, id);
+        pathUpdates[id] = null;
+        store.delete(id);
+    }
+}

--- a/mycore-migration/src/main/java/org/mycore/migration/objectversion/PathDateModifiedUpdate.java
+++ b/mycore-migration/src/main/java/org/mycore/migration/objectversion/PathDateModifiedUpdate.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.migration.objectversion;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.Date;
+
+/**
+ * A record that holds a Path and a Date to update the last modified time of the file at the given path.
+ *
+ * @param path         the path to the file
+ * @param dateModified the new last modified date
+ */
+record PathDateModifiedUpdate(Path path, Date dateModified) {
+
+    /**
+     * Update the last modified time of the file at the given path to the specified dateModified.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    void update() throws IOException {
+        Files.setLastModifiedTime(path, FileTime.fromMillis(dateModified.getTime()));
+    }
+}


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3523).

Use command to recreate versions-metadata directories.

- every revision is read an reapplied to a new svn repository
- for every revision a normalizing is done for every MCRObject ([MCR-3375](https://mycore.atlassian.net/browse/MCR-3375))
- if a significant change is detected after normalizing (ignoring only modified date and servflags) commit as new revision preserving the original commit log, author and date
- after the process swap the repositories and keeping a ".backup" directory (e.g. "mods.backup")

After this migration is is recommended to perform a repair on all "derivates", e.g. `repair metadata search of base mir_mods`

Also a history is rewritten, MIR users should recreate static content:
@sebhofmann Please insert command here


[MCR-3375]: https://mycore.atlassian.net/browse/MCR-3375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ