### PR TITLE
MCR-3126 lazy MCROCFLFileSystemProvider init

### DIFF
--- a/mycore-ocfl/src/test/java/org/mycore/ocfl/niofs/MCROCFLFileSystemProviderSPITest.java
+++ b/mycore-ocfl/src/test/java/org/mycore/ocfl/niofs/MCROCFLFileSystemProviderSPITest.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.ocfl.niofs;
+
+import java.nio.file.spi.FileSystemProvider;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class MCROCFLFileSystemProviderSPITest {
+
+    @Test
+    public void testFileSystemProviderSPI() {
+        Assertions.assertDoesNotThrow(FileSystemProvider::installedProviders,
+            "Listing all providers should not throw an exception");
+    }
+
+}

--- a/mycore-ocfl/src/test/java/org/mycore/ocfl/niofs/MCROCFLFileSystemProviderSPITest.java
+++ b/mycore-ocfl/src/test/java/org/mycore/ocfl/niofs/MCROCFLFileSystemProviderSPITest.java
@@ -19,6 +19,7 @@
 package org.mycore.ocfl.niofs;
 
 import java.nio.file.spi.FileSystemProvider;
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,12 @@ public class MCROCFLFileSystemProviderSPITest {
     public void testFileSystemProviderSPI() {
         Assertions.assertDoesNotThrow(FileSystemProvider::installedProviders,
             "Listing all providers should not throw an exception");
+
+        List<FileSystemProvider> fileSystemProviders = FileSystemProvider.installedProviders();
+        Assertions.assertTrue(
+            fileSystemProviders.stream()
+                .anyMatch(fileSystemProvider -> fileSystemProvider instanceof MCROCFLFileSystemProvider),
+            "OCFL Provider should be listed");
     }
 
 }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3126).

MCROCFLFileSystemProvider darf kein MCRConfiguration im Konstruktor verwenden, sondern erst, wenn das Filesystem gebaut wird.