### PR TITLE
MCR-3567 fix some bugs and add JUnit tests for Etags

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/content/MCRPathContent.java
+++ b/mycore-base/src/main/java/org/mycore/common/content/MCRPathContent.java
@@ -31,7 +31,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.Locale;
 import java.util.Objects;
 
 import org.mycore.datamodel.niofs.MCRFileAttributes;
@@ -89,20 +88,24 @@ public class MCRPathContent extends MCRContent implements MCRSeekableChannelCont
         return (attrs != null ? attrs.lastModifiedTime() : Files.getLastModifiedTime(path)).toMillis();
     }
 
+    private static String getETag(MCRFileAttributes<?> fAttrs) {
+        return '"' + fAttrs.digest().toHexString() + '"';
+    }
+
     @Override
     public String getETag() throws IOException {
-        if (attrs instanceof MCRFileAttributes fAttrs) {
-            return String.format(Locale.ROOT, "\"%s\"", fAttrs.digest().toHexString());
-        }
-
-        if (Files.getFileStore(path).supportsFileAttributeView("md5")) {
-            Object fileKey = Files.getAttribute(path, "md5:md5");
-            if (fileKey instanceof String s) {
-                return String.format(Locale.ROOT, "\"%s\"", s);
+        if (attrs instanceof MCRFileAttributes<?> fAttrs) {
+            return getETag(fAttrs);
+        } else if (attrs == null) {
+            try {
+                MCRFileAttributes mcrattrs = Files.readAttributes(path, MCRFileAttributes.class);
+                return getETag(mcrattrs);
+            } catch (UnsupportedOperationException ignored) {
+                //no support for MCRFileAttributes
             }
         }
 
-        return super.getETag();
+        return "\"" + length() + '-' + lastModified() + '"';
     }
 
     @Override

--- a/mycore-base/src/main/java/org/mycore/common/content/MCRStringContent.java
+++ b/mycore-base/src/main/java/org/mycore/common/content/MCRStringContent.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 
-import java.util.Locale;
 import org.mycore.common.MCRConstants;
 import org.mycore.common.MCRException;
 
@@ -82,12 +81,11 @@ public class MCRStringContent extends MCRContent {
 
     @Override
     public long lastModified() {
-        return -1;
+        return lastModified;
     }
 
     @Override
     public String getETag() {
-      int hash = asString().hashCode();
-      return String.format(Locale.ROOT, "\"%s\"", Integer.toHexString(hash));
+        return '"' + Integer.toHexString(text.hashCode()) + '"';
     }
 }

--- a/mycore-base/src/main/java/org/mycore/common/content/util/MCRRestContentHelper.java
+++ b/mycore-base/src/main/java/org/mycore/common/content/util/MCRRestContentHelper.java
@@ -150,7 +150,7 @@ public final class MCRRestContentHelper {
         return response.build();
     }
 
-    private static EntityTag parseEtag(String eTag) {
+    public static EntityTag parseEtag(String eTag) {
         if (eTag == null) {
             return null;
         }

--- a/mycore-base/src/test/java/org/mycore/common/content/MCREtagHelper.java
+++ b/mycore-base/src/test/java/org/mycore/common/content/MCREtagHelper.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.content;
+
+class MCREtagHelper {
+
+    static boolean isValidEtag(String etag) {
+        if (etag == null || etag.isEmpty()) {
+            return false;
+        }
+        //support weak etags
+        if (etag.startsWith("W/")) {
+            etag = etag.substring(2);
+        }
+        // ETag must be enclosed in double quotes
+        if (!(etag.startsWith("\"") && etag.endsWith("\""))) {
+            return false;
+        }
+        // Remove the surrounding quotes for further validation
+        String etagValue = etag.substring(1, etag.length() - 1);
+        // ETag must not contain control characters or whitespace
+        for (char c : etagValue.toCharArray()) {
+            if (Character.isISOControl(c) || Character.isWhitespace(c)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/mycore-base/src/test/java/org/mycore/common/content/MCRPathContentTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/content/MCRPathContentTest.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.content;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import org.junit.jupiter.api.Test;
+import org.mycore.common.digest.MCRDigest;
+import org.mycore.common.digest.MCRMD5Digest;
+import org.mycore.datamodel.niofs.MCRDefaultFileAttributes;
+import org.mycore.datamodel.niofs.MCRFileAttributes;
+
+class MCRPathContentTest {
+
+    @Test
+    void getETag() throws IOException {
+        Path path = Path.of("src", "test", "resources", "MCRContentTest", "test.xml");
+        BasicFileAttributes attrs = Files.readAttributes(path, BasicFileAttributes.class);
+        assertNotNull(attrs);
+        MCRPathContent content = new MCRPathContent(path, attrs);
+        String etag = content.getETag();
+        assertNotNull(etag);
+        assertTrue(MCREtagHelper.isValidEtag(etag), "ETag is not valid: " + etag);
+    }
+
+    @Test
+    void getDigestETag() throws IOException {
+        Path path = Path.of("src", "test", "resources", "MCRContentTest", "test.xml");
+        BasicFileAttributes attrs = Files.readAttributes(path, BasicFileAttributes.class);
+        assertNotNull(attrs);
+        MCRDigest digest = new MCRMD5Digest("facedbadc0ffee1234567890deadbeef");
+        MCRFileAttributes mcrattrs = MCRDefaultFileAttributes.ofAttributes(attrs, digest);
+        MCRPathContent content = new MCRPathContent(path, mcrattrs);
+        String etag = content.getETag();
+        assertNotNull(etag);
+        assertTrue(MCREtagHelper.isValidEtag(etag), "ETag is not valid: " + etag);
+    }
+}

--- a/mycore-base/src/test/java/org/mycore/common/content/MCRStringContentTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/content/MCRStringContentTest.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.content;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class MCRStringContentTest {
+
+    @Test
+    void getETag() {
+        MCRStringContent test = new MCRStringContent("Test content for ETag");
+        String etag = test.getETag();
+        assertNotNull(etag);
+        assertTrue(MCREtagHelper.isValidEtag(etag), "ETag is not valid: " + etag);
+    }
+}

--- a/mycore-base/src/test/java/org/mycore/common/content/MCRURLContentTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/content/MCRURLContentTest.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.content;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+class MCRURLContentTest {
+
+    @Test
+    void getETag() throws IOException {
+        MCRURLContent test = new MCRURLContent(this.getClass().getResource("/MCRContentTest/test.xml"));
+        String etag = test.getETag();
+        assertNotNull(etag);
+        assertTrue(MCREtagHelper.isValidEtag(etag), "ETag is not valid: " + etag);
+    }
+}


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3567).

smaller improvements and add Junit tests.

This pull request refactors ETag generation and validation for content classes, improves consistency, and introduces comprehensive unit tests for ETag handling. The main changes include simplifying ETag formatting, centralizing ETag validation logic, updating REST API code to use the new ETag approach, and adding tests for all major content types.

### ETag generation and formatting improvements

* Refactored ETag generation in `MCRPathContent` and `MCRStringContent` to use direct string concatenation for quotes and removed usage of `Locale.ROOT` and `String.format`. ETag values are now always enclosed in double quotes and do not rely on locale formatting. (`[[1]](diffhunk://#diff-0f8631e8cd6e99e73f275cebbf9fd3f8a93a149fb9a5304c31361b26408452d4L92-R108)`, `[[2]](diffhunk://#diff-38d9ba1e85a8e48dd4fdf64b94db0f9db3ce61bcc3539b67a580ce486e3e1e35L85-R89)`)
* Added a private static helper method `getETag` in `MCRPathContent` for consistent ETag creation from `MCRFileAttributes`. (`[mycore-base/src/main/java/org/mycore/common/content/MCRPathContent.javaL92-R108](diffhunk://#diff-0f8631e8cd6e99e73f275cebbf9fd3f8a93a149fb9a5304c31361b26408452d4L92-R108)`)

### ETag validation and helper utilities

* Introduced new utility class `MCREtagHelper` with a method `isValidEtag` to validate ETag format, supporting both strong and weak ETags. (`[mycore-base/src/test/java/org/mycore/common/content/MCREtagHelper.javaR1-R45](diffhunk://#diff-8b85b76a8077f7b025853cf5d5311d3e04dc11f4d6bb81d35280024da78f2443R1-R45)`)

### REST API updates

* Updated REST API code in `MCRRestDerivateContents` to use the new ETag generation logic from `MCRPathContent`, ensuring consistent ETag values across API responses and proper handling of weak ETags. (`[[1]](diffhunk://#diff-6054e3a4bf229af922f7d0797f0d550606248d2e3f765f0f1961f8a910bc13bcL241-R252)`, `[[2]](diffhunk://#diff-6054e3a4bf229af922f7d0797f0d550606248d2e3f765f0f1961f8a910bc13bcL308-R318)`, `[[3]](diffhunk://#diff-6054e3a4bf229af922f7d0797f0d550606248d2e3f765f0f1961f8a910bc13bcL343-R353)`, `[[4]](diffhunk://#diff-6054e3a4bf229af922f7d0797f0d550606248d2e3f765f0f1961f8a910bc13bcL471-R481)`)

### Unit tests for ETag handling

* Added new unit tests for `MCRPathContent`, `MCRStringContent`, and `MCRURLContent` to verify ETag generation and validation using `MCREtagHelper`. (`[[1]](diffhunk://#diff-853eb0e10aaf651ea89cf5731ee874128c1a1f59772e156346d05d20b3311dd6R1-R62)`, `[[2]](diffhunk://#diff-3e477ba48f8faad95cfb6333637f69fd2bab2682434d5fd1234f407bb920a282R1-R36)`, `[[3]](diffhunk://#diff-135c6cb94f93d064cd4bd6d67503360d48cb84dfe00d5a45002f1cc21d83911dR1-R37)`)

### Code cleanup

* Removed unnecessary imports of `Locale` from content classes where it is no longer needed due to ETag formatting changes. (`[[1]](diffhunk://#diff-0f8631e8cd6e99e73f275cebbf9fd3f8a93a149fb9a5304c31361b26408452d4L34)`, `[[2]](diffhunk://#diff-38d9ba1e85a8e48dd4fdf64b94db0f9db3ce61bcc3539b67a580ce486e3e1e35L26)`)