### PR TITLE
MCR-3676 XSLT rendering failures caused by invalid MCRObjects

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/xml/MCRURIResolver.java
+++ b/mycore-base/src/main/java/org/mycore/common/xml/MCRURIResolver.java
@@ -178,7 +178,7 @@ public final class MCRURIResolver implements URIResolver {
     public static MCRURIResolver obtainInstance() {
         return SHARED_INSTANCE;
     }
-    
+
     public static Map<String, String> getParameterMap(String key) {
         String[] param;
         StringTokenizer tok = new StringTokenizer(key, "&");
@@ -511,22 +511,26 @@ public final class MCRURIResolver implements URIResolver {
                 params = Collections.emptyMap();
             }
 
-            MCRObjectID mcrid = MCRObjectID.getInstance(id);
+            MCRObjectID mcrId = MCRObjectID.getInstance(id);
             try {
-                MCRXMLMetadataManager xmlmm = MCRXMLMetadataManager.getInstance();
-
                 MCRContent content;
                 if (params.containsKey("r")) {
-                    content = xmlmm.retrieveContent(mcrid, params.get("r"));
+                    content = MCRXMLMetadataManager.getInstance().retrieveContent(mcrId, params.get("r"));
                 } else {
-                    if (mcrid.getTypeId().equals(MCRDerivate.OBJECT_TYPE) ||
+                    if (mcrId.getTypeId().equals(MCRDerivate.OBJECT_TYPE) ||
                         (params.containsKey("expanded") && params.get("expanded").equals("false"))) {
-                        content = xmlmm.retrieveContent(mcrid);
+                        content = MCRXMLMetadataManager.getInstance().retrieveContent(mcrId);
                     } else {
-                        MCRObject expanded = MCRMetadataManager.retrieveMCRObject(mcrid);
-                        MCRExpandedObject expandedObject =
-                            MCRExpandedObjectManager.getInstance().getExpandedObject(expanded);
-                        content = new MCRBaseContent(expandedObject);
+                        try {
+                            MCRObject mcrObject = MCRMetadataManager.retrieveMCRObject(mcrId);
+                            MCRExpandedObject expandedObject =
+                                MCRExpandedObjectManager.getInstance().getExpandedObject(mcrObject);
+                            content = new MCRBaseContent(expandedObject);
+                        } catch (Exception e) {
+                            LOGGER.error(() -> "Could not retrieve MCRObject with ID " + mcrId
+                                + ". Try to use fallback with MCRXMLMetadataManager.", e);
+                            content = MCRXMLMetadataManager.getInstance().retrieveContent(mcrId);
+                        }
                     }
                 }
                 if (content == null) {

--- a/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRObjectServlet.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/servlets/MCRObjectServlet.java
@@ -26,7 +26,8 @@ import java.io.Serial;
 import java.util.Optional;
 
 import javax.xml.transform.TransformerException;
-
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.mycore.access.MCRAccessManager;
 import org.mycore.common.MCRException;
 import org.mycore.common.MCRExpandedObjectManager;
@@ -54,6 +55,8 @@ public class MCRObjectServlet extends MCRContentServlet {
 
     @Serial
     private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = LogManager.getLogger();
 
     private static final String I18N_ERROR_PREFIX = "component.base.error";
 
@@ -92,17 +95,22 @@ public class MCRObjectServlet extends MCRContentServlet {
         }
     }
 
-    private MCRContent requestLocalObject(MCRObjectID mcrid, final HttpServletResponse resp, boolean expanded)
+    private MCRContent requestLocalObject(MCRObjectID mcrId, final HttpServletResponse resp, boolean expanded)
         throws IOException {
-        if (MCRMetadataManager.exists(mcrid)) {
-            MCRBase base = MCRMetadataManager.retrieve(mcrid);
-            if (expanded && base instanceof MCRObject object) {
-                base = MCRExpandedObjectManager.getInstance().getExpandedObject(object);
+        if (MCRMetadataManager.exists(mcrId)) {
+            try {
+                MCRBase base = MCRMetadataManager.retrieve(mcrId);
+                if (expanded && base instanceof MCRObject object) {
+                    base = MCRExpandedObjectManager.getInstance().getExpandedObject(object);
+                }
+                return new MCRBaseContent(base);
+            } catch (Exception e) {
+                LOGGER.error(() -> "Unable to retrieve object " + mcrId
+                    + " from MCRMetadataManager. Fallback: try to return from MCRXMLMetadataManager ", e);
+                return MCRXMLMetadataManager.getInstance().retrieveContent(mcrId);
             }
-
-            return new MCRBaseContent(base);
         }
-        resp.sendError(HttpServletResponse.SC_NOT_FOUND, getErrorI18N(I18N_ERROR_PREFIX, "notFound", mcrid));
+        resp.sendError(HttpServletResponse.SC_NOT_FOUND, getErrorI18N(I18N_ERROR_PREFIX, "notFound", mcrId));
         return null;
     }
 


### PR DESCRIPTION
* use MCRXMLMetadataManager to retrieve content directly from hard drive if validation or expanding fails

[Link to jira](https://mycore.atlassian.net/browse/MCR-3676).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [ ] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
