### PR TITLE
MCR-3601 OverlappingFileLockException when migrating to 2025.12

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/MCRExpandedObjectCache.java
+++ b/mycore-base/src/main/java/org/mycore/common/MCRExpandedObjectCache.java
@@ -49,16 +49,9 @@ public final class MCRExpandedObjectCache {
         return instance;
     }
 
-    // false negative: https://github.com/pmd/pmd/issues/4516
-    @SuppressWarnings("PMD.UnusedLocalVariable")
     private static MCRExpandedObject readExpandedObject(Path expandedObjectPath) {
-        try (FileChannel channel =
-            FileChannel.open(expandedObjectPath, StandardOpenOption.READ, StandardOpenOption.WRITE,
-                StandardOpenOption.SYNC);
-            FileLock fl = channel.lock()) {
-            byte[] fileContent = new byte[(int) channel.size()];
-            ByteBuffer buffer = ByteBuffer.wrap(fileContent);
-            channel.read(buffer);
+        try {
+            byte[] fileContent = Files.readAllBytes(expandedObjectPath);
             SAXBuilder saxBuilder = new SAXBuilder();
             Document jdom = saxBuilder.build(new ByteArrayInputStream(fileContent));
             return new MCRExpandedObject(jdom);


### PR DESCRIPTION
Remove the use of a FileLock when reading cached expanded objects to prevent OverlappingFileLockException triggered by concurrent reader/writer locks inside the same JVM. Rely on the existing ReentrantReadWriteLock for intra-process synchronization and keep the FileLock on writes for inter-process protection.

[Link to jira](https://mycore.atlassian.net/browse/MCR-3601).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [ ] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.


