### PR TITLE
MCR-3595 Added support for property MCR.Solr.Proxy.Disallowed.Parameter to allow removing of arbitrary parameters from solr requests

### DIFF
--- a/mycore-solr/src/main/java/org/mycore/solr/proxy/MCRSolrProxyServlet.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/proxy/MCRSolrProxyServlet.java
@@ -282,6 +282,10 @@ public class MCRSolrProxyServlet extends MCRServlet {
         MCRConfiguration2.getString("MCR.Solr.Disallowed.Facets")
             .ifPresent(disallowedFacets -> MCRConfiguration2.splitValue(disallowedFacets)
                 .forEach(disallowedFacet -> solrParameter.remove("facet.field", disallowedFacet)));
+
+        MCRConfiguration2.getString("MCR.Solr.Proxy.Disallowed.Parameter")
+            .ifPresent(disallowedParameter -> MCRConfiguration2.splitValue(disallowedParameter)
+                .forEach(solrParameter::remove));
     }
 
     private void updateQueryHandlerMap(HttpServletResponse resp) throws IOException {

--- a/mycore-solr/src/main/resources/components/solr/config/mycore.properties
+++ b/mycore-solr/src/main/resources/components/solr/config/mycore.properties
@@ -145,6 +145,9 @@ MCR.Solr.AddDerivates.Fields=id,returnId,derivateMaindoc,iviewFile,derivateType
 # comma separated list of disallowed facets
 #MCR.Solr.Disallowed.Facets=
 
+# comma separated list of disallowed parameters the proxy servlet will not forward to solr
+#MCR.Solr.Proxy.Disallowed.Parameter=
+
 # mapper, that retrieves an MCRObjectID from string 
 #MCR.Object.IDMapper.Class=org.mycore.solr.idmapper.MCRSolrIDMapper
 #MCR.Object.IDMapper.ObjectSolrFields=doi,category,derivates,id


### PR DESCRIPTION
[MCR-3595](https://mycore.atlassian.net/browse/MCR-3595).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [ ] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [ ] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [ ] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [ ] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [ ] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?


[MCR-3595]: https://mycore.atlassian.net/browse/MCR-3595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