### PR TITLE
MCR-3665 use getOwner() instead of getXlinkHref()

### DIFF
--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRDefaultLinkProvider.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRDefaultLinkProvider.java
@@ -77,13 +77,13 @@ public class MCRDefaultLinkProvider implements MCRBaseLinkProvider {
         MCRObjectID mcrId = obj.getId();
         // set new entries
         MCRObjectMetadata meta = obj.getMetadata();
-        //use Set for category collection to remove duplicates if there are any
+        // use Set for category collection to remove duplicates if there are any
         meta.stream().flatMap(MCRMetaElement::stream).forEach(inf -> {
             if (inf instanceof MCRMetaLinkID linkID) {
                 linkReferences.add(new MCRLinkReference(mcrId, linkID.getXLinkHrefID(), ENTRY_TYPE_REFERENCE, ""));
             } else if (inf instanceof MCRMetaDerivateLink derLink) {
-                linkReferences.add(new MCRLinkReference(mcrId, MCRObjectID.getInstance(derLink.getXLinkHref()),
-                    ENTRY_TYPE_DERIVATE_LINK, ""));
+                MCRObjectID derivateId = MCRObjectID.getInstance(derLink.getOwner());
+                linkReferences.add(new MCRLinkReference(mcrId, derivateId, ENTRY_TYPE_DERIVATE_LINK, ""));
             }
         });
 


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3665).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [ ] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
