### PR TITLE
MCR-3560 fix MCRCronjobManagerErrorTest

### DIFF
--- a/mycore-cronjob/src/test/java/org/mycore/mcr/cronjob/MCRCronjobManagerErrorTest.java
+++ b/mycore-cronjob/src/test/java/org/mycore/mcr/cronjob/MCRCronjobManagerErrorTest.java
@@ -40,7 +40,7 @@ public class MCRCronjobManagerErrorTest {
     /** Asserts that jobs will be rescheduled when an error occurs in the job */
     @Test
     public void testScheduleOnError() {
-        assertEquals(0, MCRTestCronJob.count, "job shouldn't have run yet");
+        assertEquals(0, MCRTestErrorCronJob.count, "job shouldn't have run yet");
         MCRCronjobManager.getInstance().startUp(null);
         try {
             Thread.sleep(2500);


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3560).

This pull request updates a test in the cronjob manager error test suite to reference the correct job class. The change ensures that the test is checking the intended error-handling behavior.

* Test correction:
  * In `MCRCronjobManagerErrorTest.java`, replaced `MCRTestCronJob.count` with `MCRTestErrorCronJob.count` in the `testScheduleOnError` method to properly verify the error scenario.

Follow up to https://github.com/MyCoRe-Org/mycore/pull/2742