### PR TITLE
MCR-3637 rename MCRCategoryID.isRootID() to isRoot()

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/content/MCRPathContent.java
+++ b/mycore-base/src/main/java/org/mycore/common/content/MCRPathContent.java
@@ -98,7 +98,7 @@ public class MCRPathContent extends MCRContent implements MCRSeekableChannelCont
             return getETag(fAttrs);
         } else if (attrs == null) {
             try {
-                MCRFileAttributes mcrattrs = Files.readAttributes(path, MCRFileAttributes.class);
+                MCRFileAttributes<?> mcrattrs = Files.readAttributes(path, MCRFileAttributes.class);
                 return getETag(mcrattrs);
             } catch (UnsupportedOperationException ignored) {
                 //no support for MCRFileAttributes

--- a/mycore-base/src/main/java/org/mycore/common/xml/MCRXMLFunctions.java
+++ b/mycore-base/src/main/java/org/mycore/common/xml/MCRXMLFunctions.java
@@ -661,7 +661,7 @@ public class MCRXMLFunctions {
     public static boolean hasParentCategory(String classificationId, String categoryId) {
         MCRCategoryID categID = new MCRCategoryID(classificationId, categoryId);
         //root category has level 0
-        return !categID.isRootID() && MCRCategoryDAOFactory.obtainInstance().getCategory(categID, 0).getLevel() > 1;
+        return !categID.isARootID() && MCRCategoryDAOFactory.obtainInstance().getCategory(categID, 0).getLevel() > 1;
     }
 
     public static String getDisplayName(String classificationId, String categoryId) {

--- a/mycore-base/src/main/java/org/mycore/common/xml/MCRXMLFunctions.java
+++ b/mycore-base/src/main/java/org/mycore/common/xml/MCRXMLFunctions.java
@@ -661,7 +661,7 @@ public class MCRXMLFunctions {
     public static boolean hasParentCategory(String classificationId, String categoryId) {
         MCRCategoryID categID = new MCRCategoryID(classificationId, categoryId);
         //root category has level 0
-        return !categID.isARootID() && MCRCategoryDAOFactory.obtainInstance().getCategory(categID, 0).getLevel() > 1;
+        return !categID.isRoot() && MCRCategoryDAOFactory.obtainInstance().getCategory(categID, 0).getLevel() > 1;
     }
 
     public static String getDisplayName(String classificationId, String categoryId) {

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/MCRCategoryID.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/MCRCategoryID.java
@@ -109,8 +109,25 @@ public class MCRCategoryID implements Serializable {
         }
     }
 
+    /**
+     * @return true, if this category is a root category.
+     * 
+     * @deprecated Use {@link isARootID()} instead.
+     * The method name is in conflict with the JavaBeans Specification 1.01, §8.3.2 
+     * There is also a getter getRootID() which returns a String.
+     * Therefore this method will be renamed to isARootID().
+     */
+    @Deprecated(forRemoval = true)
     @Transient
     public boolean isRootID() {
+        return isARootID();
+    }
+
+    /**
+     * @return true, if this category is a root category.
+     */
+    @Transient
+    public boolean isARootID() {
         return id == null || id.isEmpty();
     }
 

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/MCRCategoryID.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/MCRCategoryID.java
@@ -112,22 +112,22 @@ public class MCRCategoryID implements Serializable {
     /**
      * @return true, if this category is a root category.
      * 
-     * @deprecated Use {@link isARootID()} instead.
+     * @deprecated Use {@link isRoot()} instead.
      * The method name is in conflict with the JavaBeans Specification 1.01, §8.3.2 
      * There is also a getter getRootID() which returns a String.
-     * Therefore this method will be renamed to isARootID().
+     * Therefore this method will be renamed to isRoot().
      */
     @Deprecated(forRemoval = true)
     @Transient
     public boolean isRootID() {
-        return isARootID();
+        return isRoot();
     }
 
     /**
      * @return true, if this category is a root category.
      */
     @Transient
-    public boolean isARootID() {
+    public boolean isRoot() {
         return id == null || id.isEmpty();
     }
 

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRAbstractCategoryImpl.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRAbstractCategoryImpl.java
@@ -113,7 +113,7 @@ public abstract class MCRAbstractCategoryImpl implements MCRCategory {
 
     @Override
     public MCRCategory getRoot() {
-        if (getId().isARootID()) {
+        if (getId().isRoot()) {
             return this;
         }
         if (root == null && getParent() != null) {
@@ -146,7 +146,7 @@ public abstract class MCRAbstractCategoryImpl implements MCRCategory {
 
     @Override
     public final boolean isClassification() {
-        return getId().isARootID();
+        return getId().isRoot();
     }
 
     @Override

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRAbstractCategoryImpl.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRAbstractCategoryImpl.java
@@ -113,7 +113,7 @@ public abstract class MCRAbstractCategoryImpl implements MCRCategory {
 
     @Override
     public MCRCategory getRoot() {
-        if (getId().isRootID()) {
+        if (getId().isARootID()) {
             return this;
         }
         if (root == null && getParent() != null) {
@@ -146,7 +146,7 @@ public abstract class MCRAbstractCategoryImpl implements MCRCategory {
 
     @Override
     public final boolean isClassification() {
-        return getId().isRootID();
+        return getId().isARootID();
     }
 
     @Override

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRCategoryDAOImpl.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRCategoryDAOImpl.java
@@ -221,7 +221,7 @@ public class MCRCategoryDAOImpl implements MCRCategoryDAO {
         EntityManager entityManager = MCREntityManagerProvider.getCurrentEntityManager();
         final boolean fetchAllChildren = childLevel < 0;
         Query q;
-        if (id.isARootID()) {
+        if (id.isRoot()) {
             q = entityManager.createNamedQuery(NAMED_QUERY_NAMESPACE
                 + (fetchAllChildren ? "prefetchClassQuery" : "prefetchClassLevelQuery"));
             if (!fetchAllChildren) {
@@ -345,7 +345,7 @@ public class MCRCategoryDAOImpl implements MCRCategoryDAO {
     public MCRCategory getRootCategory(MCRCategoryID baseID, int childLevel) {
         return Optional.ofNullable(getCategory(baseID, childLevel))
             .map(c -> {
-                if (baseID.isARootID()) {
+                if (baseID.isRoot()) {
                     return c;
                 }
                 List<MCRCategory> parents = getParents(baseID);

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRCategoryDAOImpl.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRCategoryDAOImpl.java
@@ -221,7 +221,7 @@ public class MCRCategoryDAOImpl implements MCRCategoryDAO {
         EntityManager entityManager = MCREntityManagerProvider.getCurrentEntityManager();
         final boolean fetchAllChildren = childLevel < 0;
         Query q;
-        if (id.isRootID()) {
+        if (id.isARootID()) {
             q = entityManager.createNamedQuery(NAMED_QUERY_NAMESPACE
                 + (fetchAllChildren ? "prefetchClassQuery" : "prefetchClassLevelQuery"));
             if (!fetchAllChildren) {
@@ -345,7 +345,7 @@ public class MCRCategoryDAOImpl implements MCRCategoryDAO {
     public MCRCategory getRootCategory(MCRCategoryID baseID, int childLevel) {
         return Optional.ofNullable(getCategory(baseID, childLevel))
             .map(c -> {
-                if (baseID.isRootID()) {
+                if (baseID.isARootID()) {
                     return c;
                 }
                 List<MCRCategory> parents = getParents(baseID);

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRCategoryDTO.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRCategoryDTO.java
@@ -102,7 +102,7 @@ public class MCRCategoryDTO {
         cat.setInternalID(internalID);
         cat.setURI(uri);
         cat.setId(id);
-        if (cat.getId().isARootID()) {
+        if (cat.getId().isRoot()) {
             cat.setRoot(cat);
         }
         cat.setLeft(leftValue);

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRCategoryDTO.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/impl/MCRCategoryDTO.java
@@ -102,7 +102,7 @@ public class MCRCategoryDTO {
         cat.setInternalID(internalID);
         cat.setURI(uri);
         cat.setId(id);
-        if (cat.getId().isRootID()) {
+        if (cat.getId().isARootID()) {
             cat.setRoot(cat);
         }
         cat.setLeft(leftValue);

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/mapping/MCRXMappingClassificationGeneratorBase.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/mapping/MCRXMappingClassificationGeneratorBase.java
@@ -84,7 +84,7 @@ public abstract class MCRXMappingClassificationGeneratorBase implements Generato
         return sourceCategory.getLabel(LABEL_LANG_X_MAPPING)
             .map(label -> evaluator.getCategoryIds(label.getText(), object)
                 .stream()
-                .filter(categoryId -> !categoryId.isRootID())
+                .filter(categoryId -> !categoryId.isARootID())
                 .filter(categoryId -> dao.exist(categoryId) || handleMissingCategory(categoryId, sourceCategoryId))
                 .map(targetCategoryId -> new XMapping(sourceCategoryId, targetCategoryId))
                 .collect(Collectors.toList()))

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/mapping/MCRXMappingClassificationGeneratorBase.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/mapping/MCRXMappingClassificationGeneratorBase.java
@@ -84,7 +84,7 @@ public abstract class MCRXMappingClassificationGeneratorBase implements Generato
         return sourceCategory.getLabel(LABEL_LANG_X_MAPPING)
             .map(label -> evaluator.getCategoryIds(label.getText(), object)
                 .stream()
-                .filter(categoryId -> !categoryId.isARootID())
+                .filter(categoryId -> !categoryId.isRoot())
                 .filter(categoryId -> dao.exist(categoryId) || handleMissingCategory(categoryId, sourceCategoryId))
                 .map(targetCategoryId -> new XMapping(sourceCategoryId, targetCategoryId))
                 .collect(Collectors.toList()))

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClass.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClass.java
@@ -106,7 +106,7 @@ public class MCRClass {
     }
 
     public static MCRClass ofCategory(MCRCategory rootCategory) {
-        if (!rootCategory.getId().isRootID()) {
+        if (!rootCategory.getId().isARootID()) {
             throw new IllegalArgumentException("Not a root category");
         }
         MCRClass mcrClass = new MCRClass();

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClass.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClass.java
@@ -106,7 +106,7 @@ public class MCRClass {
     }
 
     public static MCRClass ofCategory(MCRCategory rootCategory) {
-        if (!rootCategory.getId().isARootID()) {
+        if (!rootCategory.getId().isRoot()) {
             throw new IllegalArgumentException("Not a root category");
         }
         MCRClass mcrClass = new MCRClass();

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClassCategory.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClassCategory.java
@@ -99,7 +99,7 @@ public class MCRClassCategory {
     public static MCRClassCategory ofCategory(MCRCategory from) {
         MCRClassCategory categ = new MCRClassCategory();
         MCRCategoryID categoryID = from.getId();
-        categ.setID(categoryID.isARootID() ? categoryID.getRootID() : categoryID.getId());
+        categ.setID(categoryID.isRoot() ? categoryID.getRootID() : categoryID.getId());
         categ.setUrl(MCRClassURL.ofUri(from.getURI()));
         categ.getCategory().addAll(
             from.getChildren()

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClassCategory.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClassCategory.java
@@ -99,7 +99,7 @@ public class MCRClassCategory {
     public static MCRClassCategory ofCategory(MCRCategory from) {
         MCRClassCategory categ = new MCRClassCategory();
         MCRCategoryID categoryID = from.getId();
-        categ.setID(categoryID.isRootID() ? categoryID.getRootID() : categoryID.getId());
+        categ.setID(categoryID.isARootID() ? categoryID.getRootID() : categoryID.getId());
         categ.setUrl(MCRClassURL.ofUri(from.getURI()));
         categ.getCategory().addAll(
             from.getChildren()

--- a/mycore-classeditor/src/main/java/org/mycore/frontend/classeditor/resources/MCRClassificationEditorResource.java
+++ b/mycore-classeditor/src/main/java/org/mycore/frontend/classeditor/resources/MCRClassificationEditorResource.java
@@ -460,7 +460,7 @@ public class MCRClassificationEditorResource {
         public void run() {
             MCRCategoryID categoryID = category.getId();
             if (CATEGORY_DAO.exist(categoryID)) {
-                if (categoryID.isARootID()
+                if (categoryID.isRoot()
                     && !MCRAccessManager.checkPermission(categoryID.getRootID(), PERMISSION_DELETE)) {
                     throw new WebApplicationException(Status.UNAUTHORIZED);
                 }

--- a/mycore-classeditor/src/main/java/org/mycore/frontend/classeditor/resources/MCRClassificationEditorResource.java
+++ b/mycore-classeditor/src/main/java/org/mycore/frontend/classeditor/resources/MCRClassificationEditorResource.java
@@ -460,7 +460,7 @@ public class MCRClassificationEditorResource {
         public void run() {
             MCRCategoryID categoryID = category.getId();
             if (CATEGORY_DAO.exist(categoryID)) {
-                if (categoryID.isRootID()
+                if (categoryID.isARootID()
                     && !MCRAccessManager.checkPermission(categoryID.getRootID(), PERMISSION_DELETE)) {
                     throw new WebApplicationException(Status.UNAUTHORIZED);
                 }

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/classification/MCROCFLClassificationEventHandler.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/classification/MCROCFLClassificationEventHandler.java
@@ -44,7 +44,7 @@ public class MCROCFLClassificationEventHandler implements MCREventHandler {
                 case CREATE -> addClassificationEvent(mcrCg.getRoot().getId(), MCRAbstractMetadataVersion.CREATED);
                 case UPDATE -> addClassificationEvent(mcrCg.getRoot().getId(), MCRAbstractMetadataVersion.UPDATED);
                 case DELETE -> {
-                    if (mcrCg.getId().isRootID()) {
+                    if (mcrCg.getId().isARootID()) {
                         // delete complete classification
                         addClassificationEvent(mcrCg.getRoot().getId(), MCRAbstractMetadataVersion.DELETED);
                     } else {

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/classification/MCROCFLClassificationEventHandler.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/classification/MCROCFLClassificationEventHandler.java
@@ -44,7 +44,7 @@ public class MCROCFLClassificationEventHandler implements MCREventHandler {
                 case CREATE -> addClassificationEvent(mcrCg.getRoot().getId(), MCRAbstractMetadataVersion.CREATED);
                 case UPDATE -> addClassificationEvent(mcrCg.getRoot().getId(), MCRAbstractMetadataVersion.UPDATED);
                 case DELETE -> {
-                    if (mcrCg.getId().isARootID()) {
+                    if (mcrCg.getId().isRoot()) {
                         // delete complete classification
                         addClassificationEvent(mcrCg.getRoot().getId(), MCRAbstractMetadataVersion.DELETED);
                     } else {

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/classification/MCROCFLClassificationTransaction.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/classification/MCROCFLClassificationTransaction.java
@@ -126,7 +126,7 @@ public class MCROCFLClassificationTransaction implements MCRPersistenceTransacti
      * @param type 'A' for created, 'M' for modified, 'D' deleted
      */
     public static void addClassificationEvent(MCRCategoryID id, char type) {
-        if (!Objects.requireNonNull(id).isARootID()) {
+        if (!Objects.requireNonNull(id).isRoot()) {
             throw new IllegalArgumentException("Only root category ids are allowed: " + id);
         }
         switch (type) {

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/classification/MCROCFLClassificationTransaction.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/classification/MCROCFLClassificationTransaction.java
@@ -126,7 +126,7 @@ public class MCROCFLClassificationTransaction implements MCRPersistenceTransacti
      * @param type 'A' for created, 'M' for modified, 'D' deleted
      */
     public static void addClassificationEvent(MCRCategoryID id, char type) {
-        if (!Objects.requireNonNull(id).isRootID()) {
+        if (!Objects.requireNonNull(id).isARootID()) {
             throw new IllegalArgumentException("Only root category ids are allowed: " + id);
         }
         switch (type) {

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/classification/MCROCFLXMLClassificationManager.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/classification/MCROCFLXMLClassificationManager.java
@@ -152,7 +152,7 @@ public class MCROCFLXMLClassificationManager implements MCRXMLClassificationMana
      * @throws MCRUsageException if the Category is not a root classification
      */
     protected String buildFilePath(MCRCategoryID mcrid) {
-        if (!mcrid.isRootID()) {
+        if (!mcrid.isARootID()) {
             throw new IllegalArgumentException("Only root categories are allowed: " + mcrid);
         }
         return ROOT_FOLDER + mcrid + ".xml";

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/classification/MCROCFLXMLClassificationManager.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/classification/MCROCFLXMLClassificationManager.java
@@ -152,7 +152,7 @@ public class MCROCFLXMLClassificationManager implements MCRXMLClassificationMana
      * @throws MCRUsageException if the Category is not a root classification
      */
     protected String buildFilePath(MCRCategoryID mcrid) {
-        if (!mcrid.isARootID()) {
+        if (!mcrid.isRoot()) {
             throw new IllegalArgumentException("Only root categories are allowed: " + mcrid);
         }
         return ROOT_FOLDER + mcrid + ".xml";

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/commands/MCROCFLCommands.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/commands/MCROCFLCommands.java
@@ -370,7 +370,7 @@ public class MCROCFLCommands {
         help = "Permanently delete classification {0} and its history from ocfl")
     public static void purgeClass(String mcrCgIdString) {
         MCRCategoryID mcrCgId = MCRCategoryID.ofString(mcrCgIdString);
-        if (!mcrCgId.isARootID()) {
+        if (!mcrCgId.isRoot()) {
             throw new MCRUsageException("You can only purge root classifications!");
         }
         MCRConfiguration2.getSingleInstanceOfOrThrow(

--- a/mycore-ocfl/src/main/java/org/mycore/ocfl/commands/MCROCFLCommands.java
+++ b/mycore-ocfl/src/main/java/org/mycore/ocfl/commands/MCROCFLCommands.java
@@ -370,7 +370,7 @@ public class MCROCFLCommands {
         help = "Permanently delete classification {0} and its history from ocfl")
     public static void purgeClass(String mcrCgIdString) {
         MCRCategoryID mcrCgId = MCRCategoryID.ofString(mcrCgIdString);
-        if (!mcrCgId.isRootID()) {
+        if (!mcrCgId.isARootID()) {
             throw new MCRUsageException("You can only purge root classifications!");
         }
         MCRConfiguration2.getSingleInstanceOfOrThrow(

--- a/mycore-user2/src/main/java/org/mycore/user2/MCRRoleManager.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/MCRRoleManager.java
@@ -106,7 +106,7 @@ public class MCRRoleManager {
      */
     public static MCRRole getExternalRole(String name) {
         MCRCategoryID categoryID = MCRCategoryID.ofString(name);
-        if (categoryID.isARootID()) {
+        if (categoryID.isRoot()) {
             LOGGER.debug("External role may not be a rootCategory: {}", categoryID);
             return null;
         }

--- a/mycore-user2/src/main/java/org/mycore/user2/MCRRoleManager.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/MCRRoleManager.java
@@ -106,7 +106,7 @@ public class MCRRoleManager {
      */
     public static MCRRole getExternalRole(String name) {
         MCRCategoryID categoryID = MCRCategoryID.ofString(name);
-        if (categoryID.isRootID()) {
+        if (categoryID.isARootID()) {
             LOGGER.debug("External role may not be a rootCategory: {}", categoryID);
             return null;
         }

--- a/mycore-user2/src/main/java/org/mycore/user2/MCRRoleServlet.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/MCRRoleServlet.java
@@ -143,7 +143,7 @@ public class MCRRoleServlet extends MCRServlet {
         }
         Element rootElement = getRootElement(request);
         rootElement.setAttribute("classID", categoryID.getRootID());
-        if (!categoryID.isARootID()) {
+        if (!categoryID.isRoot()) {
             rootElement.setAttribute("categID", categoryID.getId());
         }
         request.setAttribute(LAYOUT_ELEMENT_KEY, new Document(rootElement));

--- a/mycore-user2/src/main/java/org/mycore/user2/MCRRoleServlet.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/MCRRoleServlet.java
@@ -143,7 +143,7 @@ public class MCRRoleServlet extends MCRServlet {
         }
         Element rootElement = getRootElement(request);
         rootElement.setAttribute("classID", categoryID.getRootID());
-        if (!categoryID.isRootID()) {
+        if (!categoryID.isARootID()) {
             rootElement.setAttribute("categID", categoryID.getId());
         }
         request.setAttribute(LAYOUT_ELEMENT_KEY, new Document(rootElement));


### PR DESCRIPTION
in conflict with other getter getRootID()

[Link to jira](https://mycore.atlassian.net/browse/MCR-3637).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [x] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [x] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [x] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [ ] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [ ] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [x] If the **public API** has changed:
  - [x] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [x] Java license headers are added where necessary.
- [x] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [x] All configuration options are documented in Javadoc and `mycore.properties`.
- [x] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [x] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
