### PR TITLE
MCR-3660 MCRPath.normalize() incorrectly removes leading segments in relative paths

### DIFF
--- a/mycore-base/src/main/java/org/mycore/datamodel/niofs/MCRPath.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/niofs/MCRPath.java
@@ -38,7 +38,9 @@ import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import java.text.MessageFormat;
 import java.text.Normalizer;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.NoSuchElementException;
@@ -404,65 +406,80 @@ public abstract class MCRPath implements Path {
         };
     }
 
+    private static boolean needsNormalization(String path) {
+        int start = 0;
+        int length = path.length();
+
+        while (start < length) {
+            int end = path.indexOf(SEPARATOR, start);
+            if (end < 0) {
+                end = length;
+            }
+
+            int segmentLength = end - start;
+            if (segmentLength == 1 && path.charAt(start) == '.') {
+                return true;
+            }
+            if (segmentLength == 2
+                && path.charAt(start) == '.'
+                && path.charAt(start + 1) == '.') {
+                return true;
+            }
+
+            start = end + 1;
+        }
+
+        return false;
+    }
+
     /* (non-Javadoc)
      * @see java.nio.file.Path#normalize()
      */
     @Override
-    public Path normalize() {
-        final int count = getNameCount();
-        int remaining = count;
-        final boolean[] ignoreSubPath = new boolean[count];
-
-        for (int i = 0; i < count; i++) {
-            if (ignoreSubPath[i]) {
-                continue;
-            }
-            final int subPathIndex = offsets[i];
-            int subPathLength;
-            if (i == offsets.length - 1) {
-                subPathLength = path.length() - subPathIndex;
-            } else {
-                subPathLength = offsets[i + 1] - subPathIndex - 1;
-            }
-            if (path.charAt(subPathIndex) == '.') {
-                if (subPathLength == 1) {
-                    ignoreSubPath[i] = true;
-                    remaining--;
-                } else if (subPathLength == 2 && path.charAt(subPathIndex + 1) == '.') {
-                    ignoreSubPath[i] = true;
-                    remaining--;
-                    //go backward to the last unignored and mark it ignored
-                    //can't normalize if all preceding elements already ignored
-                    for (int r = i - 1; r > 0; r--) {
-                        if (!ignoreSubPath[r]) {
-                            ignoreSubPath[r] = true;
-                            remaining--;
-                            break;
-                        }
-                    }
-                }
-            }
-
-        }
-
-        if (count == remaining) {
+    public MCRPath normalize() {
+        if (!needsNormalization(path)) {
             return this;
         }
-        if (remaining == 0) {
+
+        final int count = getNameCount();
+        final boolean absolute = isAbsolute();
+        final Deque<String> normalizedElements = new ArrayDeque<>(count);
+        boolean changed = false;
+
+        for (int i = 0; i < count; i++) {
+            final String element = getPathElement(i);
+            switch (element) {
+                case "." -> changed = true;
+                case ".." -> {
+                    if (!normalizedElements.isEmpty() && !"..".equals(normalizedElements.getLast())) {
+                        normalizedElements.removeLast();
+                        changed = true;
+                    } else if (absolute) {
+                        changed = true;
+                    } else {
+                        normalizedElements.addLast(element);
+                    }
+                }
+                default -> normalizedElements.addLast(element);
+            }
+        }
+
+        if (!changed) {
+            return this;
+        }
+        if (normalizedElements.isEmpty()) {
             return isAbsolute() ? getRoot() : getFileSystem().emptyPath();
         }
+
         final StringBuilder sb = new StringBuilder(path.length());
-        if (isAbsolute()) {
+        if (absolute) {
             sb.append(SEPARATOR);
         }
-        for (int i = 0; i < count; i++) {
-            if (ignoreSubPath[i]) {
-                continue;
-            }
-            sb.append(getPathElement(i));
-            if (--remaining > 0) {
-                sb.append('/');
-            }
+
+        final Iterator<String> it = normalizedElements.iterator();
+        sb.append(it.next());
+        while (it.hasNext()) {
+            sb.append(SEPARATOR).append(it.next());
         }
         return MCRAbstractFileSystem.getPath(root, sb.toString(), getFileSystem());
     }

--- a/mycore-base/src/test/java/org/mycore/datamodel/niofs/MCRPathTest.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/niofs/MCRPathTest.java
@@ -18,6 +18,7 @@
 
 package org.mycore.datamodel.niofs;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -43,6 +44,61 @@ public class MCRPathTest {
         assertFalse(test1.startsWith(test2));
         test2 = test1.resolve(new TestMCRPath("bin", "/bar"));
         assertFalse(test1.startsWith(test2));
+    }
+
+    @Test
+    public void normalizeRelativeWithLeadingDotDot() {
+        // ../../Test.png should stay unchanged — no preceding elements to cancel
+        Path path = new TestMCRPath(null, "../../Test.png");
+        assertEquals("../../Test.png", path.normalize().toString());
+    }
+
+    @Test
+    public void normalizeRelativeSingleDotDot() {
+        // ../foo should stay unchanged
+        Path path = new TestMCRPath(null, "../foo");
+        assertEquals("../foo", path.normalize().toString());
+    }
+
+    @Test
+    public void normalizeRelativeDotDotBeyondBase() {
+        // foo/../../bar should normalize to ../bar
+        Path path = new TestMCRPath(null, "foo/../../bar");
+        assertEquals("../bar", path.normalize().toString());
+    }
+
+    @Test
+    public void normalizeRelativeDotDotCancels() {
+        // foo/bar/../baz should normalize to foo/baz
+        Path path = new TestMCRPath(null, "foo/bar/../baz");
+        assertEquals("foo/baz", path.normalize().toString());
+    }
+
+    @Test
+    public void normalizeRelativeDot() {
+        // foo/./bar should normalize to foo/bar
+        Path path = new TestMCRPath(null, "foo/./bar");
+        assertEquals("foo/bar", path.normalize().toString());
+    }
+
+    @Test
+    public void normalizeAbsoluteDotDot() {
+        // absolute: /foo/bar/../baz should normalize to /foo/baz
+        Path path = new TestMCRPath("owner", "/foo/bar/../baz");
+        assertEquals("owner:/foo/baz", path.normalize().toString());
+    }
+
+    @Test
+    public void normalizeAbsoluteDotDotAtRoot() {
+        // absolute: /foo/.. should normalize to root
+        Path path = new TestMCRPath("owner", "/foo/..");
+        assertEquals("owner:/", path.normalize().toString());
+    }
+
+    @Test
+    public void normalizeNoOpWhenClean() {
+        Path path = new TestMCRPath(null, "foo/bar");
+        assertEquals("foo/bar", path.normalize().toString());
     }
 
     private static class TestMCRPath extends MCRPath {


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3660).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [ ] The issue in the ticket is clearly described and the solution is documented.
- [ ] Design decisions (if any) are explained.
- [ ] The ticket references the correct source and target branches.
- [ ] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [ ] Affected version is listed in the ticket.
- [ ] Minimal code changes were made (no refactoring).
- [ ] This PR truly fixes **only** the reported bug.
- [ ] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [ ] I have tested the changes locally.
- [ ] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [ ] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
