### PR TITLE
MCR-3654 add exponential retry delay for failed jobs in jobapi

### DIFF
--- a/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/MCRJobConfig.java
+++ b/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/MCRJobConfig.java
@@ -97,12 +97,10 @@ public interface MCRJobConfig {
 
     /**
      * The default multiplier used for exponential backoff when retrying failed jobs.
-     * @return the multiplier, defaults to 1 (no exponential backoff)
+     * @return the multiplier
      * @see #retryDelayMultiplier(Class)
      */
-    default Integer retryDelayMultiplier() {
-        return 1;
-    }
+    Integer retryDelayMultiplier();
 
     /**
      * Returns the list of {@link MCRJobStatusListener} for the given action.

--- a/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/MCRJobConfig.java
+++ b/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/MCRJobConfig.java
@@ -87,6 +87,24 @@ public interface MCRJobConfig {
     Boolean activated();
 
     /**
+     * The multiplier used for exponential backoff when retrying failed jobs. The actual delay before a retry is
+     * calculated as {@code timeTillReset * multiplier^(tries-1)}. A multiplier of 1 (default) means no exponential
+     * backoff, i.e. the delay is constant. A multiplier of 2 means the delay doubles with each retry.
+     * @param action the action
+     * @return the optional multiplier
+     */
+    Optional<Integer> retryDelayMultiplier(Class<? extends MCRJobAction> action);
+
+    /**
+     * The default multiplier used for exponential backoff when retrying failed jobs.
+     * @return the multiplier, defaults to 1 (no exponential backoff)
+     * @see #retryDelayMultiplier(Class)
+     */
+    default Integer retryDelayMultiplier() {
+        return 1;
+    }
+
+    /**
      * Returns the list of {@link MCRJobStatusListener} for the given action.
      * @param action the action
      * @return the list of listeners

--- a/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/MCRJobResetter.java
+++ b/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/MCRJobResetter.java
@@ -77,14 +77,17 @@ public class MCRJobResetter extends MCRCronjob {
      */
     protected static long resetJobsWithAction(Class<? extends MCRJobAction> action, MCRJobConfig config, MCRJobDAO dao,
         Queue<MCRJob> queue, MCRJobStatus status) {
-        Duration maxTimeDiff = config.timeTillReset(action).orElseGet(config::timeTillReset);
+        Duration baseDelay = config.timeTillReset(action).orElseGet(config::timeTillReset);
+        int multiplier = config.retryDelayMultiplier(action).orElseGet(config::retryDelayMultiplier);
         List<MCRJob> jobs = dao.getJobs(action, Collections.emptyMap(), List.of(status), null, null);
         long current = System.currentTimeMillis();
 
         return jobs.stream().filter(job -> {
             long start = job.getStart().getTime();
             Duration elapsedTime = Duration.ofMillis(current - start);
-            return maxTimeDiff.minus(elapsedTime).isNegative();
+            int tries = job.getTries() != null ? job.getTries() : 0;
+            Duration delay = baseDelay.multipliedBy((long) Math.pow(multiplier, Math.max(0, tries - 1)));
+            return delay.minus(elapsedTime).isNegative();
         }).filter(queue::offer).count();
     }
 

--- a/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/MCRJobResetter.java
+++ b/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/MCRJobResetter.java
@@ -86,7 +86,11 @@ public class MCRJobResetter extends MCRCronjob {
             long start = job.getStart().getTime();
             Duration elapsedTime = Duration.ofMillis(current - start);
             int tries = job.getTries() != null ? job.getTries() : 0;
-            Duration delay = baseDelay.multipliedBy((long) Math.pow(multiplier, Math.max(0, tries - 1)));
+            long factor = (long) Math.pow(multiplier, Math.max(0, tries - 1));
+            if (factor <= 0) {
+                factor = Long.MAX_VALUE;
+            }
+            Duration delay = baseDelay.multipliedBy(factor);
             return delay.minus(elapsedTime).isNegative();
         }).filter(queue::offer).count();
     }

--- a/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/config2/MCRConfiguration2JobConfig.java
+++ b/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/config2/MCRConfiguration2JobConfig.java
@@ -105,6 +105,13 @@ public class MCRConfiguration2JobConfig implements MCRJobConfig {
     }
 
     @Override
