### PR TITLE
MCR-3632 fix test isolation and nesting

### DIFF
--- a/mycore-base/src/test/java/org/mycore/test/MCRTestExtension.java
+++ b/mycore-base/src/test/java/org/mycore/test/MCRTestExtension.java
@@ -109,9 +109,10 @@ public class MCRTestExtension implements Extension, BeforeEachCallback, AfterEac
     }
 
     private Map<String, String> getConfigProperties(ExtensionContext context) {
-        return getClassContext(context).getStore(NAMESPACE)
+        ExtensionContext classContext = getClassContext(context);
+        return classContext.getStore(NAMESPACE)
             .getOrComputeIfAbsent(MCRTestExtension.PROPERTIES_MAP_PROPERTY, k -> {
-                LOGGER.debug(() -> getClassContext(context).getRequiredTestClass() + " creating new properties map");
+                LOGGER.debug(() -> classContext.getRequiredTestClass() + " creating new properties map");
                 return new HashMap<>();
             }, Map.class);
     }

--- a/mycore-base/src/test/java/org/mycore/test/MCRTestExtension.java
+++ b/mycore-base/src/test/java/org/mycore/test/MCRTestExtension.java
@@ -99,10 +99,19 @@ public class MCRTestExtension implements Extension, BeforeEachCallback, AfterEac
         MCRConfigurationBase.initialize(configurationLoader.loadDeprecated(), mycoreProperties, true);
     }
 
+    private ExtensionContext getClassContext(ExtensionContext context) {
+        ExtensionContext currentCtx = context;
+        //navigate up to the class context, which can be several levels up for @ParameterizedTest
+        while (currentCtx.getTestMethod().isPresent() && currentCtx.getParent().isPresent()) {
+            currentCtx = currentCtx.getParent().get();
+        }
+        return currentCtx;
+    }
+
     private Map<String, String> getConfigProperties(ExtensionContext context) {
-        return context.getRoot().getStore(NAMESPACE)
+        return getClassContext(context).getStore(NAMESPACE)
             .getOrComputeIfAbsent(MCRTestExtension.PROPERTIES_MAP_PROPERTY, k -> {
-                LOGGER.debug(() -> context.getElement().get() + " creating new properties map");
+                LOGGER.debug(() -> getClassContext(context).getRequiredTestClass() + " creating new properties map");
                 return new HashMap<>();
             }, Map.class);
     }
@@ -172,7 +181,7 @@ public class MCRTestExtension implements Extension, BeforeEachCallback, AfterEac
         if (context.getTestMethod().isPresent()) {
             throw new IllegalStateException("This method should only be called for class-level extensions.");
         }
