### PR TITLE
MCR-3602 Corrupted checksums when renaming a derivate's files

### DIFF
--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRDerivateServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRDerivateServlet.java
@@ -23,6 +23,7 @@ import static org.mycore.access.MCRAccessManager.PERMISSION_WRITE;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -182,7 +183,7 @@ public class MCRDerivateServlet extends MCRServlet {
         updateMainFile = isMainFileUpdateRequired(pathFrom, derivateId);
 
         // this should always be a MCRPath, if not then ClassCastException is okay
-        MCRPath resultingFile = (MCRPath) Files.move(pathFrom, pathTo);
+        MCRPath resultingFile = (MCRPath) Files.move(pathFrom, pathTo, StandardCopyOption.COPY_ATTRIBUTES);
 
         if (updateMainFile) {
             setMainFile(derivateId, resultingFile);


### PR DESCRIPTION
When renaming a file using MCRDerivateServlet, a corrupted checksum will be written to mcrdata.xml.

The reason for this is that the call to Files.move() does not include the COPY_ATTRIBUTES flag.

This commit adds the missing flag.

[Link to jira](https://mycore.atlassian.net/browse/MCR-3602).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [X] The issue in the ticket is clearly described and the solution is documented.
- [X] Design decisions (if any) are explained.
- [X] The ticket references the correct source and target branches.
- [X] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [X] Affected version is listed in the ticket.
- [X] Minimal code changes were made (no refactoring).
- [X] This PR truly fixes **only** the reported bug.
- [X] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [X] I have tested the changes locally.
- [X] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [X] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
