### PR TITLE
MCR-3673 DNBRegister make date parsing more robust

### DIFF
--- a/mycore-pi/pom.xml
+++ b/mycore-pi/pom.xml
@@ -117,6 +117,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mycore</groupId>
       <artifactId>mycore-ifs</artifactId>
       <scope>test</scope>

--- a/mycore-pi/src/main/java/org/mycore/pi/urn/MCRURNUtils.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/urn/MCRURNUtils.java
@@ -19,9 +19,8 @@
 package org.mycore.pi.urn;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Date;
-import java.util.Locale;
 import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
@@ -57,7 +56,8 @@ public class MCRURNUtils {
             return null;
         }
 
-        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.GERMAN).parse(date);
+        Instant instant = Instant.parse(date);
+        return Date.from(instant);
     }
 
 }

--- a/mycore-pi/src/test/java/org/mycore/pi/urn/MCRURNUtilsTest.java
+++ b/mycore-pi/src/test/java/org/mycore/pi/urn/MCRURNUtilsTest.java
@@ -1,0 +1,65 @@
+package org.mycore.pi.urn;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+
+import java.text.ParseException;
+import java.time.format.DateTimeParseException;
+import java.util.Date;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mycore.pi.urn.rest.MCRDNBURNRestClient;
+import org.mycore.test.MyCoReTest;
+
+import com.google.gson.JsonObject;
+
+@MyCoReTest
+public class MCRURNUtilsTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "2025-11-07T15:00:21.000Z",
+        "2025-11-07T15:00:21Z",
+        "2025-11-07T15:00:21.1Z",
+        "2025-11-07T15:00:21-12:00",
+        "2025-11-07T15:00:21+01:00",
+        "2025-11-07T15:00:21.123456Z",
+    })
+    public void testGetDNBRegisterDateValid(String dateString) throws ParseException {
+        try (MockedStatic<MCRDNBURNRestClient> urnClient = Mockito.mockStatic(MCRDNBURNRestClient.class)) {
+            urnClient.when(() -> MCRDNBURNRestClient.getRegistrationInfo(anyString()))
+                .thenReturn(createTestJson(dateString));
+            Date returnDate = MCRURNUtils.getDNBRegisterDate("urn:test:123");
+            assertNotNull(returnDate);
+        }
+    }
+
+    @Test
+    public void testGetDNBRegisterDateInvalid() {
+        String dateString = "invalidDate";
+
+        try (MockedStatic<MCRDNBURNRestClient> urnClient = Mockito.mockStatic(MCRDNBURNRestClient.class)) {
+            urnClient.when(() -> MCRDNBURNRestClient.getRegistrationInfo(anyString()))
+                .thenReturn(createTestJson(dateString));
+            assertThrows(DateTimeParseException.class, () -> MCRURNUtils.getDNBRegisterDate("urn:test:123"));
+        }
+    }
+
+    private static Optional<JsonObject> createTestJson(String dateString) {
+        JsonObject json = new JsonObject();
+        json.addProperty("created", dateString);
+        json.addProperty("lastModified", dateString);
+        json.addProperty("myUrls", "123");
+        json.addProperty("namespace", "123");
+        json.addProperty("self", "123");
+        json.addProperty("urls", "123");
+        json.addProperty("urn", "123");
+        return Optional.of(json);
+    }
+}


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3673).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [ ] The issue in the ticket is clearly described and the solution is documented.
- [ ] Design decisions (if any) are explained.
- [ ] The ticket references the correct source and target branches.
- [ ] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [ ] Affected version is listed in the ticket.
- [ ] Minimal code changes were made (no refactoring).
- [ ] This PR truly fixes **only** the reported bug.
- [ ] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [ ] I have tested the changes locally.
- [ ] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [ ] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
