### PR TITLE
MCR-3639 Add support for annotation based configuration of string-valued maps and lists

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/config/MCRConfigurableInstanceHelper.java
+++ b/mycore-base/src/main/java/org/mycore/common/config/MCRConfigurableInstanceHelper.java
@@ -23,6 +23,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -35,8 +37,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
@@ -52,6 +57,8 @@ import org.mycore.common.config.annotation.MCRInstanceList;
 import org.mycore.common.config.annotation.MCRInstanceMap;
 import org.mycore.common.config.annotation.MCRPostConstruction;
 import org.mycore.common.config.annotation.MCRProperty;
+import org.mycore.common.config.annotation.MCRPropertyList;
+import org.mycore.common.config.annotation.MCRPropertyMap;
 import org.mycore.common.config.annotation.MCRRawProperties;
 import org.mycore.common.config.annotation.MCRSentinel;
 
@@ -62,7 +69,7 @@ import jakarta.inject.Singleton;
  *
  * @author Sebastian Hofmann
  */
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.SingleMethodSingleton",
+@SuppressWarnings({ "PMD.AvoidDuplicateLiterals", "PMD.SingleMethodSingleton",
     "PMD.MCR.Singleton.MethodModifiers", "PMD.MCR.Singleton.MethodReturnType",
     "PMD.MCR.Singleton.ClassModifiers", "PMD.MCR.Singleton.PrivateConstructor",
     "PMD.MCR.Singleton.NonPrivateConstructors",
@@ -73,8 +80,8 @@ class MCRConfigurableInstanceHelper {
 
     public static final Set<Option> NO_OPTIONS = Collections.emptySet();
 
-    public static final Set<Option> ADD_IMPLICIT_CLASS_PROPERTIES
-        = Collections.singleton(Option.ADD_IMPLICIT_CLASS_PROPERTIES);
+    public static final Set<Option> ADD_IMPLICIT_CLASS_PROPERTIES =
+        Collections.singleton(Option.ADD_IMPLICIT_CLASS_PROPERTIES);
 
     private static final ConcurrentMap<Class<?>, ClassInfo<?>> INFOS = new ConcurrentHashMap<>();
 
@@ -163,6 +170,7 @@ class MCRConfigurableInstanceHelper {
         Set<Option> options) throws MCRConfigurationException {
         String className = configuration.className();
         if (className == null || className.isBlank()) {
+
             if (options.contains(Option.ADD_IMPLICIT_CLASS_PROPERTIES) && Modifier.isFinal(superClass.getModifiers())) {
                 configuration = configuration.fixedClass(superClass);
                 if (LOGGER.isInfoEnabled()) {
@@ -181,8 +189,7 @@ class MCRConfigurableInstanceHelper {
         } else {
             throw new MCRConfigurationException("Configured instance of class " + instance.getClass().getName()
                 + " is incompatible with intended super class " + superClass.getName() + "'"
-                + (name != null ? " in configured class " + name : "")
-            );
+                + (name != null ? " in configured class " + name : ""));
         }
     }
 
@@ -335,20 +342,18 @@ class MCRConfigurableInstanceHelper {
 
             List<Method> declaredFactoryMethods = findFactoryMethods(targetClass, targetClass.getDeclaredMethods());
             Optional<Supplier<T>> factory = Stream.<Supplier<Optional<Supplier<T>>>>of(
-                    () -> findSingletonFactoryMethod(declaredFactoryMethods),
-                    () -> findAnnotatedFactoryMethod(declaredFactoryMethods),
-                    () -> findDefaultConstructor(targetClass))
+                () -> findSingletonFactoryMethod(declaredFactoryMethods),
+                () -> findAnnotatedFactoryMethod(declaredFactoryMethods),
+                () -> findDefaultConstructor(targetClass))
                 .map(Supplier::get)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .findFirst();
 
-            return factory.orElseThrow(() ->
-                new MCRConfigurationException("Class " + targetClass.getName() + " has "
-                    + " has no singleton factory method (public, static, matching return type, parameterless, name"
-                    + " equals 'getInstance'), no annotated factory method (public, static, matching return type,"
-                    + " parameterless, annotated with @MCRFactory) and no public parameterless constructor")
-            );
+            return factory.orElseThrow(() -> new MCRConfigurationException("Class " + targetClass.getName() + " has "
+                + " has no singleton factory method (public, static, matching return type, parameterless, name"
+                + " equals 'getInstance'), no annotated factory method (public, static, matching return type,"
+                + " parameterless, annotated with @MCRFactory) and no public parameterless constructor"));
 
         }
 
@@ -709,6 +714,34 @@ class MCRConfigurableInstanceHelper {
 
         }),
 
+        PROPERTY_MAP(SourceGroup.VALUE_INJECTION, new AnnotationMapper<MCRPropertyMap>() {
+
+            @Override
+            public Class<MCRPropertyMap> annotationClass() {
+                return MCRPropertyMap.class;
+            }
+
+            @Override
+            public Source<MCRPropertyMap, ?> annotationToSource(MCRPropertyMap annotation) {
+                return new PropertyMapSource(annotation);
+            }
+
+        }),
+
+        PROPERTY_LIST(SourceGroup.VALUE_INJECTION, new AnnotationMapper<MCRPropertyList>() {
+
+            @Override
+            public Class<MCRPropertyList> annotationClass() {
+                return MCRPropertyList.class;
+            }
+
+            @Override
+            public Source<MCRPropertyList, ?> annotationToSource(MCRPropertyList annotation) {
+                return new PropertyListSource(annotation);
+            }
+
+        }),
+
         RAW_PROPERTIES(SourceGroup.VALUE_INJECTION, new AnnotationMapper<MCRRawProperties>() {
 
             @Override
@@ -718,7 +751,7 @@ class MCRConfigurableInstanceHelper {
 
             @Override
             public Source<MCRRawProperties, ?> annotationToSource(MCRRawProperties annotation) {
-              return new RawPropertiesSource(annotation);
+                return new RawPropertiesSource(annotation);
             }
 
         }),
@@ -866,13 +899,15 @@ class MCRConfigurableInstanceHelper {
         @Override
         public String get(MCRInstanceConfiguration configuration, Target<?> target) {
 
-            String value;
-
-            if (!annotation.absolute()) {
-                value = configuration.properties().get(annotation.name());
-            } else {
-                value = configuration.fullProperties().get(annotation.name());
+            String name = annotation.name();
+            if (name.isEmpty()) {
+                throw new MCRConfigurationException("The name must not be empty");
             }
+
+            Map<String, String> properties =
+                annotation.absolute() ? configuration.fullProperties() : configuration.properties();
+
+            String value = properties.get(name);
 
             if (value == null && !Objects.equals("", annotation.defaultName())) {
                 value = configuration.fullProperties().get(annotation.defaultName());
@@ -885,7 +920,7 @@ class MCRConfigurableInstanceHelper {
             if (value == null && annotation.required()) {
                 throw new MCRConfigurationException("The required property "
                     + configuration.name().canonical() + "."
-                    + annotation.name() + " is missing");
+                    + name + " is missing");
             }
 
             return value;
@@ -894,29 +929,26 @@ class MCRConfigurableInstanceHelper {
 
     }
 
-    private static final class AllPropertiesSource extends Source<MCRProperty, Map<String, String>> {
+    private static final class PropertyMapSource extends Source<MCRPropertyMap, Map<String, String>> {
 
-        private final MCRProperty annotation;
+        private final MCRPropertyMap annotation;
 
-        private final String prefix;
-
-        private AllPropertiesSource(MCRProperty annotation, String prefix) {
+        private PropertyMapSource(MCRPropertyMap annotation) {
             this.annotation = annotation;
-            this.prefix = prefix;
         }
 
         @Override
         public SourceType type() {
-            return SourceType.PROPERTY;
+            return SourceType.PROPERTY_MAP;
         }
 
         @Override
-        public Class<MCRProperty> annotationClass() {
-            return MCRProperty.class;
+        public Class<MCRPropertyMap> annotationClass() {
+            return MCRPropertyMap.class;
         }
 
         @Override
-        public MCRProperty annotation() {
+        public MCRPropertyMap annotation() {
             return annotation;
         }
 
@@ -938,18 +970,258 @@ class MCRConfigurableInstanceHelper {
         @Override
         public Map<String, String> get(MCRInstanceConfiguration configuration, Target<?> target) {
 
-            Map<String, String> properties = annotation.absolute() ?
-                configuration.fullProperties() : configuration.properties();
+            String propertyName = configuration.name().canonical();
+            Map<String, String> properties;
+            if (annotation.absolute()) {
+                properties = configuration.fullProperties();
+            } else {
+                properties = configuration.properties();
+                // when non-empty class suffix is used, the property with empty name may contain the short-form-map
+                if (configuration.name().suffix() != MCRInstanceName.Suffix.NONE && annotation.name().isEmpty()) {
+                    properties.put("", configuration.fullProperties().get(propertyName));
+                }
+            }
 
-            Map<String, String> filteredProperties = new HashMap<>();
+            Map<String, String> propertyMap = getPropertyMap(propertyName, annotation.name(), properties);
+            String defaultName = annotation.defaultName();
+            if (propertyMap == null && !defaultName.isEmpty()) {
+                propertyMap = getPropertyMap(defaultName, defaultName, configuration.fullProperties());
+                if (propertyMap == null || (propertyMap.isEmpty() && annotation.required())) {
+                    throw new MCRConfigurationException("Missing default configuration entries like: "
+                        + defaultName + ", " + defaultName + ".A, " + defaultName + ".B, ...");
+                }
+            }
+
+            if ((propertyMap == null || propertyMap.isEmpty()) && annotation.required()) {
+                throw new MCRConfigurationException("Missing configuration entries like: "
+                    + getExampleNames(configuration, "A", "B") + ", ...");
+            }
+
+            return propertyMap == null ? new HashMap<>() : propertyMap;
+
+        }
+
+        private Map<String, String> getPropertyMap(String fullPropertyName, String propertyName,
+            Map<String, String> properties) {
+
+            AtomicBoolean hasRelevantProperty = new AtomicBoolean(false);
+            String prefix = propertyName.isEmpty() ? "" : propertyName + ".";
+
+            Map<String, String> shortFormMap = Map.of();
+            String shortFormPropertyValue = properties.get(propertyName);
+            if (shortFormPropertyValue != null) {
+                hasRelevantProperty.set(true);
+                shortFormMap = parseShortFormMap(fullPropertyName, shortFormPropertyValue);
+            }
+
+            Map<String, String> propertyMap = new HashMap<>(shortFormMap);
+            int prefixLength = prefix.length();
             properties.forEach((key, value) -> {
-                if (key.startsWith(prefix)) {
-                    filteredProperties.put(key.substring(prefix.length()), value);
+                if (key.startsWith(prefix) && !key.isEmpty()) {
+                    int index = key.indexOf('.', prefixLength);
+                    if (index == -1) {
+                        if (!value.isEmpty()) {
+                            hasRelevantProperty.set(true);
+                            propertyMap.put(key.substring(prefixLength), value);
+                        }
+                    }
                 }
             });
 
-            return filteredProperties;
+            MCRSentinel sentinel = annotation.sentinel();
+            if (sentinel.enabled()) {
+                for (String key : new HashSet<>(propertyMap.keySet())) {
+                    boolean sentinelValue = sentinel.defaultValue();
+                    String configurationValue = properties.get(prefix + key + "." + sentinel.name());
+                    if (configurationValue != null) {
+                        sentinelValue = Boolean.parseBoolean(configurationValue);
+                    }
+                    if (sentinelValue == sentinel.rejectionValue()) {
+                        propertyMap.remove(key);
+                    }
+                }
+            }
 
+            return hasRelevantProperty.get() ? propertyMap : null;
+
+        }
+
+        private Map<String, String> parseShortFormMap(String propertyName, String value) {
+            Map<String, String> shortFormMap = new HashMap<>();
+            MCRConfiguration2.splitValue(value).forEach(string -> {
+                String[] parts = string.split(":", 2);
+                if (parts.length != 2 || parts[0].isBlank() || parts[1].isBlank()) {
+                    if (LOGGER.isWarnEnabled()) {
+                        LOGGER.warn("Ignoring incomplete short-form-map entry {} while processing {}",
+                            value, propertyName);
+                    }
+                } else {
+                    shortFormMap.put(parts[0], parts[1]);
+                }
+            });
+            return shortFormMap;
+        }
+
+        private String getExampleNames(MCRInstanceConfiguration configuration, String... examples) {
+            if (Objects.equals("", annotation.name())) {
+                return Arrays.stream(examples).map(example -> configuration.name().subName(example).canonical())
+                    .collect(Collectors.joining(", "));
+            } else {
+                return configuration.name().subName(annotation.name()).canonical() + ", "
+                    + Arrays.stream(examples).map(
+                        example -> configuration.name().subName(annotation.name() + "." + example).canonical())
+                        .collect(Collectors.joining(", "));
+            }
+        }
+
+    }
+
+    private static final class PropertyListSource extends Source<MCRPropertyList, List<String>> {
+
+        private final MCRPropertyList annotation;
+
+        private PropertyListSource(MCRPropertyList annotation) {
+            this.annotation = annotation;
+        }
+
+        @Override
+        public SourceType type() {
+            return SourceType.PROPERTY_LIST;
+        }
+
+        @Override
+        public Class<MCRPropertyList> annotationClass() {
+            return MCRPropertyList.class;
+        }
+
+        @Override
+        public MCRPropertyList annotation() {
+            return annotation;
+        }
+
+        @Override
+        public int order() {
+            return annotation.order();
+        }
+
+        @Override
+        public Set<TargetType> allowedTargetTypes() {
+            return EnumSet.allOf(TargetType.class);
+        }
+
+        @Override
+        public Class<?> valueClass() {
+            return List.class;
+        }
+
+        @Override
+        public List<String> get(MCRInstanceConfiguration configuration, Target<?> target) {
+
+            String propertyName = configuration.name().canonical();
+            Map<String, String> properties;
+            if (annotation.absolute()) {
+                properties = configuration.fullProperties();
+            } else {
+                properties = configuration.properties();
+                // when non-empty class suffix is used, the property with empty name may contain the short-form-list
+                if (configuration.name().suffix() != MCRInstanceName.Suffix.NONE && annotation.name().isEmpty()) {
+                    properties.put("", configuration.fullProperties().get(propertyName));
+                }
+            }
+
+            List<String> propertyList = getPropertyList(propertyName, annotation.name(), properties);
+            String defaultName = annotation.defaultName();
+            if (propertyList == null && !defaultName.isEmpty()) {
+                propertyList = getPropertyList(defaultName, defaultName, configuration.fullProperties());
+                if (propertyList == null || (propertyList.isEmpty() && annotation.required())) {
+                    throw new MCRConfigurationException("Missing default configuration entries like: "
+                        + defaultName + ", " + defaultName + ".1, " + defaultName + ".2, ...");
+                }
+            }
+
+            if ((propertyList == null || propertyList.isEmpty()) && annotation.required()) {
+                throw new MCRConfigurationException("Missing configuration entries like: "
+                    + getExampleNames(configuration, "1", "2") + ", ...");
+            }
+
+            return propertyList == null ? new ArrayList<>() : propertyList;
+
+        }
+
+        private List<String> getPropertyList(String fullPropertyName, String propertyName,
+            Map<String, String> properties) {
+
+            AtomicBoolean hasRelevantProperty = new AtomicBoolean(false);
+            String prefix = propertyName.isEmpty() ? "" : propertyName + ".";
+
+            Map<String, String> propertyMap = new HashMap<>();
+            int prefixLength = prefix.length();
+            properties.forEach((key, value) -> {
+                if (key.startsWith(prefix) && !key.isEmpty()) {
+                    int index = key.indexOf('.', prefixLength);
+                    if (index == -1) {
+                        if (!value.isEmpty()) {
+                            hasRelevantProperty.set(true);
+                            propertyMap.put(key.substring(prefixLength), value);
+                        }
+                    }
+                }
+            });
+
+            MCRSentinel sentinel = annotation.sentinel();
+            if (sentinel.enabled()) {
+                for (String key : new HashSet<>(propertyMap.keySet())) {
+                    boolean sentinelValue = sentinel.defaultValue();
+                    String configurationValue = properties.get(prefix + key + "." + sentinel.name());
+                    if (configurationValue != null) {
+                        sentinelValue = Boolean.parseBoolean(configurationValue);
+                    }
+                    if (sentinelValue == sentinel.rejectionValue()) {
+                        propertyMap.remove(key);
+                    }
+                }
+            }
+
+            SortedMap<Integer, String> orderedPropertyMap = new TreeMap<>();
+            propertyMap.forEach((key, value) -> {
+                try {
+                    orderedPropertyMap.put(Integer.parseInt(key), value);
+                } catch (NumberFormatException e) {
+                    throw new MCRConfigurationException("Property list key '" + fullPropertyName
+                        + "." + key + "' is not a valid integer index", e);
+                }
+            });
+
+            List<String> shortFormList = List.of();
+            String shortFormPropertyValue = properties.get(propertyName);
+            if (shortFormPropertyValue != null) {
+                hasRelevantProperty.set(true);
+                shortFormList = parseShortFormList(shortFormPropertyValue);
+            }
+
+            List<String> propertyList = new ArrayList<>(orderedPropertyMap.size() + shortFormList.size());
+            propertyList.addAll(orderedPropertyMap.headMap(0).values());
+            propertyList.addAll(shortFormList);
+            propertyList.addAll(orderedPropertyMap.tailMap(0).values());
+
+            return hasRelevantProperty.get() ? propertyList : null;
+
+        }
+
+        private List<String> parseShortFormList(String value) {
+            return MCRConfiguration2.splitValue(value).toList();
+        }
+
+        private String getExampleNames(MCRInstanceConfiguration configuration, String... examples) {
+            if (Objects.equals("", annotation.name())) {
+                return Arrays.stream(examples).map(example -> configuration.name().subName(example).canonical())
+                    .collect(Collectors.joining(", "));
+            } else {
+                return configuration.name().subName(annotation.name()).canonical() + ", "
+                    + Arrays.stream(examples).map(
+                        example -> configuration.name().subName(annotation.name() + "." + example).canonical())
+                        .collect(Collectors.joining(", "));
+            }
         }
 
     }
@@ -1005,8 +1277,8 @@ class MCRConfigurableInstanceHelper {
         @Override
         public Map<String, String> get(MCRInstanceConfiguration configuration, Target<?> target) {
 
-            Map<String, String> properties = annotation.absolute() ?
-                configuration.fullProperties() : configuration.properties();
+            Map<String, String> properties =
+                annotation.absolute() ? configuration.fullProperties() : configuration.properties();
 
             Map<String, String> filteredProperties = new HashMap<>();
             properties.forEach((key, value) -> {
@@ -1068,7 +1340,12 @@ class MCRConfigurableInstanceHelper {
         @Override
         public Object get(MCRInstanceConfiguration configuration, Target<?> target) {
 
-            MCRInstanceConfiguration nestedConfiguration = configuration.nestedConfiguration(annotation().name());
+            String name = annotation().name();
+            if (name.isEmpty()) {
+                throw new MCRConfigurationException("The name must not be empty");
+            }
+
+            MCRInstanceConfiguration nestedConfiguration = configuration.nestedConfiguration(name);
 
             MCRSentinel sentinel = annotation.sentinel();
             if (sentinel.enabled()) {
@@ -1168,8 +1445,8 @@ class MCRConfigurableInstanceHelper {
 
             Set<Option> options = createOptions(annotation.valueClass(), annotation.required());
             Map<String, Object> instanceMap = nestedConfigurationMap.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry ->
-                    getInstance(annotation.valueClass(), entry.getValue(), options)));
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                    entry -> getInstance(annotation.valueClass(), entry.getValue(), options)));
 
             instanceMap.values().forEach(instance -> {
                 if (!annotation.valueClass().isAssignableFrom(instance.getClass())) {
@@ -1263,8 +1540,8 @@ class MCRConfigurableInstanceHelper {
             }
 
             Set<Option> options = createOptions(annotation.valueClass(), annotation.required());
-            List<Object> instanceList = nestedConfigurationList.stream().map(c ->
-                (Object) getInstance(annotation.valueClass(), c, options)).toList();
+            List<Object> instanceList = nestedConfigurationList.stream()
+                .map(c -> (Object) getInstance(annotation.valueClass(), c, options)).toList();
 
             instanceList.forEach(instance -> {
                 if (!annotation.valueClass().isAssignableFrom(instance.getClass())) {
@@ -1376,6 +1653,5 @@ class MCRConfigurableInstanceHelper {
         ADD_IMPLICIT_CLASS_PROPERTIES;
 
     }
-
 
 }

--- a/mycore-base/src/main/java/org/mycore/common/config/annotation/MCRProperty.java
+++ b/mycore-base/src/main/java/org/mycore/common/config/annotation/MCRProperty.java
@@ -40,10 +40,7 @@ import org.mycore.common.config.MCRConfigurationException;
 public @interface MCRProperty {
 
     /**
-     * @return The name of property, <code>*</code> for a map of all properties or a prefix,
-     * followed by <code>.*</code> for a map of all properties whose name starts with that prefix.
-     * Support for maps will be removed in a future release of MyCoRe. {@link MCRRawProperties}
-     * should be used instead.
+     * @return The name of property containing the string value.
      */
     String name();
 
@@ -55,14 +52,14 @@ public @interface MCRProperty {
 
     /**
      * @return true if the property name specified by {@link MCRProperty#name()} is absolute and not specific for
-     * this instance e.g. MCR.NameOfProject.
+     * this instance e.g. <code>MCR.Foo.Bar</code>.
      */
     boolean absolute() default false;
 
     /**
-     * @return The name for a default property that should be used as a default value if the property
-     * specified by {@link MCRProperty#name()} is not present in the properties. {@link MCRConfigurationException} is
-     * thrown if the default property is not present. The default property must be absolute, e.g. MCR.NameOfProject.
+     * @return The name for a default property that should be used as a fallback, if no value is configured.
+     * A {@link MCRConfigurationException} is thrown if the default property is not configured.
+     * The default property must be absolute, e.g. <code>MCR.Foo.Bar</code>.
      */
     String defaultName() default "";
 

--- a/mycore-base/src/main/java/org/mycore/common/config/annotation/MCRPropertyList.java
+++ b/mycore-base/src/main/java/org/mycore/common/config/annotation/MCRPropertyList.java
@@ -18,47 +18,54 @@
 
 package org.mycore.common.config.annotation;
 
-import org.mycore.common.config.MCRConfigurationException;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.mycore.common.config.MCRConfigurationException;
+
 /**
  * This annotation is used to mark fields or methods that should be set to or called with
- * a map of string values from the configuration properties.
+ * a list of {@link String} values from the configuration properties.
  * <p>
  * The field or method needs to be public.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.FIELD })
 @Inherited
-public @interface MCRRawProperties {
+public @interface MCRPropertyList {
 
     /**
-     * @return The pattern describing the properties to be included.
-     * <ul>
-     *  <li><code>*</code> for a map of all properties.
-     *  <li>prefix followed by <code>.*</code> for a map of all properties
-     *      starting with the given prefix and <code>.</code>.
-     * </ul>
+     * @return The prefix for names of properties containing the list values.
      */
-    String namePattern();
+    String name() default "";
 
     /**
-     * @return true if at least one property matching the patter specified by {@link MCRRawProperties#namePattern()}
+     * @return true if the at least one sub-property of the property specified by {@link MCRPropertyList#name()}
      * has to be present in the properties. {@link MCRConfigurationException} is thrown if a value is required
      * but not present.
      */
     boolean required() default true;
 
     /**
-     * @return true if the property name pattern specified by {@link MCRRawProperties#namePattern()}
-     * is absolute and not specific for this instance e.g. <code>MCR.Foo.Bar</code>.
+     * @return true if the property name specified by {@link MCRPropertyList#name()} is absolute and not specific for
+     * this instance e.g. <code>MCR.Foo.Bar</code>.
      */
     boolean absolute() default false;
+
+    /**
+     * @return The name for a default property that should be used as a fallback, if no list values are configured.
+     * A {@link MCRConfigurationException} is thrown if no default property is not configured.
+     * The default property must be absolute, e.g. <code>MCR.Foo.Bar</code>.
+     */
+    String defaultName() default "";
+    
+    /**
+     * @return The {@link MCRSentinel} for the configured instances.
+     */
+    MCRSentinel sentinel() default @MCRSentinel(enabled = false);
 
     /**
      * @return The order in which the annotated fields or methods are processed. The higher the value, the later the

--- a/mycore-base/src/main/java/org/mycore/common/config/annotation/MCRPropertyMap.java
+++ b/mycore-base/src/main/java/org/mycore/common/config/annotation/MCRPropertyMap.java
@@ -18,47 +18,54 @@
 
 package org.mycore.common.config.annotation;
 
-import org.mycore.common.config.MCRConfigurationException;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.mycore.common.config.MCRConfigurationException;
+
 /**
  * This annotation is used to mark fields or methods that should be set to or called with
- * a map of string values from the configuration properties.
+ * a map of {@link String} values from the configuration properties.
  * <p>
  * The field or method needs to be public.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.FIELD })
 @Inherited
-public @interface MCRRawProperties {
+public @interface MCRPropertyMap {
 
     /**
-     * @return The pattern describing the properties to be included.
-     * <ul>
-     *  <li><code>*</code> for a map of all properties.
-     *  <li>prefix followed by <code>.*</code> for a map of all properties
-     *      starting with the given prefix and <code>.</code>.
-     * </ul>
+     * @return The prefix for names of properties containing the map values.
      */
-    String namePattern();
+    String name() default "";
 
     /**
-     * @return true if at least one property matching the patter specified by {@link MCRRawProperties#namePattern()}
+     * @return true if the at least one sub-property of the property specified by {@link MCRPropertyMap#name()}
      * has to be present in the properties. {@link MCRConfigurationException} is thrown if a value is required
      * but not present.
      */
     boolean required() default true;
 
     /**
-     * @return true if the property name pattern specified by {@link MCRRawProperties#namePattern()}
-     * is absolute and not specific for this instance e.g. <code>MCR.Foo.Bar</code>.
+     * @return true if the property name specified by {@link MCRPropertyMap#name()} is absolute and not specific for
+     * this instance e.g. <code>MCR.Foo.Bar</code>.
      */
     boolean absolute() default false;
+
+    /**
+     * @return The name for a default property that should be used as a fallback, if no map values are configured.
+     * A {@link MCRConfigurationException} is thrown if no default property is not configured.
+     * The default property must be absolute, e.g. <code>MCR.Foo.Bar</code>.
+     */
+    String defaultName() default "";
+
+    /**
+     * @return The {@link MCRSentinel} for the configured instances.
+     */
+    MCRSentinel sentinel() default @MCRSentinel(enabled = false);
 
     /**
      * @return The order in which the annotated fields or methods are processed. The higher the value, the later the

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/mapping/MCRDefaultXPathClassificationGenerator.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/mapping/MCRDefaultXPathClassificationGenerator.java
@@ -24,9 +24,8 @@ import java.util.function.Supplier;
 
 import org.jdom2.Document;
 import org.jdom2.Parent;
-import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.config.annotation.MCRConfigurationProxy;
-import org.mycore.common.config.annotation.MCRProperty;
+import org.mycore.common.config.annotation.MCRPropertyList;
 import org.mycore.datamodel.classifications2.MCRCategoryDAO;
 import org.mycore.datamodel.classifications2.mapping.MCRGeneratorClassificationMapperBase.Generator;
 import org.mycore.datamodel.metadata.MCRObject;
@@ -88,16 +87,12 @@ public final class MCRDefaultXPathClassificationGenerator extends MCRXPathClassi
 
     public static class Factory implements Supplier<MCRDefaultXPathClassificationGenerator> {
 
-        @MCRProperty(name = CLASSIFICATION_IDS_KEY, required = false)
-        public String classificationIds;
+        @MCRPropertyList(name = CLASSIFICATION_IDS_KEY, required = false)
+        public List<String> classificationIds;
 
         @Override
         public MCRDefaultXPathClassificationGenerator get() {
-            return new MCRDefaultXPathClassificationGenerator(getClassificationsIds());
-        }
-
-        private List<String> getClassificationsIds() {
-            return MCRConfiguration2.splitValue(classificationIds == null ? "" : classificationIds).toList();
+            return new MCRDefaultXPathClassificationGenerator(classificationIds);
         }
 
     }

--- a/mycore-base/src/main/java/org/mycore/resource/provider/MCRFileSystemResourceProvider.java
+++ b/mycore-base/src/main/java/org/mycore/resource/provider/MCRFileSystemResourceProvider.java
@@ -27,9 +27,9 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.apache.logging.log4j.Level;
-import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.config.annotation.MCRConfigurationProxy;
 import org.mycore.common.config.annotation.MCRProperty;
+import org.mycore.common.config.annotation.MCRPropertyList;
 import org.mycore.common.hint.MCRHints;
 import org.mycore.common.log.MCRTreeMessage;
 
@@ -52,8 +52,7 @@ import org.mycore.common.log.MCRTreeMessage;
  * [...].Class=org.mycore.resource.provider.MCRFileSystemResourceProvider
  * [...].Coverage=Lorem ipsum dolor sit amet
  * [...].Mode=RESOURCES
- * [...].BaseDirs.10=/base/dir/foo
- * [...].BaseDirs.20=/base/dir/bar
+ * [...].BaseDirs=/base/dir/foo,/base/dir/bar
  * </code></pre>
  */
 @MCRConfigurationProxy(proxyClass = MCRFileSystemResourceProvider.Factory.class)
@@ -93,13 +92,13 @@ public final class MCRFileSystemResourceProvider extends MCRFileSystemResourcePr
         @MCRProperty(name = MODE_KEY)
         public String mode;
 
-        @MCRProperty(name = BASE_DIRS_KEY)
-        public String baseDirs;
+        @MCRPropertyList(name = BASE_DIRS_KEY, required = false)
+        public List<String> baseDirs;
 
         @Override
         public MCRFileSystemResourceProvider get() {
             MCRResourceProviderMode mode = MCRResourceProviderMode.valueOf(this.mode);
-            List<Path> baseDirs = MCRConfiguration2.splitValue(this.baseDirs).map(Paths::get).toList();
+            List<Path> baseDirs = this.baseDirs.stream().map(Paths::get).toList();
             return new MCRFileSystemResourceProvider(coverage, mode, baseDirs);
         }
 

--- a/mycore-base/src/test/java/org/mycore/common/config/MCRConfigurableInstanceHelperCollectionTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/config/MCRConfigurableInstanceHelperCollectionTest.java
@@ -1,0 +1,715 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mycore.common.MCRTestConfiguration;
+import org.mycore.common.MCRTestProperty;
+import org.mycore.common.config.annotation.MCRPropertyList;
+import org.mycore.common.config.annotation.MCRPropertyMap;
+import org.mycore.common.config.annotation.MCRSentinel;
+import org.mycore.test.MyCoReTest;
+
+@MyCoReTest
+public class MCRConfigurableInstanceHelperCollectionTest {
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithMap.class),
+            @MCRTestProperty(key = "Foo.EntryA", string = "ValueA"),
+            @MCRTestProperty(key = "Foo.EntryB", string = "ValueB"),
+        })
+    public void map() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithMap instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithMap.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.map);
+        assertEquals(2, instance.map.size());
+
+        String valueA = instance.map.get("EntryA");
+        assertNotNull(valueA);
+        assertEquals("ValueA", valueA);
+
+        String valueB = instance.map.get("EntryB");
+        assertNotNull(valueB);
+        assertEquals("ValueB", valueB);
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithMap.class),
+        })
+    public void mapNotPresent() {
+
+        assertThrows(
+            MCRConfigurationException.class,
+            () -> {
+                MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+                MCRConfigurableInstanceHelper.getInstance(Object.class, configuration);
+            });
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithOptionalMap.class),
+            @MCRTestProperty(key = "Foo.EntryA", string = "ValueA"),
+            @MCRTestProperty(key = "Foo.EntryB", string = "ValueB"),
+        })
+    public void optionalMap() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithOptionalMap instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithOptionalMap.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.map);
+        assertEquals(2, instance.map.size());
+
+        String valueA = instance.map.get("EntryA");
+        assertNotNull(valueA);
+        assertEquals("ValueA", valueA);
+
+        String valueB = instance.map.get("EntryB");
+        assertNotNull(valueB);
+        assertEquals("ValueB", valueB);
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithOptionalMap.class),
+        })
+    public void optionalMapNotPresent() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithOptionalMap instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithOptionalMap.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.map);
+        assertEquals(0, instance.map.size());
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithMapWithSentinel.class),
+            @MCRTestProperty(key = "Foo.EntryA.Sentinel", string = "false"),
+            @MCRTestProperty(key = "Foo.EntryA", string = "ValueA"),
+            @MCRTestProperty(key = "Foo.EntryB.Sentinel", string = "true"),
+            @MCRTestProperty(key = "Foo.EntryB", string = "ValueB"),
+            @MCRTestProperty(key = "Foo.EntryC", string = "ValueC"),
+        })
+    public void mapWithSentinel() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithMapWithSentinel instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithMapWithSentinel.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.map);
+        assertEquals(2, instance.map.size());
+
+        assertNull(instance.map.get("EntryA"));
+        assertNotNull(instance.map.get("EntryB"));
+        assertEquals("ValueB", instance.map.get("EntryB"));
+        assertNotNull(instance.map.get("EntryC"));
+        assertEquals("ValueC", instance.map.get("EntryC"));
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithMapsWithPrefix.class),
+            @MCRTestProperty(key = "Foo.Map1.Entry", string = "ValueA"),
+            @MCRTestProperty(key = "Foo.Map2.Entry", string = "ValueB"),
+        })
+    public void mapWithPrefix() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithMapsWithPrefix instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithMapsWithPrefix.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.map1);
+        assertNotNull(instance.map2);
+        assertEquals(1, instance.map1.size());
+        assertEquals(1, instance.map2.size());
+
+        String valueA = instance.map1.get("Entry");
+        assertNotNull(valueA);
+        assertEquals("ValueA", valueA);
+
+        String valueB = instance.map2.get("Entry");
+        assertNotNull(valueB);
+        assertEquals("ValueB", valueB);
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithMapWithPrefix.class),
+            @MCRTestProperty(key = "Foo.Map", string = "EntryA:ValueA,EntryB:ValueB"),
+        })
+    public void shortFormMapWithPrefix() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithMapWithPrefix instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithMapWithPrefix.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.map);
+        assertEquals(2, instance.map.size());
+
+        String valueA = instance.map.get("EntryA");
+        assertNotNull(valueA);
+        assertEquals("ValueA", valueA);
+
+        String valueB = instance.map.get("EntryB");
+        assertNotNull(valueB);
+        assertEquals("ValueB", valueB);
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithMapWithPrefix.class),
+            @MCRTestProperty(key = "Foo.Map", string = "A:ShortValueA,B:ShortValueB"),
+            @MCRTestProperty(key = "Foo.Map.EntryA", string = "ValueA"),
+            @MCRTestProperty(key = "Foo.Map.EntryB", string = "ValueB"),
+        })
+    public void mixedFormMapWithPrefix() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithMapWithPrefix instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithMapWithPrefix.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.map);
+        assertEquals(4, instance.map.size());
+
+        String valueA = instance.map.get("EntryA");
+        assertNotNull(valueA);
+        assertEquals("ValueA", valueA);
+
+        String shortValueA = instance.map.get("A");
+        assertNotNull(shortValueA);
+        assertEquals("ShortValueA", shortValueA);
+
+        String shortValueB = instance.map.get("B");
+        assertNotNull(shortValueB);
+        assertEquals("ShortValueB", shortValueB);
+
+        String valueB = instance.map.get("EntryB");
+        assertNotNull(valueB);
+        assertEquals("ValueB", valueB);
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", string = "EntryA:ValueA,EntryB:ValueB"),
+        })
+    public void shortFormMapWithoutPrefix() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo.Class");
+        TestClassWithMapWithoutPrefix instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithMapWithoutPrefix.class, configuration,
+                MCRConfigurableInstanceHelper.ADD_IMPLICIT_CLASS_PROPERTIES);
+
+        assertNotNull(instance);
+        assertNotNull(instance.map);
+        assertEquals(2, instance.map.size());
+
+        String valueA = instance.map.get("EntryA");
+        assertNotNull(valueA);
+        assertEquals("ValueA", valueA);
+
+        String valueB = instance.map.get("EntryB");
+        assertNotNull(valueB);
+        assertEquals("ValueB", valueB);
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithMapWithPrefix.class),
+            @MCRTestProperty(key = "Foo.Map", string = "A:ShortValueA,B"),
+            @MCRTestProperty(key = "Foo.Map.EntryA", string = "ValueA"),
+            @MCRTestProperty(key = "Foo.Map.EntryB", empty = true),
+        })
+    public void mapWithEmptyMapValues() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithMapWithPrefix instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithMapWithPrefix.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.map);
+        assertEquals(2, instance.map.size());
+
+        String valueA = instance.map.get("EntryA");
+        assertNotNull(valueA);
+        assertEquals("ValueA", valueA);
+
+        String shortValueA = instance.map.get("A");
+        assertNotNull(shortValueA);
+        assertEquals("ShortValueA", shortValueA);
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithMapWithPrefixAndSentinel.class),
+            @MCRTestProperty(key = "Foo.Map.EntryA.Sentinel", string = "false"),
+            @MCRTestProperty(key = "Foo.Map.EntryA", string = "ValueA"),
+            @MCRTestProperty(key = "Foo.Map.EntryB.Sentinel", string = "true"),
+            @MCRTestProperty(key = "Foo.Map.EntryB", string = "ValueB"),
+            @MCRTestProperty(key = "Foo.Map.EntryC", string = "ValueC"),
+        })
+    public void mapWithPrefixAndSentinel() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithMapWithPrefixAndSentinel instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithMapWithPrefixAndSentinel.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.map);
+        assertEquals(2, instance.map.size());
+
+        assertNull(instance.map.get("EntryA"));
+        assertNotNull(instance.map.get("EntryB"));
+        assertEquals("ValueB", instance.map.get("EntryB"));
+        assertNotNull(instance.map.get("EntryC"));
+        assertEquals("ValueC", instance.map.get("EntryC"));
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithList.class),
+            @MCRTestProperty(key = "Foo.23", string = "Value23"),
+            @MCRTestProperty(key = "Foo.42", string = "Value42"),
+        })
+    public void list() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithList instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithList.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.list);
+        assertEquals(2, instance.list.size());
+
+        String value23 = instance.list.get(0);
+        assertNotNull(value23);
+        assertEquals("Value23", value23);
+
+        String value42 = instance.list.get(1);
+        assertNotNull(value42);
+        assertEquals("Value42", value42);
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithList.class),
+        })
+    public void listNotPresent() {
+
+        assertThrows(
+            MCRConfigurationException.class,
+            () -> {
+                MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+                MCRConfigurableInstanceHelper.getInstance(Object.class, configuration);
+            });
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithOptionalList.class),
+            @MCRTestProperty(key = "Foo.23", string = "Value23"),
+            @MCRTestProperty(key = "Foo.42", string = "Value42"),
+        })
+    public void optionalList() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithOptionalList instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithOptionalList.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.list);
+        assertEquals(2, instance.list.size());
+
+        String value23 = instance.list.get(0);
+        assertNotNull(value23);
+        assertEquals("Value23", value23);
+
+        String value42 = instance.list.get(1);
+        assertNotNull(value42);
+        assertEquals("Value42", value42);
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithOptionalList.class),
+        })
+    public void optionalListNotPresent() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithOptionalList instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithOptionalList.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.list);
+        assertEquals(0, instance.list.size());
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithListAndSentinel.class),
+            @MCRTestProperty(key = "Foo.7.Sentinel", string = "false"),
+            @MCRTestProperty(key = "Foo.7", string = "Value7"),
+            @MCRTestProperty(key = "Foo.23.Sentinel", string = "true"),
+            @MCRTestProperty(key = "Foo.23", string = "Value23"),
+            @MCRTestProperty(key = "Foo.42", string = "Value42"),
+
+        })
+    public void listWithSentinel() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithListAndSentinel instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithListAndSentinel.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.list);
+        assertEquals(2, instance.list.size());
+
+        assertEquals("Value23", instance.list.get(0));
+        assertEquals("Value42", instance.list.get(1));
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithListsWithPrefix.class),
+            @MCRTestProperty(key = "Foo.List1.23", string = "Value23"),
+            @MCRTestProperty(key = "Foo.List2.42", string = "Value42"),
+        })
+    public void listWithPrefix() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithListsWithPrefix instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithListsWithPrefix.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.list1);
+        assertNotNull(instance.list2);
+        assertEquals(1, instance.list1.size());
+        assertEquals(1, instance.list2.size());
+
+        String value23 = instance.list1.get(0);
+        assertNotNull(value23);
+        assertEquals("Value23", value23);
+
+        String value42 = instance.list2.get(0);
+        assertNotNull(value42);
+        assertEquals("Value42", value42);
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithListWithPrefix.class),
+            @MCRTestProperty(key = "Foo.List", string = "ShortValue23,ShortValue42"),
+        })
+    public void shortFormListWithPrefix() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithListWithPrefix instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithListWithPrefix.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.list);
+        assertEquals(2, instance.list.size());
+
+        String shortValue23 = instance.list.get(0);
+        assertNotNull(shortValue23);
+        assertEquals("ShortValue23", shortValue23);
+
+        String shortValue42 = instance.list.get(1);
+        assertNotNull(shortValue42);
+        assertEquals("ShortValue42", shortValue42);
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithListWithPrefix.class),
+            @MCRTestProperty(key = "Foo.List", string = "ShortValue23,ShortValue42"),
+            @MCRTestProperty(key = "Foo.List.42", string = "AfterValue42"),
+            @MCRTestProperty(key = "Foo.List.-23", string = "BeforeValue23"),
+        })
+    public void mixedFormListWithPrefix() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithListWithPrefix instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithListWithPrefix.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.list);
+        assertEquals(4, instance.list.size());
+
+        String beforeValue23 = instance.list.get(0);
+        assertNotNull(beforeValue23);
+        assertEquals("BeforeValue23", beforeValue23);
+
+        String shortValue23 = instance.list.get(1);
+        assertNotNull(shortValue23);
+        assertEquals("ShortValue23", shortValue23);
+
+        String shortValue42 = instance.list.get(2);
+        assertNotNull(shortValue42);
+        assertEquals("ShortValue42", shortValue42);
+
+        String afterValue42 = instance.list.get(3);
+        assertNotNull(afterValue42);
+        assertEquals("AfterValue42", afterValue42);
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", string = "ShortValue23,ShortValue42"),
+        })
+    public void shortFormListWithoutPrefix() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo.Class");
+        TestClassWithListWithoutPrefix instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithListWithoutPrefix.class, configuration,
+                MCRConfigurableInstanceHelper.ADD_IMPLICIT_CLASS_PROPERTIES);
+
+        assertNotNull(instance);
+        assertNotNull(instance.list);
+        assertEquals(2, instance.list.size());
+
+        String shortValue23 = instance.list.get(0);
+        assertNotNull(shortValue23);
+        assertEquals("ShortValue23", shortValue23);
+
+        String shortValue42 = instance.list.get(1);
+        assertNotNull(shortValue42);
+        assertEquals("ShortValue42", shortValue42);
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithListWithPrefix.class),
+            @MCRTestProperty(key = "Foo.List", string = "ShortValue23,"),
+            @MCRTestProperty(key = "Foo.List.42", string = "AfterValue42"),
+            @MCRTestProperty(key = "Foo.List.-23", empty = true),
+        })
+    public void listWithEmptyValues() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithListWithPrefix instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithListWithPrefix.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.list);
+        assertEquals(2, instance.list.size());
+
+        String beforeValue23 = instance.list.get(0);
+        assertNotNull(beforeValue23);
+        assertEquals("ShortValue23", beforeValue23);
+
+        String shortValue23 = instance.list.get(1);
+        assertNotNull(shortValue23);
+        assertEquals("AfterValue42", shortValue23);
+
+    }
+
+    @Test
+    @MCRTestConfiguration(
+        properties = {
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithListWithPrefixAndSentinel.class),
+            @MCRTestProperty(key = "Foo.List.7.Sentinel", string = "false"),
+            @MCRTestProperty(key = "Foo.List.7", string = "Value7"),
+            @MCRTestProperty(key = "Foo.List.23.Sentinel", string = "true"),
+            @MCRTestProperty(key = "Foo.List.23", string = "Value23"),
+            @MCRTestProperty(key = "Foo.List.42", string = "Value42"),
+        })
+    public void listWithPrefixAndSentinel() {
+
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        TestClassWithListWithPrefixAndSentinel instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithListWithPrefixAndSentinel.class, configuration);
+
+        assertNotNull(instance);
+        assertNotNull(instance.list);
+        assertEquals(2, instance.list.size());
+
+        assertEquals("Value23", instance.list.get(0));
+        assertEquals("Value42", instance.list.get(1));
+
+    }
+
+    public static class TestClassWithMap {
+
+        @MCRPropertyMap
+        public Map<String, String> map;
+
+    }
+
+    public static class TestClassWithOptionalMap {
+
+        @MCRPropertyMap(required = false)
+        public Map<String, String> map;
+
+    }
+
+    public static class TestClassWithMapWithSentinel {
+
+        @MCRPropertyMap(sentinel = @MCRSentinel(name = "Sentinel"))
+        public Map<String, String> map;
+
+    }
+
+    public static class TestClassWithMapsWithPrefix {
+
+        @MCRPropertyMap(name = "Map1")
+        public Map<String, String> map1;
+
+        @MCRPropertyMap(name = "Map2")
+        public Map<String, String> map2;
+
+    }
+
+    public static class TestClassWithMapWithPrefix {
+
+        @MCRPropertyMap(name = "Map")
+        public Map<String, String> map;
+
+    }
+
+    public static class TestClassWithMapWithPrefixAndSentinel {
+
+        @MCRPropertyMap(name = "Map", sentinel = @MCRSentinel(name = "Sentinel"))
+        public Map<String, String> map;
+
+    }
+
+    public static final class TestClassWithMapWithoutPrefix {
+
+        @MCRPropertyMap
+        public Map<String, String> map;
+
+    }
+
+    public static class TestClassWithList {
+
+        @MCRPropertyList
+        public List<String> list;
+
+    }
+
+    public static class TestClassWithOptionalList {
+
+        @MCRPropertyList(required = false)
+        public List<String> list;
+
+    }
+
+    public static class TestClassWithListAndSentinel {
+
+        @MCRPropertyList(sentinel = @MCRSentinel(name = "Sentinel"))
+        public List<String> list;
+
+    }
+
+    public static class TestClassWithListsWithPrefix {
+
+        @MCRPropertyList(name = "List1")
+        public List<String> list1;
+
+        @MCRPropertyList(name = "List2")
+        public List<String> list2;
+
+    }
+
+    public static class TestClassWithListWithPrefix {
+
+        @MCRPropertyList(name = "List")
+        public List<String> list;
+
+    }
+
+    public static class TestClassWithListWithPrefixAndSentinel {
+
+        @MCRPropertyList(name = "List", sentinel = @MCRSentinel(name = "Sentinel"))
+        public List<String> list;
+
+    }
+
+    public static final class TestClassWithListWithoutPrefix {
+
+        @MCRPropertyList
+        public List<String> list;
+
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/common/config/MCRConfigurableInstanceHelperDefaultTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/config/MCRConfigurableInstanceHelperDefaultTest.java
@@ -178,7 +178,7 @@ public class MCRConfigurableInstanceHelperDefaultTest {
         assertNotNull(instance.list);
         assertEquals(2, instance.list.size());
 
-        Entry oneEntry = instance.list.getFirst();
+        Entry oneEntry = instance.list.get(0);
         assertNotNull(oneEntry);
         assertEquals(OneKindOfEntry.class, oneEntry.getClass());
         assertEquals("OneValue", oneEntry.get());
@@ -207,7 +207,7 @@ public class MCRConfigurableInstanceHelperDefaultTest {
         assertNotNull(instance.list);
         assertEquals(2, instance.list.size());
 
-        ImplicitEntry oneEntry = instance.list.getFirst();
+        ImplicitEntry oneEntry = instance.list.get(0);
         assertNotNull(oneEntry);
         assertEquals(ImplicitEntry.class, oneEntry.getClass());
         assertEquals("Custom1", oneEntry.string1);

--- a/mycore-base/src/test/java/org/mycore/common/config/MCRConfigurableInstanceHelperNestedTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/config/MCRConfigurableInstanceHelperNestedTest.java
@@ -44,8 +44,8 @@ public class MCRConfigurableInstanceHelperNestedTest {
         properties = {
             @MCRTestProperty(key = "Foo", classNameOf = TestClassWithNestedClass.class),
             @MCRTestProperty(key = "Foo.Nested", classNameOf = NestedClass.class),
-            @MCRTestProperty(key = "Foo.Nested.Property1", string = "Value1"),
-            @MCRTestProperty(key = "Foo.Nested.Property2", string = "Value2")
+            @MCRTestProperty(key = "Foo.Nested.PropertyA", string = "ValueA"),
+            @MCRTestProperty(key = "Foo.Nested.PropertyB", string = "ValueB")
         })
     public void nested() {
 
@@ -55,8 +55,8 @@ public class MCRConfigurableInstanceHelperNestedTest {
 
         assertNotNull(instance);
         assertNotNull(instance.nested);
-        assertEquals("Value1", instance.nested.string1);
-        assertEquals("Value2", instance.nested.string2);
+        assertEquals("ValueA", instance.nested.string1);
+        assertEquals("ValueB", instance.nested.string2);
 
     }
 
@@ -80,8 +80,8 @@ public class MCRConfigurableInstanceHelperNestedTest {
     @MCRTestConfiguration(
         properties = {
             @MCRTestProperty(key = "Foo", classNameOf = TestClassWithImplicitNestedClass.class),
-            @MCRTestProperty(key = "Foo.Nested.Property1", string = "Value1"),
-            @MCRTestProperty(key = "Foo.Nested.Property2", string = "Value2")
+            @MCRTestProperty(key = "Foo.Nested.PropertyA", string = "ValueA"),
+            @MCRTestProperty(key = "Foo.Nested.PropertyB", string = "ValueB")
         })
     public void nestedImplicit() {
 
@@ -91,8 +91,8 @@ public class MCRConfigurableInstanceHelperNestedTest {
 
         assertNotNull(instance);
         assertNotNull(instance.nested);
-        assertEquals("Value1", instance.nested.string1);
-        assertEquals("Value2", instance.nested.string2);
+        assertEquals("ValueA", instance.nested.string1);
+        assertEquals("ValueB", instance.nested.string2);
 
     }
 
@@ -101,8 +101,8 @@ public class MCRConfigurableInstanceHelperNestedTest {
         properties = {
             @MCRTestProperty(key = "Foo", classNameOf = TestClassWithOptionalNestedClass.class),
             @MCRTestProperty(key = "Foo.Nested", classNameOf = NestedClass.class),
-            @MCRTestProperty(key = "Foo.Nested.Property1", string = "Value1"),
-            @MCRTestProperty(key = "Foo.Nested.Property2", string = "Value2")
+            @MCRTestProperty(key = "Foo.Nested.PropertyA", string = "ValueA"),
+            @MCRTestProperty(key = "Foo.Nested.PropertyB", string = "ValueB")
         })
     public void nestedOptional() {
 
@@ -112,8 +112,8 @@ public class MCRConfigurableInstanceHelperNestedTest {
 
         assertNotNull(instance);
         assertNotNull(instance.nested);
-        assertEquals("Value1", instance.nested.string1);
-        assertEquals("Value2", instance.nested.string2);
+        assertEquals("ValueA", instance.nested.string1);
+        assertEquals("ValueB", instance.nested.string2);
 
     }
 
@@ -139,8 +139,8 @@ public class MCRConfigurableInstanceHelperNestedTest {
             @MCRTestProperty(key = "Foo", classNameOf = TestClassWithNestedNestedClass.class),
             @MCRTestProperty(key = "Foo.Nested", classNameOf = TestClassWithNestedClass.class),
             @MCRTestProperty(key = "Foo.Nested.Nested", classNameOf = NestedClass.class),
-            @MCRTestProperty(key = "Foo.Nested.Nested.Property1", string = "Value1"),
-            @MCRTestProperty(key = "Foo.Nested.Nested.Property2", string = "Value2")
+            @MCRTestProperty(key = "Foo.Nested.Nested.PropertyA", string = "ValueA"),
+            @MCRTestProperty(key = "Foo.Nested.Nested.PropertyB", string = "ValueB")
         })
     public void nestedNested() {
 
@@ -151,8 +151,8 @@ public class MCRConfigurableInstanceHelperNestedTest {
         assertNotNull(instance);
         assertNotNull(instance.nested);
         assertNotNull(instance.nested.nested);
-        assertEquals("Value1", instance.nested.nested.string1);
-        assertEquals("Value2", instance.nested.nested.string2);
+        assertEquals("ValueA", instance.nested.nested.string1);
+        assertEquals("ValueB", instance.nested.nested.string2);
 
     }
 
@@ -162,8 +162,8 @@ public class MCRConfigurableInstanceHelperNestedTest {
             @MCRTestProperty(key = "Foo", classNameOf = TestClassWithOptionalNestedClassAndSentinel.class),
             @MCRTestProperty(key = "Foo.Nested", classNameOf = NestedClass.class),
             @MCRTestProperty(key = "Foo.Nested.Sentinel", string = "true"),
-            @MCRTestProperty(key = "Foo.Nested.Property1", string = "Value1"),
-            @MCRTestProperty(key = "Foo.Nested.Property2", string = "Value2")
+            @MCRTestProperty(key = "Foo.Nested.PropertyA", string = "ValueA"),
+            @MCRTestProperty(key = "Foo.Nested.PropertyB", string = "ValueB")
         })
     public void nestedOptionalAndSentinel() {
 
@@ -173,8 +173,8 @@ public class MCRConfigurableInstanceHelperNestedTest {
 
         assertNotNull(instance);
         assertNotNull(instance.nested);
-        assertEquals("Value1", instance.nested.string1);
-        assertEquals("Value2", instance.nested.string2);
+        assertEquals("ValueA", instance.nested.string1);
+        assertEquals("ValueB", instance.nested.string2);
 
     }
 
@@ -184,8 +184,8 @@ public class MCRConfigurableInstanceHelperNestedTest {
             @MCRTestProperty(key = "Foo", classNameOf = TestClassWithOptionalNestedClassAndSentinel.class),
             @MCRTestProperty(key = "Foo.Nested", classNameOf = NestedClass.class),
             @MCRTestProperty(key = "Foo.Nested.Sentinel", string = "false"),
-            @MCRTestProperty(key = "Foo.Nested.Property1", string = "Value1"),
-            @MCRTestProperty(key = "Foo.Nested.Property2", string = "Value2")
+            @MCRTestProperty(key = "Foo.Nested.PropertyA", string = "ValueA"),
+            @MCRTestProperty(key = "Foo.Nested.PropertyB", string = "ValueB")
         })
     public void nestedOptionalAndSentinelNotPresent() {
 
@@ -203,9 +203,9 @@ public class MCRConfigurableInstanceHelperNestedTest {
         properties = {
             @MCRTestProperty(key = "Foo", classNameOf = TestClassWithNestedMap.class),
             @MCRTestProperty(key = "Foo.EntryA", classNameOf = OneKindOfEntry.class),
-            @MCRTestProperty(key = "Foo.EntryA.OneProperty", string = "OneValue"),
+            @MCRTestProperty(key = "Foo.EntryA.PropertyA", string = "ValueA"),
             @MCRTestProperty(key = "Foo.EntryB", classNameOf = OtherKindOfEntry.class),
-            @MCRTestProperty(key = "Foo.EntryB.OtherProperty", string = "OtherValue"),
+            @MCRTestProperty(key = "Foo.EntryB.PropertyB", string = "ValueB"),
         })
     public void nestedMap() {
 
@@ -217,15 +217,15 @@ public class MCRConfigurableInstanceHelperNestedTest {
         assertNotNull(instance.map);
         assertEquals(2, instance.map.size());
 
-        Entry oneEntry = instance.map.get("EntryA");
-        assertNotNull(oneEntry);
-        assertEquals(OneKindOfEntry.class, oneEntry.getClass());
-        assertEquals("OneValue", oneEntry.get());
+        Entry entryA = instance.map.get("EntryA");
+        assertNotNull(entryA);
+        assertEquals(OneKindOfEntry.class, entryA.getClass());
+        assertEquals("ValueA", entryA.get());
 
-        Entry otherEntry = instance.map.get("EntryB");
-        assertNotNull(otherEntry);
-        assertEquals(OtherKindOfEntry.class, otherEntry.getClass());
-        assertEquals("OtherValue", otherEntry.get());
+        Entry entryB = instance.map.get("EntryB");
+        assertNotNull(entryB);
+        assertEquals(OtherKindOfEntry.class, entryB.getClass());
+        assertEquals("ValueB", entryB.get());
 
     }
 
@@ -249,8 +249,8 @@ public class MCRConfigurableInstanceHelperNestedTest {
     @MCRTestConfiguration(
         properties = {
             @MCRTestProperty(key = "Foo", classNameOf = TestClassWithNestedMapOfImplicitEntries.class),
-            @MCRTestProperty(key = "Foo.EntryA.Property", string = "A"),
-            @MCRTestProperty(key = "Foo.EntryB.Property", string = "B"),
+            @MCRTestProperty(key = "Foo.EntryA.Property", string = "ValueA"),
+            @MCRTestProperty(key = "Foo.EntryB.Property", string = "ValueB"),
         })
     public void nestedMapImplicit() {
 
@@ -262,15 +262,15 @@ public class MCRConfigurableInstanceHelperNestedTest {
         assertNotNull(instance.map);
         assertEquals(2, instance.map.size());
 
-        ImplicitEntry oneEntry = instance.map.get("EntryA");
-        assertNotNull(oneEntry);
-        assertEquals(ImplicitEntry.class, oneEntry.getClass());
-        assertEquals("A", oneEntry.string);
+        ImplicitEntry entryA = instance.map.get("EntryA");
+        assertNotNull(entryA);
+        assertEquals(ImplicitEntry.class, entryA.getClass());
+        assertEquals("ValueA", entryA.string);
 
-        ImplicitEntry otherEntry = instance.map.get("EntryB");
-        assertNotNull(otherEntry);
-        assertEquals(ImplicitEntry.class, otherEntry.getClass());
-        assertEquals("B", otherEntry.string);
+        ImplicitEntry entryB = instance.map.get("EntryB");
+        assertNotNull(entryB);
+        assertEquals(ImplicitEntry.class, entryB.getClass());
+        assertEquals("ValueB", entryB.string);
 
     }
 
@@ -279,9 +279,9 @@ public class MCRConfigurableInstanceHelperNestedTest {
         properties = {
             @MCRTestProperty(key = "Foo", classNameOf = TestClassWithOptionalNestedMap.class),
             @MCRTestProperty(key = "Foo.EntryA", classNameOf = OneKindOfEntry.class),
-            @MCRTestProperty(key = "Foo.EntryA.OneProperty", string = "OneValue"),
+            @MCRTestProperty(key = "Foo.EntryA.PropertyA", string = "ValueA"),
             @MCRTestProperty(key = "Foo.EntryB", classNameOf = OtherKindOfEntry.class),
-            @MCRTestProperty(key = "Foo.EntryB.OtherProperty", string = "OtherValue"),
+            @MCRTestProperty(key = "Foo.EntryB.PropertyB", string = "ValueB"),
         })
     public void nestedOptionalMap() {
 
@@ -293,15 +293,15 @@ public class MCRConfigurableInstanceHelperNestedTest {
         assertNotNull(instance.map);
         assertEquals(2, instance.map.size());
 
-        Entry oneEntry = instance.map.get("EntryA");
-        assertNotNull(oneEntry);
-        assertEquals(OneKindOfEntry.class, oneEntry.getClass());
-        assertEquals("OneValue", oneEntry.get());
+        Entry entryA = instance.map.get("EntryA");
+        assertNotNull(entryA);
+        assertEquals(OneKindOfEntry.class, entryA.getClass());
+        assertEquals("ValueA", entryA.get());
 
-        Entry otherEntry = instance.map.get("EntryB");
-        assertNotNull(otherEntry);
-        assertEquals(OtherKindOfEntry.class, otherEntry.getClass());
-        assertEquals("OtherValue", otherEntry.get());
+        Entry entryB = instance.map.get("EntryB");
+        assertNotNull(entryB);
+        assertEquals(OtherKindOfEntry.class, entryB.getClass());
+        assertEquals("ValueB", entryB.get());
 
     }
 
@@ -328,12 +328,12 @@ public class MCRConfigurableInstanceHelperNestedTest {
             @MCRTestProperty(key = "Foo", classNameOf = TestClassWithNestedMapWithSentinel.class),
             @MCRTestProperty(key = "Foo.EntryA", classNameOf = SimpleEntry.class),
             @MCRTestProperty(key = "Foo.EntryA.Sentinel", string = "false"),
-            @MCRTestProperty(key = "Foo.EntryA.Property", string = "A"),
+            @MCRTestProperty(key = "Foo.EntryA.Property", string = "ValueA"),
             @MCRTestProperty(key = "Foo.EntryB", classNameOf = SimpleEntry.class),
             @MCRTestProperty(key = "Foo.EntryB.Sentinel", string = "true"),
-            @MCRTestProperty(key = "Foo.EntryB.Property", string = "B"),
+            @MCRTestProperty(key = "Foo.EntryB.Property", string = "ValueB"),
             @MCRTestProperty(key = "Foo.EntryC", classNameOf = SimpleEntry.class),
-            @MCRTestProperty(key = "Foo.EntryC.Property", string = "C"),
+            @MCRTestProperty(key = "Foo.EntryC.Property", string = "ValueC"),
 
         })
     public void nestedMapWithSentinel() {
@@ -348,26 +348,26 @@ public class MCRConfigurableInstanceHelperNestedTest {
 
         assertNull(instance.map.get("EntryA"));
         assertNotNull(instance.map.get("EntryB"));
-        assertEquals("B", instance.map.get("EntryB").string);
+        assertEquals("ValueB", instance.map.get("EntryB").string);
         assertNotNull(instance.map.get("EntryC"));
-        assertEquals("C", instance.map.get("EntryC").string);
+        assertEquals("ValueC", instance.map.get("EntryC").string);
 
     }
 
     @Test
     @MCRTestConfiguration(
         properties = {
-            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithNestedMapWithPrefix.class),
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithNestedMapsWithPrefix.class),
             @MCRTestProperty(key = "Foo.Map1.Entry", classNameOf = OneKindOfEntry.class),
-            @MCRTestProperty(key = "Foo.Map1.Entry.OneProperty", string = "OneValue"),
+            @MCRTestProperty(key = "Foo.Map1.Entry.PropertyA", string = "ValueA"),
             @MCRTestProperty(key = "Foo.Map2.Entry", classNameOf = OtherKindOfEntry.class),
-            @MCRTestProperty(key = "Foo.Map2.Entry.OtherProperty", string = "OtherValue"),
+            @MCRTestProperty(key = "Foo.Map2.Entry.PropertyB", string = "ValueB"),
         })
     public void nestedMapWithPrefix() {
 
         MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
-        TestClassWithNestedMapWithPrefix instance = MCRConfigurableInstanceHelper
-            .getInstance(TestClassWithNestedMapWithPrefix.class, configuration);
+        TestClassWithNestedMapsWithPrefix instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithNestedMapsWithPrefix.class, configuration);
 
         assertNotNull(instance);
         assertNotNull(instance.map1);
@@ -375,15 +375,15 @@ public class MCRConfigurableInstanceHelperNestedTest {
         assertEquals(1, instance.map1.size());
         assertEquals(1, instance.map2.size());
 
-        Entry oneEntry = instance.map1.get("Entry");
-        assertNotNull(oneEntry);
-        assertEquals(OneKindOfEntry.class, oneEntry.getClass());
-        assertEquals("OneValue", oneEntry.get());
+        Entry entryA = instance.map1.get("Entry");
+        assertNotNull(entryA);
+        assertEquals(OneKindOfEntry.class, entryA.getClass());
+        assertEquals("ValueA", entryA.get());
 
-        Entry otherEntry = instance.map2.get("Entry");
-        assertNotNull(otherEntry);
-        assertEquals(OtherKindOfEntry.class, otherEntry.getClass());
-        assertEquals("OtherValue", otherEntry.get());
+        Entry entryB = instance.map2.get("Entry");
+        assertNotNull(entryB);
+        assertEquals(OtherKindOfEntry.class, entryB.getClass());
+        assertEquals("ValueB", entryB.get());
 
     }
 
@@ -391,14 +391,14 @@ public class MCRConfigurableInstanceHelperNestedTest {
     @MCRTestConfiguration(
         properties = {
             @MCRTestProperty(key = "Foo", classNameOf = TestClassWithNestedMapWithPrefixAndSentinel.class),
-            @MCRTestProperty(key = "Foo.Map1.EntryA", classNameOf = SimpleEntry.class),
-            @MCRTestProperty(key = "Foo.Map1.EntryA.Sentinel", string = "false"),
-            @MCRTestProperty(key = "Foo.Map1.EntryA.Property", string = "A"),
-            @MCRTestProperty(key = "Foo.Map1.EntryB", classNameOf = SimpleEntry.class),
-            @MCRTestProperty(key = "Foo.Map1.EntryB.Sentinel", string = "true"),
-            @MCRTestProperty(key = "Foo.Map1.EntryB.Property", string = "B"),
-            @MCRTestProperty(key = "Foo.Map1.EntryC", classNameOf = SimpleEntry.class),
-            @MCRTestProperty(key = "Foo.Map1.EntryC.Property", string = "C"),
+            @MCRTestProperty(key = "Foo.Map.EntryA", classNameOf = SimpleEntry.class),
+            @MCRTestProperty(key = "Foo.Map.EntryA.Sentinel", string = "false"),
+            @MCRTestProperty(key = "Foo.Map.EntryA.Property", string = "ValueA"),
+            @MCRTestProperty(key = "Foo.Map.EntryB", classNameOf = SimpleEntry.class),
+            @MCRTestProperty(key = "Foo.Map.EntryB.Sentinel", string = "true"),
+            @MCRTestProperty(key = "Foo.Map.EntryB.Property", string = "ValueB"),
+            @MCRTestProperty(key = "Foo.Map.EntryC", classNameOf = SimpleEntry.class),
+            @MCRTestProperty(key = "Foo.Map.EntryC.Property", string = "ValueC"),
 
         })
     public void nestedMapWithPrefixAndSentinel() {
@@ -413,9 +413,9 @@ public class MCRConfigurableInstanceHelperNestedTest {
 
         assertNull(instance.map.get("EntryA"));
         assertNotNull(instance.map.get("EntryB"));
-        assertEquals("B", instance.map.get("EntryB").string);
+        assertEquals("ValueB", instance.map.get("EntryB").string);
         assertNotNull(instance.map.get("EntryC"));
-        assertEquals("C", instance.map.get("EntryC").string);
+        assertEquals("ValueC", instance.map.get("EntryC").string);
 
     }
 
@@ -424,9 +424,9 @@ public class MCRConfigurableInstanceHelperNestedTest {
         properties = {
             @MCRTestProperty(key = "Foo", classNameOf = TestClassWithNestedList.class),
             @MCRTestProperty(key = "Foo.23", classNameOf = OneKindOfEntry.class),
-            @MCRTestProperty(key = "Foo.23.OneProperty", string = "OneValue"),
+            @MCRTestProperty(key = "Foo.23.PropertyA", string = "Value23"),
             @MCRTestProperty(key = "Foo.42", classNameOf = OtherKindOfEntry.class),
-            @MCRTestProperty(key = "Foo.42.OtherProperty", string = "OtherValue"),
+            @MCRTestProperty(key = "Foo.42.PropertyB", string = "Value42"),
         })
     public void nestedList() {
 
@@ -438,15 +438,15 @@ public class MCRConfigurableInstanceHelperNestedTest {
         assertNotNull(instance.list);
         assertEquals(2, instance.list.size());
 
-        Entry oneEntry = instance.list.getFirst();
-        assertNotNull(oneEntry);
-        assertEquals(OneKindOfEntry.class, oneEntry.getClass());
-        assertEquals("OneValue", oneEntry.get());
+        Entry entry23 = instance.list.get(0);
+        assertNotNull(entry23);
+        assertEquals(OneKindOfEntry.class, entry23.getClass());
+        assertEquals("Value23", entry23.get());
 
-        Entry otherEntry = instance.list.get(1);
-        assertNotNull(otherEntry);
-        assertEquals(OtherKindOfEntry.class, otherEntry.getClass());
-        assertEquals("OtherValue", otherEntry.get());
+        Entry entry42 = instance.list.get(1);
+        assertNotNull(entry42);
+        assertEquals(OtherKindOfEntry.class, entry42.getClass());
+        assertEquals("Value42", entry42.get());
 
     }
 
@@ -470,8 +470,8 @@ public class MCRConfigurableInstanceHelperNestedTest {
     @MCRTestConfiguration(
         properties = {
             @MCRTestProperty(key = "Foo", classNameOf = TestClassWithNestedListOfImplicitEntries.class),
-            @MCRTestProperty(key = "Foo.23.Property", string = "23"),
-            @MCRTestProperty(key = "Foo.42.Property", string = "42"),
+            @MCRTestProperty(key = "Foo.23.Property", string = "Value23"),
+            @MCRTestProperty(key = "Foo.42.Property", string = "Value42"),
         })
     public void nestedListImplicit() {
 
@@ -483,15 +483,15 @@ public class MCRConfigurableInstanceHelperNestedTest {
         assertNotNull(instance.list);
         assertEquals(2, instance.list.size());
 
-        ImplicitEntry oneEntry = instance.list.getFirst();
-        assertNotNull(oneEntry);
-        assertEquals(ImplicitEntry.class, oneEntry.getClass());
-        assertEquals("23", oneEntry.string);
+        ImplicitEntry entry23 = instance.list.get(0);
+        assertNotNull(entry23);
+        assertEquals(ImplicitEntry.class, entry23.getClass());
+        assertEquals("Value23", entry23.string);
 
-        ImplicitEntry otherEntry = instance.list.get(1);
-        assertNotNull(otherEntry);
-        assertEquals(ImplicitEntry.class, otherEntry.getClass());
-        assertEquals("42", otherEntry.string);
+        ImplicitEntry entry42 = instance.list.get(1);
+        assertNotNull(entry42);
+        assertEquals(ImplicitEntry.class, entry42.getClass());
+        assertEquals("Value42", entry42.string);
 
     }
 
@@ -500,9 +500,9 @@ public class MCRConfigurableInstanceHelperNestedTest {
         properties = {
             @MCRTestProperty(key = "Foo", classNameOf = TestClassWithOptionalNestedList.class),
             @MCRTestProperty(key = "Foo.23", classNameOf = OneKindOfEntry.class),
-            @MCRTestProperty(key = "Foo.23.OneProperty", string = "OneValue"),
+            @MCRTestProperty(key = "Foo.23.PropertyA", string = "Value23"),
             @MCRTestProperty(key = "Foo.42", classNameOf = OtherKindOfEntry.class),
-            @MCRTestProperty(key = "Foo.42.OtherProperty", string = "OtherValue"),
+            @MCRTestProperty(key = "Foo.42.PropertyB", string = "Value42"),
         })
     public void nestedOptionalList() {
 
@@ -514,15 +514,15 @@ public class MCRConfigurableInstanceHelperNestedTest {
         assertNotNull(instance.list);
         assertEquals(2, instance.list.size());
 
-        Entry oneEntry = instance.list.getFirst();
-        assertNotNull(oneEntry);
-        assertEquals(OneKindOfEntry.class, oneEntry.getClass());
-        assertEquals("OneValue", oneEntry.get());
+        Entry entry23 = instance.list.get(0);
+        assertNotNull(entry23);
+        assertEquals(OneKindOfEntry.class, entry23.getClass());
+        assertEquals("Value23", entry23.get());
 
-        Entry otherEntry = instance.list.get(1);
-        assertNotNull(otherEntry);
-        assertEquals(OtherKindOfEntry.class, otherEntry.getClass());
-        assertEquals("OtherValue", otherEntry.get());
+        Entry entry42 = instance.list.get(1);
+        assertNotNull(entry42);
+        assertEquals(OtherKindOfEntry.class, entry42.getClass());
+        assertEquals("Value42", entry42.get());
 
     }
 
@@ -549,12 +549,12 @@ public class MCRConfigurableInstanceHelperNestedTest {
             @MCRTestProperty(key = "Foo", classNameOf = TestClassWithNestedListAndSentinel.class),
             @MCRTestProperty(key = "Foo.7", classNameOf = SimpleEntry.class),
             @MCRTestProperty(key = "Foo.7.Sentinel", string = "false"),
-            @MCRTestProperty(key = "Foo.7.Property", string = "7"),
+            @MCRTestProperty(key = "Foo.7.Property", string = "Value7"),
             @MCRTestProperty(key = "Foo.23", classNameOf = SimpleEntry.class),
             @MCRTestProperty(key = "Foo.23.Sentinel", string = "true"),
-            @MCRTestProperty(key = "Foo.23.Property", string = "23"),
+            @MCRTestProperty(key = "Foo.23.Property", string = "Value23"),
             @MCRTestProperty(key = "Foo.42", classNameOf = SimpleEntry.class),
-            @MCRTestProperty(key = "Foo.42.Property", string = "42"),
+            @MCRTestProperty(key = "Foo.42.Property", string = "Value42"),
 
         })
     public void nestedListWithSentinel() {
@@ -567,25 +567,25 @@ public class MCRConfigurableInstanceHelperNestedTest {
         assertNotNull(instance.list);
         assertEquals(2, instance.list.size());
 
-        assertEquals("23", instance.list.get(0).string);
-        assertEquals("42", instance.list.get(1).string);
+        assertEquals("Value23", instance.list.get(0).string);
+        assertEquals("Value42", instance.list.get(1).string);
 
     }
 
     @Test
     @MCRTestConfiguration(
         properties = {
-            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithNestedListWithPrefix.class),
+            @MCRTestProperty(key = "Foo", classNameOf = TestClassWithNestedListsWithPrefix.class),
             @MCRTestProperty(key = "Foo.List1.23", classNameOf = OneKindOfEntry.class),
-            @MCRTestProperty(key = "Foo.List1.23.OneProperty", string = "OneValue"),
-            @MCRTestProperty(key = "Foo.List2.23", classNameOf = OtherKindOfEntry.class),
-            @MCRTestProperty(key = "Foo.List2.23.OtherProperty", string = "OtherValue"),
+            @MCRTestProperty(key = "Foo.List1.23.PropertyA", string = "Value23"),
+            @MCRTestProperty(key = "Foo.List2.42", classNameOf = OtherKindOfEntry.class),
+            @MCRTestProperty(key = "Foo.List2.42.PropertyB", string = "Value42"),
         })
     public void nestedListWithPrefix() {
 
         MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
-        TestClassWithNestedListWithPrefix instance = MCRConfigurableInstanceHelper
-            .getInstance(TestClassWithNestedListWithPrefix.class, configuration);
+        TestClassWithNestedListsWithPrefix instance = MCRConfigurableInstanceHelper
+            .getInstance(TestClassWithNestedListsWithPrefix.class, configuration);
 
         assertNotNull(instance);
         assertNotNull(instance.list1);
@@ -593,15 +593,15 @@ public class MCRConfigurableInstanceHelperNestedTest {
         assertEquals(1, instance.list1.size());
         assertEquals(1, instance.list2.size());
 
-        Entry oneEntry = instance.list1.getFirst();
-        assertNotNull(oneEntry);
-        assertEquals(OneKindOfEntry.class, oneEntry.getClass());
-        assertEquals("OneValue", oneEntry.get());
+        Entry entry23 = instance.list1.get(0);
+        assertNotNull(entry23);
+        assertEquals(OneKindOfEntry.class, entry23.getClass());
+        assertEquals("Value23", entry23.get());
 
-        Entry otherEntry = instance.list2.getFirst();
-        assertNotNull(otherEntry);
-        assertEquals(OtherKindOfEntry.class, otherEntry.getClass());
-        assertEquals("OtherValue", otherEntry.get());
+        Entry entry42 = instance.list2.get(0);
+        assertNotNull(entry42);
+        assertEquals(OtherKindOfEntry.class, entry42.getClass());
+        assertEquals("Value42", entry42.get());
 
     }
 
@@ -609,14 +609,14 @@ public class MCRConfigurableInstanceHelperNestedTest {
     @MCRTestConfiguration(
         properties = {
             @MCRTestProperty(key = "Foo", classNameOf = TestClassWithNestedListWithPrefixAndSentinel.class),
-            @MCRTestProperty(key = "Foo.List1.7", classNameOf = SimpleEntry.class),
-            @MCRTestProperty(key = "Foo.List1.7.Sentinel", string = "false"),
-            @MCRTestProperty(key = "Foo.List1.7.Property", string = "7"),
-            @MCRTestProperty(key = "Foo.List1.23", classNameOf = SimpleEntry.class),
-            @MCRTestProperty(key = "Foo.List1.23.Sentinel", string = "true"),
-            @MCRTestProperty(key = "Foo.List1.23.Property", string = "23"),
-            @MCRTestProperty(key = "Foo.List1.42", classNameOf = SimpleEntry.class),
-            @MCRTestProperty(key = "Foo.List1.42.Property", string = "42"),
+            @MCRTestProperty(key = "Foo.List.7", classNameOf = SimpleEntry.class),
+            @MCRTestProperty(key = "Foo.List.7.Sentinel", string = "false"),
+            @MCRTestProperty(key = "Foo.List.7.Property", string = "Value7"),
+            @MCRTestProperty(key = "Foo.List.23", classNameOf = SimpleEntry.class),
+            @MCRTestProperty(key = "Foo.List.23.Sentinel", string = "true"),
+            @MCRTestProperty(key = "Foo.List.23.Property", string = "Value23"),
+            @MCRTestProperty(key = "Foo.List.42", classNameOf = SimpleEntry.class),
+            @MCRTestProperty(key = "Foo.List.42.Property", string = "Value42"),
         })
     public void nestedListWithPrefixAndSentinel() {
 
@@ -628,27 +628,27 @@ public class MCRConfigurableInstanceHelperNestedTest {
         assertNotNull(instance.list);
         assertEquals(2, instance.list.size());
 
-        assertEquals("23", instance.list.get(0).string);
-        assertEquals("42", instance.list.get(1).string);
+        assertEquals("Value23", instance.list.get(0).string);
+        assertEquals("Value42", instance.list.get(1).string);
 
     }
 
     public static class NestedClass {
 
-        @MCRProperty(name = "Property1")
+        @MCRProperty(name = "PropertyA")
         public String string1;
 
-        @MCRProperty(name = "Property2")
+        @MCRProperty(name = "PropertyB")
         public String string2;
 
     }
 
     public static final class ImplicitNestedClass {
 
-        @MCRProperty(name = "Property1")
+        @MCRProperty(name = "PropertyA")
         public String string1;
 
-        @MCRProperty(name = "Property2")
+        @MCRProperty(name = "PropertyB")
         public String string2;
 
     }
@@ -711,7 +711,7 @@ public class MCRConfigurableInstanceHelperNestedTest {
 
     public static class OneKindOfEntry extends Entry {
 
-        @MCRProperty(name = "OneProperty")
+        @MCRProperty(name = "PropertyA")
         public String string;
 
         @Override
@@ -723,7 +723,7 @@ public class MCRConfigurableInstanceHelperNestedTest {
 
     public static class OtherKindOfEntry extends Entry {
 
-        @MCRProperty(name = "OtherProperty")
+        @MCRProperty(name = "PropertyB")
         public String string;
 
         @Override
@@ -761,7 +761,7 @@ public class MCRConfigurableInstanceHelperNestedTest {
 
     }
 
-    public static class TestClassWithNestedMapWithPrefix {
+    public static class TestClassWithNestedMapsWithPrefix {
 
         @MCRInstanceMap(name = "Map1", valueClass = Entry.class)
         public Map<String, Entry> map1;
@@ -773,7 +773,7 @@ public class MCRConfigurableInstanceHelperNestedTest {
 
     public static class TestClassWithNestedMapWithPrefixAndSentinel {
 
-        @MCRInstanceMap(name = "Map1", valueClass = SimpleEntry.class, sentinel = @MCRSentinel(name = "Sentinel"))
+        @MCRInstanceMap(name = "Map", valueClass = SimpleEntry.class, sentinel = @MCRSentinel(name = "Sentinel"))
         public Map<String, SimpleEntry> map;
 
     }
@@ -806,7 +806,7 @@ public class MCRConfigurableInstanceHelperNestedTest {
 
     }
 
-    public static class TestClassWithNestedListWithPrefix {
+    public static class TestClassWithNestedListsWithPrefix {
 
         @MCRInstanceList(name = "List1", valueClass = Entry.class)
         public List<Entry> list1;
@@ -818,7 +818,7 @@ public class MCRConfigurableInstanceHelperNestedTest {
 
     public static class TestClassWithNestedListWithPrefixAndSentinel {
 
-        @MCRInstanceList(name = "List1", valueClass = SimpleEntry.class, sentinel = @MCRSentinel(name = "Sentinel"))
+        @MCRInstanceList(name = "List", valueClass = SimpleEntry.class, sentinel = @MCRSentinel(name = "Sentinel"))
         public List<SimpleEntry> list;
 
     }

--- a/mycore-base/src/test/java/org/mycore/common/config/MCRConfigurableInstancePropertyListTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/config/MCRConfigurableInstancePropertyListTest.java
@@ -1,0 +1,1079 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mycore.common.MCRTestConfiguration;
+import org.mycore.common.MCRTestProperty;
+import org.mycore.common.config.annotation.MCRPropertyList;
+import org.mycore.test.MyCoReTest;
+
+/**
+ * Programmatically created exhaustive list of tests for the following conditions:
+ * <ol>
+ *   <li>Annotation has <code>required = false</code> or not</li>
+ *   <li>Configuration property for instance value is not set, set empty in short form,
+ *   set non-empty in short form or set non-empty in long form</li>
+ *   <li>Annotation has <code>defaultName = "..."</code> or not</li>
+ *   <li>Configuration property for default value is not set, set empty in short form,
+ *   set non-empty in short form or set non-empty in long form </li>
+ * </ol>
+ * <table style="border-collapse: collapse;">
+ *   <caption>Expected results for different conditions</caption>
+ *   <tr>
+ *     <th style="border: 1px solid;">Is Required</th>
+ *     <th style="border: 1px solid;">Property</th>
+ *     <th style="border: 1px solid;">Has Default</th>
+ *     <th style="border: 1px solid;">Default Property</th>
+ *     <th style="border: 1px solid;">Expected Result</th>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;"><code>[]</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">Exception</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>X=</code></td>
+ *     <td style="border: 1px solid;"><code>[]</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>X=y,z</code></td>
+ *     <td style="border: 1px solid;"><code>[y, z]</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>X.1=y</code>, <code>X.2=z</code></td>
+ *     <td style="border: 1px solid;"><code>[y, z]</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;"><code>A=</code></td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;"><code>[]</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;"><code>A=b,c</code></td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;"><code>[b, c]</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;"><code>A.1=b</code>, <code>A.2=c</code></td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;"><code>[b, c]</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">Exception</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">Exception</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>X=</code></td>
+ *     <td style="border: 1px solid;">Exception</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>X=y,z</code></td>
+ *     <td style="border: 1px solid;"><code>[y, z]</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>X.1=y</code>, <code>X.2=z</code></td>
+ *     <td style="border: 1px solid;"><code>[y, z]</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>A=</code></td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">Exception</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>A=b,c</code></td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;"><code>[b, c]</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>A.1=b</code>, <code>A.2=c</code></td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;"><code>[b, c]</code></td>
+ *   </tr>
+ * </table>
+ */
+@MyCoReTest
+public class MCRConfigurableInstancePropertyListTest {
+
+    private static final List<String> EMPTY = List.of();
+
+    private static final List<String> DEFAULT_MAP = List.of("DefaultValue");
+
+    private static final List<String> MAP = List.of("Value");
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+    })
+    public void notRequiredPropertyMissingDefaultNotSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(EMPTY, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "MCR.List", empty = true),
+    })
+    public void notRequiredPropertyMissingDefaultNotSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(EMPTY, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "MCR.List", string = "DefaultValue,"),
+    })
+    public void notRequiredPropertyMissingDefaultNotSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(EMPTY, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "MCR.List.1", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.List.2", empty = true),
+    })
+    public void notRequiredPropertyMissingDefaultNotSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(EMPTY, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+    })
+    public void notRequiredPropertyMissingDefaultSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                NotRequiredDefaultSet.class, configuration);
+        });
+        assertEquals("Missing default configuration entries like: MCR.List, MCR.List.1, MCR.List.2, ...",
+            exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "MCR.List", empty = true),
+    })
+    public void notRequiredPropertyMissingDefaultSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(EMPTY, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "MCR.List", string = "DefaultValue,"),
+    })
+    public void notRequiredPropertyMissingDefaultSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(DEFAULT_MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "MCR.List.1", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.List.2", empty = true),
+    })
+    public void notRequiredPropertyMissingDefaultSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(DEFAULT_MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List", empty = true),
+    })
+    public void notRequiredPropertyShortEmptyDefaultNotSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(EMPTY, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List", empty = true),
+        @MCRTestProperty(key = "MCR.List", empty = true),
+    })
+    public void notRequiredPropertyShortEmptyDefaultNotSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(EMPTY, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List", empty = true),
+        @MCRTestProperty(key = "MCR.List", string = "DefaultValue,"),
+    })
+    public void notRequiredPropertyShortEmptyDefaultNotSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(EMPTY, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List", empty = true),
+        @MCRTestProperty(key = "MCR.List.1", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.List.2", empty = true),
+    })
+    public void notRequiredPropertyShortEmptyDefaultNotSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(EMPTY, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List", empty = true),
+    })
+    public void notRequiredPropertyShortEmptyDefaultSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(EMPTY, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List", empty = true),
+        @MCRTestProperty(key = "MCR.List", empty = true),
+    })
+    public void notRequiredPropertyShortEmptyDefaultSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(EMPTY, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List", empty = true),
+        @MCRTestProperty(key = "MCR.List", string = "DefaultValue,"),
+    })
+    public void notRequiredPropertyShortEmptyDefaultSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(EMPTY, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List", empty = true),
+        @MCRTestProperty(key = "MCR.List.1", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.List.2", empty = true),
+    })
+    public void notRequiredPropertyShortEmptyDefaultSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(EMPTY, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List", string = "Value,"),
+    })
+    public void notRequiredPropertyShortNotEmptyDefaultNotSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List", string = "Value,"),
+        @MCRTestProperty(key = "MCR.List", empty = true),
+    })
+    public void notRequiredPropertyShortNotEmptyDefaultNotSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List", string = "Value,"),
+        @MCRTestProperty(key = "MCR.List", string = "DefaultValue,"),
+    })
+    public void notRequiredPropertyShortNotEmptyDefaultNotSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List", string = "Value,"),
+        @MCRTestProperty(key = "MCR.List.1", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.List.2", empty = true),
+    })
+    public void notRequiredPropertyShortNotEmptyDefaultNotSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List", string = "Value,"),
+    })
+    public void notRequiredPropertyShortNotEmptyDefaultSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List", string = "Value,"),
+        @MCRTestProperty(key = "MCR.List", empty = true),
+    })
+    public void notRequiredPropertyShortNotEmptyDefaultSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List", string = "Value,"),
+        @MCRTestProperty(key = "MCR.List", string = "DefaultValue,"),
+    })
+    public void notRequiredPropertyShortNotEmptyDefaultSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List", string = "Value,"),
+        @MCRTestProperty(key = "MCR.List.1", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.List.2", empty = true),
+    })
+    public void notRequiredPropertyShortNotEmptyDefaultSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List.1", string = "Value"),
+        @MCRTestProperty(key = "Foo.List.2", empty = true),
+    })
+    public void notRequiredPropertyLongNotEmptyDefaultNotSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List.1", string = "Value"),
+        @MCRTestProperty(key = "Foo.List.2", empty = true),
+        @MCRTestProperty(key = "MCR.List", empty = true),
+    })
+    public void notRequiredPropertyLongNotEmptyDefaultNotSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List.1", string = "Value"),
+        @MCRTestProperty(key = "Foo.List.2", empty = true),
+        @MCRTestProperty(key = "MCR.List", string = "DefaultValue,"),
+    })
+    public void notRequiredPropertyLongNotEmptyDefaultNotSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List.1", string = "Value"),
+        @MCRTestProperty(key = "Foo.List.2", empty = true),
+        @MCRTestProperty(key = "MCR.List.1", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.List.2", empty = true),
+    })
+    public void notRequiredPropertyLongNotEmptyDefaultNotSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List.1", string = "Value"),
+        @MCRTestProperty(key = "Foo.List.2", empty = true),
+    })
+    public void notRequiredPropertyLongNotEmptyDefaultSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List.1", string = "Value"),
+        @MCRTestProperty(key = "Foo.List.2", empty = true),
+        @MCRTestProperty(key = "MCR.List", empty = true),
+    })
+    public void notRequiredPropertyLongNotEmptyDefaultSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List.1", string = "Value"),
+        @MCRTestProperty(key = "Foo.List.2", empty = true),
+        @MCRTestProperty(key = "MCR.List", string = "DefaultValue,"),
+    })
+    public void notRequiredPropertyLongNotEmptyDefaultSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List.1", string = "Value"),
+        @MCRTestProperty(key = "Foo.List.2", empty = true),
+        @MCRTestProperty(key = "MCR.List.1", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.List.2", empty = true),
+    })
+    public void notRequiredPropertyLongNotEmptyDefaultSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+    })
+    public void requiredPropertyMissingDefaultNotSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.List, Foo.List.1, Foo.List.2, ...",
+            exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "MCR.List", empty = true),
+    })
+    public void requiredPropertyMissingDefaultNotSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.List, Foo.List.1, Foo.List.2, ...",
+            exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "MCR.List", string = "DefaultValue,"),
+    })
+    public void requiredPropertyMissingDefaultNotSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.List, Foo.List.1, Foo.List.2, ...",
+            exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "MCR.List.1", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.List.2", empty = true),
+    })
+    public void requiredPropertyMissingDefaultNotSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.List, Foo.List.1, Foo.List.2, ...",
+            exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+    })
+    public void requiredPropertyMissingDefaultSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                RequiredDefaultSet.class, configuration);
+        });
+        assertEquals("Missing default configuration entries like: MCR.List, MCR.List.1, MCR.List.2, ...",
+            exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "MCR.List", empty = true),
+    })
+    public void requiredPropertyMissingDefaultSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                RequiredDefaultSet.class, configuration);
+        });
+        assertEquals("Missing default configuration entries like: MCR.List, MCR.List.1, MCR.List.2, ...",
+            exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "MCR.List", string = "DefaultValue,"),
+    })
+    public void requiredPropertyMissingDefaultSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(DEFAULT_MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "MCR.List.1", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.List.2", empty = true),
+    })
+    public void requiredPropertyMissingDefaultSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(DEFAULT_MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List", empty = true),
+    })
+    public void requiredPropertyShortEmptyDefaultNotSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                    RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.List, Foo.List.1, Foo.List.2, ...",
+                exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List", empty = true),
+        @MCRTestProperty(key = "MCR.List", empty = true),
+    })
+    public void requiredPropertyShortEmptyDefaultNotSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                    RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.List, Foo.List.1, Foo.List.2, ...",
+                exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List", empty = true),
+        @MCRTestProperty(key = "MCR.List", string = "DefaultValue,"),
+    })
+    public void requiredPropertyShortEmptyDefaultNotSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                    RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.List, Foo.List.1, Foo.List.2, ...",
+                exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List", empty = true),
+        @MCRTestProperty(key = "MCR.List.1", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.List.2", empty = true),
+    })
+    public void requiredPropertyShortEmptyDefaultNotSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                    RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.List, Foo.List.1, Foo.List.2, ...",
+                exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List", empty = true),
+    })
+    public void requiredPropertyShortEmptyDefaultSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                    RequiredDefaultSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.List, Foo.List.1, Foo.List.2, ...",
+                exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List", empty = true),
+        @MCRTestProperty(key = "MCR.List", empty = true),
+    })
+    public void requiredPropertyShortEmptyDefaultSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                    RequiredDefaultSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.List, Foo.List.1, Foo.List.2, ...",
+                exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List", empty = true),
+        @MCRTestProperty(key = "MCR.List", string = "DefaultValue,"),
+    })
+    public void requiredPropertyShortEmptyDefaultSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                    RequiredDefaultSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.List, Foo.List.1, Foo.List.2, ...",
+                exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List", empty = true),
+        @MCRTestProperty(key = "MCR.List.1", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.List.2", empty = true),
+    })
+    public void requiredPropertyShortEmptyDefaultSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                    RequiredDefaultSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.List, Foo.List.1, Foo.List.2, ...",
+                exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List", string = "Value,"),
+    })
+    public void requiredPropertyShortNotEmptyDefaultNotSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List", string = "Value,"),
+        @MCRTestProperty(key = "MCR.List", empty = true),
+    })
+    public void requiredPropertyShortNotEmptyDefaultNotSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List", string = "Value,"),
+        @MCRTestProperty(key = "MCR.List", string = "DefaultValue,"),
+    })
+    public void requiredPropertyShortNotEmptyDefaultNotSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List", string = "Value,"),
+        @MCRTestProperty(key = "MCR.List.1", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.List.2", empty = true),
+    })
+    public void requiredPropertyShortNotEmptyDefaultNotSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List", string = "Value,"),
+    })
+    public void requiredPropertyShortNotEmptyDefaultSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List", string = "Value,"),
+        @MCRTestProperty(key = "MCR.List", empty = true),
+    })
+    public void requiredPropertyShortNotEmptyDefaultSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List", string = "Value,"),
+        @MCRTestProperty(key = "MCR.List", string = "DefaultValue,"),
+    })
+    public void requiredPropertyShortNotEmptyDefaultSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List", string = "Value,"),
+        @MCRTestProperty(key = "MCR.List.1", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.List.2", empty = true),
+    })
+    public void requiredPropertyShortNotEmptyDefaultSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List.1", string = "Value"),
+        @MCRTestProperty(key = "Foo.List.2", empty = true),
+    })
+    public void requiredPropertyLongNotEmptyDefaultNotSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List.1", string = "Value"),
+        @MCRTestProperty(key = "Foo.List.2", empty = true),
+        @MCRTestProperty(key = "MCR.List", empty = true),
+    })
+    public void requiredPropertyLongNotEmptyDefaultNotSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List.1", string = "Value"),
+        @MCRTestProperty(key = "Foo.List.2", empty = true),
+        @MCRTestProperty(key = "MCR.List", string = "DefaultValue,"),
+    })
+    public void requiredPropertyLongNotEmptyDefaultNotSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.List.1", string = "Value"),
+        @MCRTestProperty(key = "Foo.List.2", empty = true),
+        @MCRTestProperty(key = "MCR.List.1", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.List.2", empty = true),
+    })
+    public void requiredPropertyLongNotEmptyDefaultNotSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List.1", string = "Value"),
+        @MCRTestProperty(key = "Foo.List.2", empty = true),
+    })
+    public void requiredPropertyLongNotEmptyDefaultSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List.1", string = "Value"),
+        @MCRTestProperty(key = "Foo.List.2", empty = true),
+        @MCRTestProperty(key = "MCR.List", empty = true),
+    })
+    public void requiredPropertyLongNotEmptyDefaultSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List.1", string = "Value"),
+        @MCRTestProperty(key = "Foo.List.2", empty = true),
+        @MCRTestProperty(key = "MCR.List", string = "DefaultValue,"),
+    })
+    public void requiredPropertyLongNotEmptyDefaultSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.List.1", string = "Value"),
+        @MCRTestProperty(key = "Foo.List.2", empty = true),
+        @MCRTestProperty(key = "MCR.List.1", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.List.2", empty = true),
+    })
+    public void requiredPropertyLongNotEmptyDefaultSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.list);
+    }
+
+    public static class NotRequiredDefaultNotSet {
+
+        @MCRPropertyList(name = "List", required = false)
+        public List<String> list;
+
+    }
+
+    public static class NotRequiredDefaultSet {
+
+        @MCRPropertyList(name = "List", required = false, defaultName = "MCR.List")
+        public List<String> list;
+
+    }
+
+    public static class RequiredDefaultNotSet {
+
+        @MCRPropertyList(name = "List")
+        public List<String> list;
+
+    }
+
+    public static class RequiredDefaultSet {
+
+        @MCRPropertyList(name = "List", defaultName = "MCR.List")
+        public List<String> list;
+
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/common/config/MCRConfigurableInstancePropertyMapTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/config/MCRConfigurableInstancePropertyMapTest.java
@@ -1,0 +1,1078 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mycore.common.MCRTestConfiguration;
+import org.mycore.common.MCRTestProperty;
+import org.mycore.common.config.annotation.MCRPropertyMap;
+import org.mycore.test.MyCoReTest;
+
+/**
+ * Programmatically created exhaustive list of tests for the following conditions:
+ * <ol>
+ *   <li>Annotation has <code>required = false</code> or not</li>
+ *   <li>Configuration property for instance value is not set, set empty in short form,
+ *   set non-empty in short form or set non-empty in long form</li>
+ *   <li>Annotation has <code>defaultName = "..."</code> or not</li>
+ *   <li>Configuration property for default value is not set, set empty in short form,
+ *   set non-empty in short form or set non-empty in long form </li>
+ * </ol>
+ * <table style="border-collapse: collapse;">
+ *   <caption>Expected results for different conditions</caption>
+ *   <tr>
+ *     <th style="border: 1px solid;">Is Required</th>
+ *     <th style="border: 1px solid;">Property</th>
+ *     <th style="border: 1px solid;">Has Default</th>
+ *     <th style="border: 1px solid;">Default Property</th>
+ *     <th style="border: 1px solid;">Expected Result</th>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;"><code>{}</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">Exception</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>X=</code></td>
+ *     <td style="border: 1px solid;"><code>{}</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>X=Y:y,Z:z</code></td>
+ *     <td style="border: 1px solid;"><code>{Y=y, Z=z}</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>X.Y=y</code>, <code>X.Z=z</code></td>
+ *     <td style="border: 1px solid;"><code>{Y=y, Z=z}</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;"><code>A=</code></td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;"><code>{}</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;"><code>A=B:b,C:c</code></td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;"><code>{B=b, C=c}</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;"><code>A.B=b</code>, <code>A.C=c</code></td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;"><code>{B=b, C=c}</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">Exception</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">Exception</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>X=</code></td>
+ *     <td style="border: 1px solid;">Exception</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>X=Y:y,Z:z</code></td>
+ *     <td style="border: 1px solid;"><code>{Y=y, Z=z}</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>X.Y=y</code>, <code>X.Z=z</code></td>
+ *     <td style="border: 1px solid;"><code>{Y=y, Z=z}</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>A=</code></td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">Exception</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>A=B:b,C:c</code></td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;"><code>{B=b, C=c}</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>A.B=b</code>, <code>A.C=c</code></td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;"><code>{B=b, C=c}</code></td>
+ *   </tr>
+ * </table>
+ */
+@MyCoReTest
+public class MCRConfigurableInstancePropertyMapTest {
+
+    private static final Map<String, String> EMPTY = Map.of();
+
+    private static final Map<String, String> DEFAULT_LIST = Map.of("NonEmpty", "DefaultValue");
+
+    private static final Map<String, String> MAP = Map.of("NonEmpty", "Value");
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+    })
+    public void notRequiredPropertyMissingDefaultNotSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(EMPTY, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "MCR.Map", empty = true),
+    })
+    public void notRequiredPropertyMissingDefaultNotSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(EMPTY, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "MCR.Map", string = "NonEmpty:DefaultValue,Empty:"),
+    })
+    public void notRequiredPropertyMissingDefaultNotSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(EMPTY, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "MCR.Map.NonEmpty", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.Map.Empty", empty = true),
+    })
+    public void notRequiredPropertyMissingDefaultNotSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(EMPTY, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+    })
+    public void notRequiredPropertyMissingDefaultSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(NotRequiredDefaultSet.class, configuration);
+        });
+        assertEquals("Missing default configuration entries like: MCR.Map, MCR.Map.A, MCR.Map.B, ...",
+            exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "MCR.Map", empty = true),
+    })
+    public void notRequiredPropertyMissingDefaultSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(EMPTY, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "MCR.Map", string = "NonEmpty:DefaultValue,Empty:"),
+    })
+    public void notRequiredPropertyMissingDefaultSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(DEFAULT_LIST, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "MCR.Map.NonEmpty", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.Map.Empty", empty = true),
+    })
+    public void notRequiredPropertyMissingDefaultSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(DEFAULT_LIST, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map", empty = true),
+    })
+    public void notRequiredPropertyShortEmptyDefaultNotSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(EMPTY, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map", empty = true),
+        @MCRTestProperty(key = "MCR.Map", empty = true),
+    })
+    public void notRequiredPropertyShortEmptyDefaultNotSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(EMPTY, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map", empty = true),
+        @MCRTestProperty(key = "MCR.Map", string = "NonEmpty:DefaultValue,Empty:"),
+    })
+    public void notRequiredPropertyShortEmptyDefaultNotSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(EMPTY, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map", empty = true),
+        @MCRTestProperty(key = "MCR.Map.NonEmpty", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.Map.Empty", empty = true),
+    })
+    public void notRequiredPropertyShortEmptyDefaultNotSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(EMPTY, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map", empty = true),
+    })
+    public void notRequiredPropertyShortEmptyDefaultSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(EMPTY, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map", empty = true),
+        @MCRTestProperty(key = "MCR.Map", empty = true),
+    })
+    public void notRequiredPropertyShortEmptyDefaultSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(EMPTY, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map", empty = true),
+        @MCRTestProperty(key = "MCR.Map", string = "NonEmpty:DefaultValue,Empty:"),
+    })
+    public void notRequiredPropertyShortEmptyDefaultSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(EMPTY, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map", empty = true),
+        @MCRTestProperty(key = "MCR.Map.NonEmpty", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.Map.Empty", empty = true),
+    })
+    public void notRequiredPropertyShortEmptyDefaultSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(EMPTY, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map", string = "NonEmpty:Value,Empty:"),
+    })
+    public void notRequiredPropertyShortNotEmptyDefaultNotSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map", string = "NonEmpty:Value,Empty:"),
+        @MCRTestProperty(key = "MCR.Map", empty = true),
+    })
+    public void notRequiredPropertyShortNotEmptyDefaultNotSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map", string = "NonEmpty:Value,Empty:"),
+        @MCRTestProperty(key = "MCR.Map", string = "NonEmpty:DefaultValue,Empty:"),
+    })
+    public void notRequiredPropertyShortNotEmptyDefaultNotSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map", string = "NonEmpty:Value,Empty:"),
+        @MCRTestProperty(key = "MCR.Map.NonEmpty", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.Map.Empty", empty = true),
+    })
+    public void notRequiredPropertyShortNotEmptyDefaultNotSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map", string = "NonEmpty:Value,Empty:"),
+    })
+    public void notRequiredPropertyShortNotEmptyDefaultSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map", string = "NonEmpty:Value,Empty:"),
+        @MCRTestProperty(key = "MCR.Map", empty = true),
+    })
+    public void notRequiredPropertyShortNotEmptyDefaultSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map", string = "NonEmpty:Value,Empty:"),
+        @MCRTestProperty(key = "MCR.Map", string = "NonEmpty:DefaultValue,Empty:"),
+    })
+    public void notRequiredPropertyShortNotEmptyDefaultSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map", string = "NonEmpty:Value,Empty:"),
+        @MCRTestProperty(key = "MCR.Map.NonEmpty", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.Map.Empty", empty = true),
+    })
+    public void notRequiredPropertyShortNotEmptyDefaultSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map.NonEmpty", string = "Value"),
+        @MCRTestProperty(key = "Foo.Map.Empty", empty = true),
+    })
+    public void notRequiredPropertyLongNotEmptyDefaultNotSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map.NonEmpty", string = "Value"),
+        @MCRTestProperty(key = "Foo.Map.Empty", empty = true),
+        @MCRTestProperty(key = "MCR.Map", empty = true),
+    })
+    public void notRequiredPropertyLongNotEmptyDefaultNotSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map.NonEmpty", string = "Value"),
+        @MCRTestProperty(key = "Foo.Map.Empty", empty = true),
+        @MCRTestProperty(key = "MCR.Map", string = "NonEmpty:DefaultValue,Empty:"),
+    })
+    public void notRequiredPropertyLongNotEmptyDefaultNotSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map.NonEmpty", string = "Value"),
+        @MCRTestProperty(key = "Foo.Map.Empty", empty = true),
+        @MCRTestProperty(key = "MCR.Map.NonEmpty", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.Map.Empty", empty = true),
+    })
+    public void notRequiredPropertyLongNotEmptyDefaultNotSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map.NonEmpty", string = "Value"),
+        @MCRTestProperty(key = "Foo.Map.Empty", empty = true),
+    })
+    public void notRequiredPropertyLongNotEmptyDefaultSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map.NonEmpty", string = "Value"),
+        @MCRTestProperty(key = "Foo.Map.Empty", empty = true),
+        @MCRTestProperty(key = "MCR.Map", empty = true),
+    })
+    public void notRequiredPropertyLongNotEmptyDefaultSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map.NonEmpty", string = "Value"),
+        @MCRTestProperty(key = "Foo.Map.Empty", empty = true),
+        @MCRTestProperty(key = "MCR.Map", string = "NonEmpty:DefaultValue,Empty:"),
+    })
+    public void notRequiredPropertyLongNotEmptyDefaultSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map.NonEmpty", string = "Value"),
+        @MCRTestProperty(key = "Foo.Map.Empty", empty = true),
+        @MCRTestProperty(key = "MCR.Map.NonEmpty", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.Map.Empty", empty = true),
+    })
+    public void notRequiredPropertyLongNotEmptyDefaultSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+    })
+    public void requiredPropertyMissingDefaultNotSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.Map, Foo.Map.A, Foo.Map.B, ...",
+            exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "MCR.Map", empty = true),
+    })
+    public void requiredPropertyMissingDefaultNotSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.Map, Foo.Map.A, Foo.Map.B, ...",
+            exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "MCR.Map", string = "NonEmpty:DefaultValue,Empty:"),
+    })
+    public void requiredPropertyMissingDefaultNotSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.Map, Foo.Map.A, Foo.Map.B, ...",
+            exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "MCR.Map.NonEmpty", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.Map.Empty", empty = true),
+    })
+    public void requiredPropertyMissingDefaultNotSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.Map, Foo.Map.A, Foo.Map.B, ...",
+            exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+    })
+    public void requiredPropertyMissingDefaultSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                RequiredDefaultSet.class, configuration);
+        });
+        assertEquals("Missing default configuration entries like: MCR.Map, MCR.Map.A, MCR.Map.B, ...",
+            exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "MCR.Map", empty = true),
+    })
+    public void requiredPropertyMissingDefaultSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                    RequiredDefaultSet.class, configuration);
+        });
+        assertEquals("Missing default configuration entries like: MCR.Map, MCR.Map.A, MCR.Map.B, ...",
+                exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "MCR.Map", string = "NonEmpty:DefaultValue,Empty:"),
+    })
+    public void requiredPropertyMissingDefaultSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(DEFAULT_LIST, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "MCR.Map.NonEmpty", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.Map.Empty", empty = true),
+    })
+    public void requiredPropertyMissingDefaultSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(DEFAULT_LIST, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map", empty = true),
+    })
+    public void requiredPropertyShortEmptyDefaultNotSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                    RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.Map, Foo.Map.A, Foo.Map.B, ...",
+                exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map", empty = true),
+        @MCRTestProperty(key = "MCR.Map", empty = true),
+    })
+    public void requiredPropertyShortEmptyDefaultNotSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                    RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.Map, Foo.Map.A, Foo.Map.B, ...",
+                exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map", empty = true),
+        @MCRTestProperty(key = "MCR.Map", string = "NonEmpty:DefaultValue,Empty:"),
+    })
+    public void requiredPropertyShortEmptyDefaultNotSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                    RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.Map, Foo.Map.A, Foo.Map.B, ...",
+                exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map", empty = true),
+        @MCRTestProperty(key = "MCR.Map.NonEmpty", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.Map.Empty", empty = true),
+    })
+    public void requiredPropertyShortEmptyDefaultNotSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                    RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.Map, Foo.Map.A, Foo.Map.B, ...",
+                exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map", empty = true),
+    })
+    public void requiredPropertyShortEmptyDefaultSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                    RequiredDefaultSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.Map, Foo.Map.A, Foo.Map.B, ...",
+                exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map", empty = true),
+        @MCRTestProperty(key = "MCR.Map", empty = true),
+    })
+    public void requiredPropertyShortEmptyDefaultSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                    RequiredDefaultSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.Map, Foo.Map.A, Foo.Map.B, ...",
+                exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map", empty = true),
+        @MCRTestProperty(key = "MCR.Map", string = "NonEmpty:DefaultValue,Empty:"),
+    })
+    public void requiredPropertyShortEmptyDefaultSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                    RequiredDefaultSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.Map, Foo.Map.A, Foo.Map.B, ...",
+                exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map", empty = true),
+        @MCRTestProperty(key = "MCR.Map.NonEmpty", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.Map.Empty", empty = true),
+    })
+    public void requiredPropertyShortEmptyDefaultSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                    RequiredDefaultSet.class, configuration);
+        });
+        assertEquals("Missing configuration entries like: Foo.Map, Foo.Map.A, Foo.Map.B, ...",
+                exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map", string = "NonEmpty:Value,Empty:"),
+    })
+    public void requiredPropertyShortNotEmptyDefaultNotSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map", string = "NonEmpty:Value,Empty:"),
+        @MCRTestProperty(key = "MCR.Map", empty = true),
+    })
+    public void requiredPropertyShortNotEmptyDefaultNotSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map", string = "NonEmpty:Value,Empty:"),
+        @MCRTestProperty(key = "MCR.Map", string = "NonEmpty:DefaultValue,Empty:"),
+    })
+    public void requiredPropertyShortNotEmptyDefaultNotSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map", string = "NonEmpty:Value,Empty:"),
+        @MCRTestProperty(key = "MCR.Map.NonEmpty", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.Map.Empty", empty = true),
+    })
+    public void requiredPropertyShortNotEmptyDefaultNotSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map", string = "NonEmpty:Value,Empty:"),
+    })
+    public void requiredPropertyShortNotEmptyDefaultSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map", string = "NonEmpty:Value,Empty:"),
+        @MCRTestProperty(key = "MCR.Map", empty = true),
+    })
+    public void requiredPropertyShortNotEmptyDefaultSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map", string = "NonEmpty:Value,Empty:"),
+        @MCRTestProperty(key = "MCR.Map", string = "NonEmpty:DefaultValue,Empty:"),
+    })
+    public void requiredPropertyShortNotEmptyDefaultSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map", string = "NonEmpty:Value,Empty:"),
+        @MCRTestProperty(key = "MCR.Map.NonEmpty", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.Map.Empty", empty = true),
+    })
+    public void requiredPropertyShortNotEmptyDefaultSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map.NonEmpty", string = "Value"),
+        @MCRTestProperty(key = "Foo.Map.Empty", empty = true),
+    })
+    public void requiredPropertyLongNotEmptyDefaultNotSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map.NonEmpty", string = "Value"),
+        @MCRTestProperty(key = "Foo.Map.Empty", empty = true),
+        @MCRTestProperty(key = "MCR.Map", empty = true),
+    })
+    public void requiredPropertyLongNotEmptyDefaultNotSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map.NonEmpty", string = "Value"),
+        @MCRTestProperty(key = "Foo.Map.Empty", empty = true),
+        @MCRTestProperty(key = "MCR.Map", string = "NonEmpty:DefaultValue,Empty:"),
+    })
+    public void requiredPropertyLongNotEmptyDefaultNotSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Map.NonEmpty", string = "Value"),
+        @MCRTestProperty(key = "Foo.Map.Empty", empty = true),
+        @MCRTestProperty(key = "MCR.Map.NonEmpty", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.Map.Empty", empty = true),
+    })
+    public void requiredPropertyLongNotEmptyDefaultNotSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map.NonEmpty", string = "Value"),
+        @MCRTestProperty(key = "Foo.Map.Empty", empty = true),
+    })
+    public void requiredPropertyLongNotEmptyDefaultSetDefaultPropertyMissing() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map.NonEmpty", string = "Value"),
+        @MCRTestProperty(key = "Foo.Map.Empty", empty = true),
+        @MCRTestProperty(key = "MCR.Map", empty = true),
+    })
+    public void requiredPropertyLongNotEmptyDefaultSetDefaultPropertyShortEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map.NonEmpty", string = "Value"),
+        @MCRTestProperty(key = "Foo.Map.Empty", empty = true),
+        @MCRTestProperty(key = "MCR.Map", string = "NonEmpty:DefaultValue,Empty:"),
+    })
+    public void requiredPropertyLongNotEmptyDefaultSetDefaultPropertyShortNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Map.NonEmpty", string = "Value"),
+        @MCRTestProperty(key = "Foo.Map.Empty", empty = true),
+        @MCRTestProperty(key = "MCR.Map.NonEmpty", string = "DefaultValue"),
+        @MCRTestProperty(key = "MCR.Map.Empty", empty = true),
+    })
+    public void requiredPropertyLongNotEmptyDefaultSetDefaultPropertyLongNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals(MAP, instance.map);
+    }
+
+    public static class NotRequiredDefaultNotSet {
+
+        @MCRPropertyMap(name = "Map", required = false)
+        public Map<String, String> map;
+
+    }
+
+    public static class NotRequiredDefaultSet {
+
+        @MCRPropertyMap(name = "Map", required = false, defaultName = "MCR.Map")
+        public Map<String, String> map;
+
+    }
+
+    public static class RequiredDefaultNotSet {
+
+        @MCRPropertyMap(name = "Map")
+        public Map<String, String> map;
+
+    }
+
+    public static class RequiredDefaultSet {
+
+        @MCRPropertyMap(name = "Map", defaultName = "MCR.Map")
+        public Map<String, String> map;
+
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/common/config/MCRConfigurableInstancePropertyTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/config/MCRConfigurableInstancePropertyTest.java
@@ -1,0 +1,619 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.mycore.common.MCRTestConfiguration;
+import org.mycore.common.MCRTestProperty;
+import org.mycore.common.config.annotation.MCRProperty;
+import org.mycore.test.MyCoReTest;
+
+/**
+ * Programmatically created exhaustive list of tests for the following conditions:
+ * <ol>
+ *   <li>Annotation has <code>required = false</code> or not</li>
+ *   <li>Configuration property for instance value is not set, empty or non-empty</li>
+ *   <li>Annotation has <code>defaultName = "..."</code> or not</li>
+ *   <li>Configuration property for default value is not set, empty or non-empty</li>
+ * </ol>
+ * <table style="border-collapse: collapse;">
+ *   <caption>Expected results for different conditions</caption>
+ *   <tr>
+ *     <th style="border: 1px solid;">Is Required</th>
+ *     <th style="border: 1px solid;">Property</th>
+ *     <th style="border: 1px solid;">Has Default</th>
+ *     <th style="border: 1px solid;">Default Property</th>
+ *     <th style="border: 1px solid;">Expected Result</th>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;"><code>null</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">Exception</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">empty</td>
+ *     <td style="border: 1px solid;">empty</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>DefaultValue</code></td>
+ *     <td style="border: 1px solid;"><code>DefaultValue</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">empty</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">empty</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;"><code>Value</code></td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;"><code>Value</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">no</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">Exception</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">Exception</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">empty</td>
+ *     <td style="border: 1px solid;">empty</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">not set</td>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>DefaultValue</code></td>
+ *     <td style="border: 1px solid;"><code>DefaultValue</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;">empty</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">empty</td>
+ *   </tr>
+ *   <tr>
+ *     <td style="border: 1px solid;">yes</td>
+ *     <td style="border: 1px solid;"><code>Value</code></td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;">-</td>
+ *     <td style="border: 1px solid;"><code>Value</code></td>
+ *   </tr>
+ * </table>
+ */
+@MyCoReTest
+public class MCRConfigurableInstancePropertyTest {
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+    })
+    public void notRequiredPropertyNotSetDefaultNotSetDefaultPropertyNotSet() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertNull(instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "MCR.Value", empty = true),
+    })
+    public void notRequiredPropertyNotSetDefaultNotSetDefaultPropertyEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertNull(instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "MCR.Value", string = "DefaultValue"),
+    })
+    public void notRequiredPropertyNotSetDefaultNotSetDefaultPropertyNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertNull(instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+    })
+    public void notRequiredPropertyNotSetDefaultSetDefaultPropertyNotSet() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                NotRequiredDefaultSet.class, configuration);
+        });
+        assertEquals("The default property MCR.Value is missing", exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "MCR.Value", empty = true),
+    })
+    public void notRequiredPropertyNotSetDefaultSetDefaultPropertyEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals("", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "MCR.Value", string = "DefaultValue"),
+    })
+    public void notRequiredPropertyNotSetDefaultSetDefaultPropertyNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals("DefaultValue", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Value", empty = true),
+    })
+    public void notRequiredPropertyEmptyDefaultNotSetDefaultPropertyNotSet() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals("", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Value", empty = true),
+        @MCRTestProperty(key = "MCR.Value", empty = true),
+    })
+    public void notRequiredPropertyEmptyDefaultNotSetDefaultPropertyEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals("", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Value", empty = true),
+        @MCRTestProperty(key = "MCR.Value", string = "DefaultValue"),
+    })
+    public void notRequiredPropertyEmptyDefaultNotSetDefaultPropertyNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals("", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Value", empty = true),
+    })
+    public void notRequiredPropertyEmptyDefaultSetDefaultPropertyNotSet() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals("", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Value", empty = true),
+        @MCRTestProperty(key = "MCR.Value", empty = true),
+    })
+    public void notRequiredPropertyEmptyDefaultSetDefaultPropertyEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals("", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Value", empty = true),
+        @MCRTestProperty(key = "MCR.Value", string = "DefaultValue"),
+    })
+    public void notRequiredPropertyEmptyDefaultSetDefaultPropertyNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals("", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Value", string = "Value"),
+    })
+    public void notRequiredPropertyNotEmptyDefaultNotSetDefaultPropertyNotSet() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals("Value", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Value", string = "Value"),
+        @MCRTestProperty(key = "MCR.Value", empty = true),
+    })
+    public void notRequiredPropertyNotEmptyDefaultNotSetDefaultPropertyEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals("Value", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Value", string = "Value"),
+        @MCRTestProperty(key = "MCR.Value", string = "DefaultValue"),
+    })
+    public void notRequiredPropertyNotEmptyDefaultNotSetDefaultPropertyNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultNotSet.class, configuration);
+        assertEquals("Value", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Value", string = "Value"),
+    })
+    public void notRequiredPropertyNotEmptyDefaultSetDefaultPropertyNotSet() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals("Value", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Value", string = "Value"),
+        @MCRTestProperty(key = "MCR.Value", empty = true),
+    })
+    public void notRequiredPropertyNotEmptyDefaultSetDefaultPropertyEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals("Value", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = NotRequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Value", string = "Value"),
+        @MCRTestProperty(key = "MCR.Value", string = "DefaultValue"),
+    })
+    public void notRequiredPropertyNotEmptyDefaultSetDefaultPropertyNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        NotRequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            NotRequiredDefaultSet.class, configuration);
+        assertEquals("Value", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+    })
+    public void requiredPropertyNotSetDefaultNotSetDefaultPropertyNotSet() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("The required property Foo.Value is missing", exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "MCR.Value", empty = true),
+    })
+    public void requiredPropertyNotSetDefaultNotSetDefaultPropertyEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("The required property Foo.Value is missing", exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "MCR.Value", string = "DefaultValue"),
+    })
+    public void requiredPropertyNotSetDefaultNotSetDefaultPropertyNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                RequiredDefaultNotSet.class, configuration);
+        });
+        assertEquals("The required property Foo.Value is missing", exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+    })
+    public void requiredPropertyNotSetDefaultSetDefaultPropertyNotSet() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class, () -> {
+            MCRConfigurableInstanceHelper.getInstance(
+                RequiredDefaultSet.class, configuration);
+        });
+        assertEquals("The default property MCR.Value is missing", exception.getMessage());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "MCR.Value", empty = true),
+    })
+    public void requiredPropertyNotSetDefaultSetDefaultPropertyEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals("", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "MCR.Value", string = "DefaultValue"),
+    })
+    public void requiredPropertyNotSetDefaultSetDefaultPropertyNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals("DefaultValue", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Value", empty = true),
+    })
+    public void requiredPropertyEmptyDefaultNotSetDefaultPropertyNotSet() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals("", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Value", empty = true),
+        @MCRTestProperty(key = "MCR.Value", empty = true),
+    })
+    public void requiredPropertyEmptyDefaultNotSetDefaultPropertyEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals("", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Value", empty = true),
+        @MCRTestProperty(key = "MCR.Value", string = "DefaultValue"),
+    })
+    public void requiredPropertyEmptyDefaultNotSetDefaultPropertyNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals("", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Value", empty = true),
+    })
+    public void requiredPropertyEmptyDefaultSetDefaultPropertyNotSet() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals("", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Value", empty = true),
+        @MCRTestProperty(key = "MCR.Value", empty = true),
+    })
+    public void requiredPropertyEmptyDefaultSetDefaultPropertyEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals("", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Value", empty = true),
+        @MCRTestProperty(key = "MCR.Value", string = "DefaultValue"),
+    })
+    public void requiredPropertyEmptyDefaultSetDefaultPropertyNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals("", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Value", string = "Value"),
+    })
+    public void requiredPropertyNotEmptyDefaultNotSetDefaultPropertyNotSet() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals("Value", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Value", string = "Value"),
+        @MCRTestProperty(key = "MCR.Value", empty = true),
+    })
+    public void requiredPropertyNotEmptyDefaultNotSetDefaultPropertyEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals("Value", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultNotSet.class),
+        @MCRTestProperty(key = "Foo.Value", string = "Value"),
+        @MCRTestProperty(key = "MCR.Value", string = "DefaultValue"),
+    })
+    public void requiredPropertyNotEmptyDefaultNotSetDefaultPropertyNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultNotSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultNotSet.class, configuration);
+        assertEquals("Value", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Value", string = "Value"),
+    })
+    public void requiredPropertyNotEmptyDefaultSetDefaultPropertyNotSet() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals("Value", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Value", string = "Value"),
+        @MCRTestProperty(key = "MCR.Value", empty = true),
+    })
+    public void requiredPropertyNotEmptyDefaultSetDefaultPropertyEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals("Value", instance.value);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = { @MCRTestProperty(key = "Foo",
+        classNameOf = RequiredDefaultSet.class),
+        @MCRTestProperty(key = "Foo.Value", string = "Value"),
+        @MCRTestProperty(key = "MCR.Value", string = "DefaultValue"),
+    })
+    public void requiredPropertyNotEmptyDefaultSetDefaultPropertyNotEmpty() {
+        MCRInstanceConfiguration configuration = MCRInstanceConfiguration.ofName("Foo");
+        RequiredDefaultSet instance = MCRConfigurableInstanceHelper.getInstance(
+            RequiredDefaultSet.class, configuration);
+        assertEquals("Value", instance.value);
+    }
+
+    public static class NotRequiredDefaultNotSet {
+
+        @MCRProperty(name = "Value", required = false)
+        public String value;
+
+    }
+
+    public static class NotRequiredDefaultSet {
+
+        @MCRProperty(name = "Value", required = false, defaultName = "MCR.Value")
+        public String value;
+
+    }
+
+    public static class RequiredDefaultNotSet {
+
+        @MCRProperty(name = "Value")
+        public String value;
+
+    }
+
+    public static class RequiredDefaultSet {
+
+        @MCRProperty(name = "Value", defaultName = "MCR.Value")
+        public String value;
+
+    }
+
+}

