### PR TITLE
MCR-3616 add select-lang and select-present-lang to i18n.xsl

### DIFF
--- a/mycore-base/src/main/resources/xslt/functions/i18n.xsl
+++ b/mycore-base/src/main/resources/xslt/functions/i18n.xsl
@@ -49,4 +49,44 @@
         </xsl:choose>
     </xsl:function>
 
+    <!--
+      Function: mcri18n:select-lang
+      synopsis: returns $CurrentLang if $elements[lang($CurrentLang)] is not empty, else $DefaultLang
+
+      parameters:
+      - $elements: the elements to check
+    -->
+    <xsl:function name="mcri18n:select-lang" as="xs:string">
+        <xsl:param name="elements" as="element()*"/>
+
+        <xsl:sequence select="
+      if (exists($elements[lang($CurrentLang)])) then
+        $CurrentLang
+      else
+        $DefaultLang
+    "/>
+    </xsl:function>
+
+    <!--
+      Function: mcri18n:select-present-lang
+      synopsis: returns the result of select-lang if elements for that language are present,
+                else returns a language for which elements are present
+
+      parameters:
+      - $elements: the elements to check
+    -->
+    <xsl:function name="mcri18n:select-present-lang" as="xs:string?">
+        <xsl:param name="elements" as="element()*"/>
+
+        <xsl:variable name="check" as="xs:string"
+                      select="mcri18n:select-lang($elements)"/>
+
+        <xsl:sequence select="
+      if (exists($elements[lang($check)])) then
+        $check
+      else
+        ($elements/@xml:lang/string())[1]
+    "/>
+    </xsl:function>
+
 </xsl:stylesheet>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3616).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [ ] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [x] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [ ] Affected version is listed in the ticket.
- [ ] Minimal code changes were made (no refactoring).
- [ ] This PR truly fixes **only** the reported bug.
- [ ] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [x] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
