### PR TITLE
MCR-3413 WCMS adds body tags in sections

### DIFF
--- a/mycore-wcms2/src/main/resources/META-INF/resources/modules/wcms2/js/navigation/EditContentDialog.js
+++ b/mycore-wcms2/src/main/resources/META-INF/resources/modules/wcms2/js/navigation/EditContentDialog.js
@@ -292,8 +292,14 @@ wcms.navigation.EditContentDialog = function() {
 
 		// Serialize the modified document back to a string
 		const serializer = new XMLSerializer();
-		return isHeadEmpty(head) ? serializer.serializeToString(body) : serializer.serializeToString(doc.documentElement);
-	}
+    if (isHeadEmpty(head)) {
+      return Array.from(body.childNodes)
+      .map(elem => serializer.serializeToString(elem))
+      .join("");
+    } else {
+      return serializer.serializeToString(doc.documentElement);
+    }
+  }
 
 	function popupWindow(url, windowName, win, w, h) {
 		const y = win.top.outerHeight / 2 + win.top.screenY - ( h / 2);


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3413).


When loading a CMS Page the updateImageUrls turns the string document in to Document. At the bottom the body is serialized. If the body is opened in TinyMCE, then it will be removed, but if you only open another section of the document, the body will never be removed.