+    public Integer retryDelayMultiplier() {
+        String property = CONFIG_PREFIX + CONFIG_RETRY_DELAY_MULTIPLIER;
+        return MCRConfiguration2.getInt(property)
+            .orElseThrow(() -> MCRConfiguration2.createConfigurationException(property));
+    }
+
+    @Override
     public Boolean activated() {
         String property = CONFIG_PREFIX + CONFIG_ACTIVATED;
         return MCRConfiguration2.getBoolean(property)

--- a/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/config2/MCRConfiguration2JobConfig.java
+++ b/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/config2/MCRConfiguration2JobConfig.java
@@ -44,6 +44,8 @@ public class MCRConfiguration2JobConfig implements MCRJobConfig {
 
     private static final String CONFIG_JOB_THREADS = "JobThreads";
 
+    private static final String CONFIG_RETRY_DELAY_MULTIPLIER = "RetryDelayMultiplier";
+
     private static final String CONFIG_ACTIVATED = "activated";
 
     private static final String CONFIG_PREFIX = "MCR.QueuedJob.";
@@ -73,6 +75,11 @@ public class MCRConfiguration2JobConfig implements MCRJobConfig {
     @Override
     public Optional<Boolean> activated(Class<? extends MCRJobAction> action) {
         return MCRConfiguration2.getBoolean(getActionConfigPrefix(action) + CONFIG_ACTIVATED);
+    }
+
+    @Override
+    public Optional<Integer> retryDelayMultiplier(Class<? extends MCRJobAction> action) {
+        return MCRConfiguration2.getInt(getActionConfigPrefix(action) + CONFIG_RETRY_DELAY_MULTIPLIER);
     }
 
     @Override

--- a/mycore-jobqueue/src/main/resources/components/jobqueue/config/mycore.properties
+++ b/mycore-jobqueue/src/main/resources/components/jobqueue/config/mycore.properties
@@ -14,6 +14,8 @@ MCR.QueuedJob.JobThreads=2
 MCR.QueuedJob.TimeTillReset=10
 ### Count how often a job can fail, before its status is set to failed and it will not be restarted
 MCR.QueuedJob.MaxTry=2
+### Multiplier for exponential backoff on retry delay (1 = constant delay, 2 = double delay each retry)
+MCR.QueuedJob.RetryDelayMultiplier=1
 
 MCR.QueuedJob.Selectors.Default.Enabled=true
 MCR.QueuedJob.Selectors.Default.Actions=

--- a/mycore-jobqueue/src/test/java/org/mycore/services/queuedjob/MCRDelegatingJobConfig.java
+++ b/mycore-jobqueue/src/test/java/org/mycore/services/queuedjob/MCRDelegatingJobConfig.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.services.queuedjob;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A delegating {@link MCRJobConfig} for testing purposes. All methods delegate to the given base config and can be
+ * overridden selectively.
+ */
+public class MCRDelegatingJobConfig implements MCRJobConfig {
+
+    private final MCRJobConfig delegate;
+
+    public MCRDelegatingJobConfig(MCRJobConfig delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Optional<Duration> timeTillReset(Class<? extends MCRJobAction> action) {
+        return delegate.timeTillReset(action);
+    }
+
+    @Override
+    public Optional<Integer> maxTryCount(Class<? extends MCRJobAction> action) {
+        return delegate.maxTryCount(action);
+    }
+
+    @Override
+    public Optional<Integer> maxJobThreadCount(Class<? extends MCRJobAction> action) {
+        return delegate.maxJobThreadCount(action);
+    }
+
+    @Override
+    public Optional<Boolean> activated(Class<? extends MCRJobAction> action) {
+        return delegate.activated(action);
+    }
+
+    @Override
+    public Optional<Integer> retryDelayMultiplier(Class<? extends MCRJobAction> action) {
+        return delegate.retryDelayMultiplier(action);
+    }
+
+    @Override
+    public Integer maxJobThreadCount() {
+        return delegate.maxJobThreadCount();
+    }
+
+    @Override
+    public Duration timeTillReset() {
+        return delegate.timeTillReset();
+    }
+
+    @Override
+    public Integer maxTryCount() {
+        return delegate.maxTryCount();
+    }
+
+    @Override
+    public Boolean activated() {
+        return delegate.activated();
+    }
+
+    @Override
+    public List<MCRJobStatusListener> jobStatusListeners(Class<? extends MCRJobAction> action) {
+        return delegate.jobStatusListeners(action);
+    }
+}

--- a/mycore-jobqueue/src/test/java/org/mycore/services/queuedjob/MCRDelegatingJobConfig.java
+++ b/mycore-jobqueue/src/test/java/org/mycore/services/queuedjob/MCRDelegatingJobConfig.java
@@ -75,6 +75,11 @@ public class MCRDelegatingJobConfig implements MCRJobConfig {
     }
 
     @Override
+    public Integer retryDelayMultiplier() {
+        return delegate.retryDelayMultiplier();
+    }
+
+    @Override
     public Boolean activated() {
         return delegate.activated();
     }

--- a/mycore-jobqueue/src/test/java/org/mycore/services/queuedjob/MCRJobResetterTest.java
+++ b/mycore-jobqueue/src/test/java/org/mycore/services/queuedjob/MCRJobResetterTest.java
@@ -20,8 +20,11 @@ package org.mycore.services.queuedjob;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
 
 import org.junit.jupiter.api.Test;
@@ -126,6 +129,124 @@ public class MCRJobResetterTest {
         assertEquals(1, reset2.size(), "resetted jobs in queue2 should be 1");
         assertEquals("2", reset2.poll().getParameter("count"), "reseted job should have count 2");
 
+    }
+
+    @Test
+    public void testExponentialRetryDelay() {
+        MCRMockJobDAO mockDAO = new MCRMockJobDAO();
+        Queue<MCRJob> resetQueue = new ArrayDeque<>();
+
+        // config with 5 min base delay and multiplier of 2
+        MCRConfiguration2JobConfig baseConfig = new MCRConfiguration2JobConfig();
+        MCRJobConfig config = new MCRJobConfig() {
+            @Override
+            public Optional<Duration> timeTillReset(Class<? extends MCRJobAction> action) {
+                return Optional.of(Duration.ofMinutes(5));
+            }
+
+            @Override
+            public Optional<Integer> maxTryCount(Class<? extends MCRJobAction> action) {
+                return baseConfig.maxTryCount(action);
+            }
+
+            @Override
+            public Optional<Integer> maxJobThreadCount(Class<? extends MCRJobAction> action) {
+                return baseConfig.maxJobThreadCount(action);
+            }
+
+            @Override
+            public Optional<Boolean> activated(Class<? extends MCRJobAction> action) {
+                return baseConfig.activated(action);
+            }
+
+            @Override
+            public Optional<Integer> retryDelayMultiplier(Class<? extends MCRJobAction> action) {
+                return Optional.of(2);
+            }
+
+            @Override
+            public Integer maxJobThreadCount() {
+                return baseConfig.maxJobThreadCount();
+            }
+
+            @Override
+            public Duration timeTillReset() {
+                return Duration.ofMinutes(5);
+            }
+
+            @Override
+            public Integer maxTryCount() {
+                return baseConfig.maxTryCount();
+            }
+
+            @Override
+            public Boolean activated() {
+                return baseConfig.activated();
+            }
+
+            @Override
+            public List<MCRJobStatusListener> jobStatusListeners(Class<? extends MCRJobAction> action) {
+                return baseConfig.jobStatusListeners(action);
+            }
+        };
+
+        long now = System.currentTimeMillis();
+
+        // Job with 1 try, started 6 min ago -> base delay 5min -> should be reset
+        MCRJob job1 = new MCRJob();
+        job1.setAction(MCRTestJobAction1.class);
+        job1.setParameter("id", "try1-6min");
+        job1.setStatus(MCRJobStatus.ERROR);
+        job1.setTries(1);
+        job1.setAdded(new Date(now - 6 * 60 * 1000));
+        job1.setStart(new Date(now - 6 * 60 * 1000));
+        mockDAO.daoOfferedJobs.add(job1);
+
+        // Job with 2 tries, started 6 min ago -> delay 5*2=10min -> should NOT be reset
+        MCRJob job2 = new MCRJob();
+        job2.setAction(MCRTestJobAction1.class);
+        job2.setParameter("id", "try2-6min");
+        job2.setStatus(MCRJobStatus.ERROR);
+        job2.setTries(2);
+        job2.setAdded(new Date(now - 6 * 60 * 1000));
+        job2.setStart(new Date(now - 6 * 60 * 1000));
+        mockDAO.daoOfferedJobs.add(job2);
+
+        // Job with 2 tries, started 11 min ago -> delay 5*2=10min -> should be reset
+        MCRJob job3 = new MCRJob();
+        job3.setAction(MCRTestJobAction1.class);
+        job3.setParameter("id", "try2-11min");
+        job3.setStatus(MCRJobStatus.ERROR);
+        job3.setTries(2);
+        job3.setAdded(new Date(now - 11 * 60 * 1000));
+        job3.setStart(new Date(now - 11 * 60 * 1000));
+        mockDAO.daoOfferedJobs.add(job3);
+
+        // Job with 3 tries, started 15 min ago -> delay 5*4=20min -> should NOT be reset
+        MCRJob job4 = new MCRJob();
+        job4.setAction(MCRTestJobAction1.class);
+        job4.setParameter("id", "try3-15min");
+        job4.setStatus(MCRJobStatus.ERROR);
+        job4.setTries(3);
+        job4.setAdded(new Date(now - 15 * 60 * 1000));
+        job4.setStart(new Date(now - 15 * 60 * 1000));
+        mockDAO.daoOfferedJobs.add(job4);
+
+        // Job with 3 tries, started 21 min ago -> delay 5*4=20min -> should be reset
+        MCRJob job5 = new MCRJob();
+        job5.setAction(MCRTestJobAction1.class);
+        job5.setParameter("id", "try3-21min");
+        job5.setStatus(MCRJobStatus.ERROR);
+        job5.setTries(3);
+        job5.setAdded(new Date(now - 21 * 60 * 1000));
+        job5.setStart(new Date(now - 21 * 60 * 1000));
+        mockDAO.daoOfferedJobs.add(job5);
+
+        long resetCount = MCRJobResetter.resetJobsWithAction(
+            MCRTestJobAction1.class, config, mockDAO, resetQueue, MCRJobStatus.ERROR);
+
+        assertEquals(3, resetCount, "3 jobs should be reset (try1-6min, try2-11min, try3-21min)");
+        assertEquals(3, resetQueue.size());
     }
 
 }

--- a/mycore-jobqueue/src/test/java/org/mycore/services/queuedjob/MCRJobResetterTest.java
+++ b/mycore-jobqueue/src/test/java/org/mycore/services/queuedjob/MCRJobResetterTest.java
@@ -138,35 +138,10 @@ public class MCRJobResetterTest {
 
         // config with 5 min base delay and multiplier of 2
         MCRConfiguration2JobConfig baseConfig = new MCRConfiguration2JobConfig();
-        MCRJobConfig config = new MCRJobConfig() {
+        MCRJobConfig config = new MCRDelegatingJobConfig(baseConfig) {
             @Override
             public Optional<Duration> timeTillReset(Class<? extends MCRJobAction> action) {
                 return Optional.of(Duration.ofMinutes(5));
-            }
-
-            @Override
-            public Optional<Integer> maxTryCount(Class<? extends MCRJobAction> action) {
-                return baseConfig.maxTryCount(action);
-            }
-
-            @Override
-            public Optional<Integer> maxJobThreadCount(Class<? extends MCRJobAction> action) {
-                return baseConfig.maxJobThreadCount(action);
-            }
-
-            @Override
-            public Optional<Boolean> activated(Class<? extends MCRJobAction> action) {
-                return baseConfig.activated(action);
-            }
-
-            @Override
-            public Optional<Integer> retryDelayMultiplier(Class<? extends MCRJobAction> action) {
-                return Optional.of(2);
-            }
-
-            @Override
-            public Integer maxJobThreadCount() {
-                return baseConfig.maxJobThreadCount();
             }
 
             @Override
@@ -175,18 +150,8 @@ public class MCRJobResetterTest {
             }
 
             @Override
-            public Integer maxTryCount() {
-                return baseConfig.maxTryCount();
-            }
-
-            @Override
-            public Boolean activated() {
-                return baseConfig.activated();
-            }
-
-            @Override
-            public List<MCRJobStatusListener> jobStatusListeners(Class<? extends MCRJobAction> action) {
-                return baseConfig.jobStatusListeners(action);
+            public Optional<Integer> retryDelayMultiplier(Class<? extends MCRJobAction> action) {
+                return Optional.of(2);
             }
         };
 

--- a/mycore-jobqueue/src/test/java/org/mycore/services/queuedjob/MCRJobResetterTest.java
+++ b/mycore-jobqueue/src/test/java/org/mycore/services/queuedjob/MCRJobResetterTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Date;
-import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
 


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3654).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented. ->  yes and https://github.com/MyCoRe-Org/mycore-website/pull/138
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [x] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [x] New features or migrations are documented. -> https://github.com/MyCoRe-Org/mycore-website/pull/138
- [x] Does this change affect existing applications, data, or configurations? 
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Testing
- [ ] I have tested the changes locally.
- [ ] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [x] Java license headers are added where necessary.
- [x] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [x] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