-        return context.getRoot().getStore(NAMESPACE)
+        return context.getStore(NAMESPACE)
             .getOrComputeIfAbsent(MCRTestExtension.CLASS_PROPERTIES_MAP_PROPERTY, k -> {
                 LOGGER.debug("Creating empty extension properties");
                 return new HashMap<>();

--- a/mycore-base/src/test/java/org/mycore/test/MCRTestExtensionConfigurationHelper.java
+++ b/mycore-base/src/test/java/org/mycore/test/MCRTestExtensionConfigurationHelper.java
@@ -26,7 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -156,14 +156,14 @@ public class MCRTestExtensionConfigurationHelper {
             .orElseGet(List::of);
     }
 
-    // Traverse the class hierarchy to find @MyAnnotation on the class or any of its superclasses.
+    // Traverse the class hierarchy (superclasses) and enclosing classes to find @MCRTestConfiguration annotations.
     private static List<MCRTestConfiguration> findClassHierarchyTestConfigurations(Class<?> clazz) {
         List<MCRTestConfiguration> annotations = new ArrayList<>();
-        Set<Class<?>> visited = new LinkedHashSet<>();
+        Set<Class<?>> visited = new HashSet<>();
         Class<?> currentClass = clazz;
         while (currentClass != null) {
             for (Class<?> current = currentClass; current != null; current = current.getSuperclass()) {
-                if (visited.add(current)) {
+                if (visited.add(current)) { //only add annotation of a class once
                     MCRTestConfiguration annotation = current.getAnnotation(MCRTestConfiguration.class);
                     if (annotation != null) {
                         annotations.add(annotation);

--- a/mycore-base/src/test/java/org/mycore/test/MCRTestExtensionConfigurationHelper.java
+++ b/mycore-base/src/test/java/org/mycore/test/MCRTestExtensionConfigurationHelper.java
@@ -157,11 +157,15 @@ public class MCRTestExtensionConfigurationHelper {
     // Traverse the class hierarchy to find @MyAnnotation on the class or any of its superclasses.
     private static List<MCRTestConfiguration> findClassHierarchyTestConfigurations(Class<?> clazz) {
         List<MCRTestConfiguration> annotations = new ArrayList<>();
-        for (Class<?> current = clazz; current != null; current = current.getSuperclass()) {
-            MCRTestConfiguration annotation = current.getAnnotation(MCRTestConfiguration.class);
-            if (annotation != null) {
-                annotations.add(annotation);
+        Class<?> currentClass = clazz;
+        while (currentClass != null) {
+            for (Class<?> current = currentClass; current != null; current = current.getSuperclass()) {
+                MCRTestConfiguration annotation = current.getAnnotation(MCRTestConfiguration.class);
+                if (annotation != null) {
+                    annotations.add(annotation);
+                }
             }
+            currentClass = currentClass.getEnclosingClass();
         }
         return annotations;
     }

--- a/mycore-base/src/test/java/org/mycore/test/MCRTestExtensionConfigurationHelper.java
+++ b/mycore-base/src/test/java/org/mycore/test/MCRTestExtensionConfigurationHelper.java
@@ -26,7 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -159,7 +159,7 @@ public class MCRTestExtensionConfigurationHelper {
     // Traverse the class hierarchy to find @MyAnnotation on the class or any of its superclasses.
     private static List<MCRTestConfiguration> findClassHierarchyTestConfigurations(Class<?> clazz) {
         List<MCRTestConfiguration> annotations = new ArrayList<>();
-        Set<Class<?>> visited = new HashSet<>();
+        Set<Class<?>> visited = new LinkedHashSet<>();
         Class<?> currentClass = clazz;
         while (currentClass != null) {
             for (Class<?> current = currentClass; current != null; current = current.getSuperclass()) {

--- a/mycore-base/src/test/java/org/mycore/test/MCRTestExtensionConfigurationHelper.java
+++ b/mycore-base/src/test/java/org/mycore/test/MCRTestExtensionConfigurationHelper.java
@@ -26,10 +26,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -157,12 +159,15 @@ public class MCRTestExtensionConfigurationHelper {
     // Traverse the class hierarchy to find @MyAnnotation on the class or any of its superclasses.
     private static List<MCRTestConfiguration> findClassHierarchyTestConfigurations(Class<?> clazz) {
         List<MCRTestConfiguration> annotations = new ArrayList<>();
+        Set<Class<?>> visited = new HashSet<>();
         Class<?> currentClass = clazz;
         while (currentClass != null) {
             for (Class<?> current = currentClass; current != null; current = current.getSuperclass()) {
-                MCRTestConfiguration annotation = current.getAnnotation(MCRTestConfiguration.class);
-                if (annotation != null) {
-                    annotations.add(annotation);
+                if (visited.add(current)) {
+                    MCRTestConfiguration annotation = current.getAnnotation(MCRTestConfiguration.class);
+                    if (annotation != null) {
+                        annotations.add(annotation);
+                    }
                 }
             }
             currentClass = currentClass.getEnclosingClass();


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3632).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [ ] I have tested the changes locally.
- [ ] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
