### PR TITLE
MCR-3653 xed post processor class attribute should resolve xpath expressions mcr properties

### DIFF
--- a/mycore-xeditor/src/main/java/org/mycore/frontend/xeditor/transformer/MCRPostProcessorTransformerHelper.java
+++ b/mycore-xeditor/src/main/java/org/mycore/frontend/xeditor/transformer/MCRPostProcessorTransformerHelper.java
@@ -41,7 +41,8 @@ public class MCRPostProcessorTransformerHelper extends MCRTransformerHelperBase 
 
     @Override
     void handle(MCRTransformerHelperCall call) {
-        String clazz = call.getAttributeValueOrDefault(ATTR_CLASS, null);
+        String rawClazz = call.getAttributeValueOrDefault(ATTR_CLASS, null);
+        String clazz = rawClazz != null ? replaceXPaths(rawClazz) : null;
         if (clazz != null) {
             try {
                 MCRXEditorPostProcessor instance = ((MCRXEditorPostProcessor) MCRClassTools.forName(clazz)

--- a/mycore-xeditor/src/test/java/org/mycore/frontend/xeditor/MCRTestPostProcessor.java
+++ b/mycore-xeditor/src/test/java/org/mycore/frontend/xeditor/MCRTestPostProcessor.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.frontend.xeditor;
+
+import java.util.Map;
+
+import org.jdom2.Document;
+
+/**
+ * Minimal {@link MCRXEditorPostProcessor} implementation used to test
+ * that the {@code class} attribute of {@code xed:post-processor} resolves
+ * XPath expressions / MCR properties.
+ */
+public class MCRTestPostProcessor implements MCRXEditorPostProcessor {
+
+    @Override
+    public Document process(Document xml) {
+        return xml;
+    }
+
+    @Override
+    public void setAttributes(Map<String, String> attributeMap) {
+        // nothing to do
+    }
+}

--- a/mycore-xeditor/src/test/java/org/mycore/frontend/xeditor/MCRXEditorTransformerTest.java
+++ b/mycore-xeditor/src/test/java/org/mycore/frontend/xeditor/MCRXEditorTransformerTest.java
@@ -20,6 +20,7 @@ package org.mycore.frontend.xeditor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -200,6 +201,24 @@ public class MCRXEditorTransformerTest {
     public void testSelect() throws IOException, TransformerException, JDOMException,
         SAXException, JaxenException {
         testTransformation("testSelect-editor.xml", "testSelect-source.xml", "testSelect-transformed.xml");
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = {
+        @MCRTestProperty(key = "MCR.Test.PostProcessor",
+            string = "org.mycore.frontend.xeditor.MCRTestPostProcessor")
+    })
+    public void testPostProcessorClassResolution() throws IOException, TransformerException, JDOMException,
+        SAXException, JaxenException {
+        MCREditorSession session = buildEditorSession("testBasicInputComponents-source.xml");
+        MCRParameterCollector pc = new MCRParameterCollector(false);
+        pc.setParameter("input", "testBasicInputComponents-source.xml");
+
+        MCRContent input = MCRSourceContent
+            .createInstance("resource:testPostProcessorClassResolution-editor.xml");
+        new MCRXEditorTransformer(session, pc).transform(input);
+
+        assertInstanceOf(MCRTestPostProcessor.class, session.getPostProcessor());
     }
 
 }

--- a/mycore-xeditor/src/test/resources/testPostProcessorClassResolution-editor.xml
+++ b/mycore-xeditor/src/test/resources/testPostProcessorClassResolution-editor.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<html>
+  <body>
+    <xed:form xmlns:xed="http://www.mycore.de/xeditor">
+      <xed:source uri="resource:{$input}" />
+      <xed:post-processor class="{$MCR.Test.PostProcessor}" />
+      <xed:bind xpath="document">
+        <xed:bind xpath="title">
+          <input type="text" />
+        </xed:bind>
+      </xed:bind>
+    </xed:form>
+  </body>
+</html>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3653).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [x] Instructions on how to test or use the feature are included or linked (e.g. to documentation). -> https://github.com/MyCoRe-Org/mycore-website/pull/137
- [ ] For UI changes: before & after screenshots are attached.
- [x] New features or migrations are documented. -> https://github.com/MyCoRe-Org/mycore-website/pull/137
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Testing
- [x] I have tested the changes locally.
- [x The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers. 

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [x] Java license headers are added where necessary.
- x] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [x] All configuration options are documented in Javadoc and `mycore.properties`.
- [x] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