--- a/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/MCRSimpleJobSelector.java
+++ b/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/MCRSimpleJobSelector.java
@@ -33,11 +33,11 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.mycore.common.MCRClassTools;
-import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.config.MCRConfigurationException;
 import org.mycore.common.config.annotation.MCRConfigurationProxy;
 import org.mycore.common.config.annotation.MCRPostConstruction;
 import org.mycore.common.config.annotation.MCRProperty;
+import org.mycore.common.config.annotation.MCRPropertyList;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Predicate;
@@ -155,14 +155,14 @@ public final class MCRSimpleJobSelector implements MCRJobSelector {
 
     public static class Factory implements Supplier<MCRSimpleJobSelector> {
 
-        @MCRProperty(name = ACTIONS_KEY, defaultName = "MCR.QueuedJob.Selectors.Default.Actions")
-        public String actions;
+        @MCRPropertyList(name = ACTIONS_KEY, defaultName = "MCR.QueuedJob.Selectors.Default.Actions")
+        public List<String> actions;
 
         @MCRProperty(name = ACTION_MODE_KEY, defaultName = "MCR.QueuedJob.Selectors.Default.ActionMode")
         public String actionMode;
 
-        @MCRProperty(name = STATUSES_KEY, defaultName = "MCR.QueuedJob.Selectors.Default.Statuses")
-        public String statuses;
+        @MCRPropertyList(name = STATUSES_KEY, defaultName = "MCR.QueuedJob.Selectors.Default.Statuses")
+        public List<String> statuses;
 
         @MCRProperty(name = STATUS_MODE_KEY, defaultName = "MCR.QueuedJob.Selectors.Default.StatusMode")
         public String statusMode;
@@ -179,19 +179,16 @@ public final class MCRSimpleJobSelector implements MCRJobSelector {
 
         @Override
         public MCRSimpleJobSelector get() {
-
-            Set<Class<? extends MCRJobAction>> actions = MCRConfiguration2.splitValue(this.actions)
-                .map(this::toActionJobClass).collect(Collectors.toSet());
+            Set<Class<? extends MCRJobAction>> actions = getActions();
             Mode actionMode = Mode.valueOf(this.actionMode);
-
-            Set<MCRJobStatus> statuses = MCRConfiguration2.splitValue(this.statuses)
-                .map(MCRJobStatus::valueOf).collect(Collectors.toSet());
+            Set<MCRJobStatus> statuses = getJobStatuses();
             Mode statusMode = Mode.valueOf(this.statusMode);
-
             int ageDays = Integer.parseInt(this.ageDays);
-
             return new MCRSimpleJobSelector(actions, actionMode, statuses, statusMode, ageDays);
+        }
 
+        private Set<Class<? extends MCRJobAction>> getActions() {
+            return this.actions.stream().map(this::toActionJobClass).collect(Collectors.toSet());
         }
 
         private Class<? extends MCRJobAction> toActionJobClass(String action) {
@@ -201,6 +198,10 @@ public final class MCRSimpleJobSelector implements MCRJobSelector {
                 throw new MCRConfigurationException("Missing class (" + action + ") configured in property: " +
                     property + "." + ACTIONS_KEY, e);
             }
+        }
+
+        private Set<MCRJobStatus> getJobStatuses() {
+            return this.statuses.stream().map(MCRJobStatus::valueOf).collect(Collectors.toSet());
         }
 
     }

--- a/mycore-mods/src/main/java/org/mycore/mods/classification/mapping/MCRMODSXPathClassificationGenerator.java
+++ b/mycore-mods/src/main/java/org/mycore/mods/classification/mapping/MCRMODSXPathClassificationGenerator.java
@@ -23,9 +23,8 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.jdom2.Parent;
-import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.config.annotation.MCRConfigurationProxy;
-import org.mycore.common.config.annotation.MCRProperty;
+import org.mycore.common.config.annotation.MCRPropertyList;
 import org.mycore.datamodel.classifications2.MCRCategoryDAO;
 import org.mycore.datamodel.classifications2.mapping.MCRGeneratorClassificationMapperBase.Generator;
 import org.mycore.datamodel.classifications2.mapping.MCRXPathClassificationGeneratorBase;
@@ -90,16 +89,12 @@ public final class MCRMODSXPathClassificationGenerator extends MCRXPathClassific
 
     public static class Factory implements Supplier<MCRMODSXPathClassificationGenerator> {
 
-        @MCRProperty(name = CLASSIFICATION_IDS_KEY, required = false)
-        public String classificationIds;
+        @MCRPropertyList(name = CLASSIFICATION_IDS_KEY, required = false)
+        public List<String> classificationIds;
 
         @Override
         public MCRMODSXPathClassificationGenerator get() {
-            return new MCRMODSXPathClassificationGenerator(getClassificationsIds());
-        }
-
-        private List<String> getClassificationsIds() {
-            return MCRConfiguration2.splitValue(classificationIds == null ? "" : classificationIds).toList();
+            return new MCRMODSXPathClassificationGenerator(classificationIds);
         }
 
     }

--- a/mycore-user2/src/main/java/org/mycore/user2/hash/MCRPasswordCheckManager.java
+++ b/mycore-user2/src/main/java/org/mycore/user2/hash/MCRPasswordCheckManager.java
@@ -18,13 +18,13 @@
 
 package org.mycore.user2.hash;
 
-import static org.mycore.common.config.MCRConfiguration2.splitValue;
 import static org.mycore.user2.hash.MCRPasswordCheckManagerHelper.checkConfigurationHasNoIncompatibleChange;
 import static org.mycore.user2.hash.MCRPasswordCheckManagerHelper.checkSelectedStrategyIsNotOutdated;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -39,6 +39,7 @@ import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.config.annotation.MCRConfigurationProxy;
 import org.mycore.common.config.annotation.MCRInstanceMap;
 import org.mycore.common.config.annotation.MCRProperty;
+import org.mycore.common.config.annotation.MCRPropertyList;
 import org.mycore.common.config.annotation.MCRSentinel;
 
 /**
@@ -179,17 +180,13 @@ public final class MCRPasswordCheckManager {
         @MCRProperty(name = SELECTED_STRATEGY_KEY)
         public String selectedStrategy;
 
-        @MCRProperty(name = CONFIGURATION_CHECKS_KEY)
-        public String configurationChecks;
+        @MCRPropertyList(name = CONFIGURATION_CHECKS_KEY, required = false)
+        public List<String> configurationChecks;
 
         @Override
         public MCRPasswordCheckManager get() {
-
             SecureRandom random = getStrongSecureRandom();
-
-            Set<ConfigurationCheck> configurationChecks = splitValue(this.configurationChecks)
-                .map(ConfigurationCheck::valueOf).collect(Collectors.toSet());
-
+            Set<ConfigurationCheck> configurationChecks = getConfigurationChecks();
             return new MCRPasswordCheckManager(random, strategies, selectedStrategy, configurationChecks);
 
         }
@@ -200,6 +197,10 @@ public final class MCRPasswordCheckManager {
             } catch (NoSuchAlgorithmException e) {
                 throw new MCRException("Failed to obtain strong secure random number generator", e);
             }
+        }
+
+        private Set<ConfigurationCheck> getConfigurationChecks() {
+            return this.configurationChecks.stream().map(ConfigurationCheck::valueOf).collect(Collectors.toSet());
         }
 
     }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3639).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [x] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [x] Were existing tests modified?
  - [x] Yes: explain the changes for reviewers. 
  
_As per Scout rule:_ Test property names and values used in `MCRConfigurableInstanceHelperNestedTest` have been changed to align with the new test class `MCRConfigurableInstanceHelperCollectionTest` which has similar tests (the names and values have become a bit unwieldy). `List#getFirst()` has been replaced with  `List#get(0)` in the tests, b/c it better reflects the indexed-based access to the tested lists.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [x] If not, no action needed.
- [x] Java license headers are added where necessary.
- [x] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [x] All configuration options are documented in Javadoc and `mycore.properties`.
- [x] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
