### PR TITLE
MCR-3677 fix MCRClassificationEditorResourceTest on Windows

### DIFF
--- a/mycore-base/src/test/java/org/mycore/datamodel/ifs2/MCRFileStoreTest.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/ifs2/MCRFileStoreTest.java
@@ -282,7 +282,6 @@ public class MCRFileStoreTest extends MCRIFS2TestCase {
     }
 
     private void sortChildren(Element parent) {
-        @SuppressWarnings("unchecked")
         List<Element> children = parent.getChildren();
         if (children == null || children.size() == 0) {
             return;

--- a/mycore-base/src/test/java/org/mycore/datamodel/ifs2/test/MCRJimfsTestStoreConfig.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/ifs2/test/MCRJimfsTestStoreConfig.java
@@ -1,0 +1,54 @@
+package org.mycore.datamodel.ifs2.test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.mycore.datamodel.ifs2.MCRStore.MCRStoreConfig;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+
+/**
+ * test configuration for an MCRStore, that uses an in-memory-fileystem (jimfs).
+ */
+public class MCRJimfsTestStoreConfig implements MCRStoreConfig {
+
+    private final Path baseDir;
+
+    public MCRJimfsTestStoreConfig(String fsName) throws IOException {
+        URI jimfsURI = URI.create("jimfs://" + fsName);
+        FileSystem fileSystem = Jimfs.newFileSystem(fsName, Configuration.unix());
+        try {
+            fileSystem = FileSystems.getFileSystem(jimfsURI);
+        } catch (FileSystemNotFoundException e) {
+            fileSystem = FileSystems.newFileSystem(jimfsURI, Map.of("fileSystem", fileSystem));
+        }
+        baseDir = fileSystem.getPath("/");
+    }
+
+    @Override
+    public String getID() {
+        return "Test";
+    }
+
+    @Override
+    public String getPrefix() {
+        return getID() + "_";
+    }
+
+    @Override
+    public String getBaseDir() {
+        return baseDir.toUri().toString();
+    }
+
+    @Override
+    public String getSlotLayout() {
+        return "4-4-2";
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/datamodel/ifs2/test/MCRJimfsTestStoreConfig.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/ifs2/test/MCRJimfsTestStoreConfig.java
@@ -1,3 +1,21 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.mycore.datamodel.ifs2.test;
 
 import java.io.IOException;
@@ -14,7 +32,7 @@ import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 
 /**
- * test configuration for an MCRStore, that uses an in-memory-fileystem (jimfs).
+ * Test configuration for an MCRStore that uses an in-memory-fileystem (jimfs).
  */
 public class MCRJimfsTestStoreConfig implements MCRStoreConfig {
 

--- a/mycore-base/src/test/java/org/mycore/datamodel/ifs2/test/MCRStoreManagerTest.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/ifs2/test/MCRStoreManagerTest.java
@@ -20,66 +20,17 @@ package org.mycore.datamodel.ifs2.test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.IOException;
-import java.net.URI;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystemNotFoundException;
-import java.nio.file.FileSystems;
-import java.nio.file.Path;
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 import org.mycore.datamodel.ifs2.MCRFileStore;
-import org.mycore.datamodel.ifs2.MCRStore.MCRStoreConfig;
 import org.mycore.datamodel.ifs2.MCRStoreManager;
-
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Jimfs;
 
 public class MCRStoreManagerTest {
     @Test
     public void createMCRFileStore() throws Exception {
-        StoreConfig config = new StoreConfig();
+        MCRJimfsTestStoreConfig config = new MCRJimfsTestStoreConfig(MCRStoreManagerTest.class.getSimpleName());
         MCRFileStore fileStore = MCRStoreManager.createStore(config, MCRFileStore.class);
 
         assertNotNull(fileStore, "MCRStoreManager could not create Filestore.");
     }
 
-    class StoreConfig implements MCRStoreConfig {
-
-        private final Path baseDir;
-
-        StoreConfig() throws IOException {
-            String fsName = MCRStoreManagerTest.class.getSimpleName();
-            URI jimfsURI = URI.create("jimfs://" + fsName);
-            FileSystem fileSystem = Jimfs.newFileSystem(fsName, Configuration.unix());
-            try {
-                fileSystem = FileSystems.getFileSystem(jimfsURI);
-            } catch (FileSystemNotFoundException e) {
-                fileSystem = FileSystems.newFileSystem(jimfsURI, Map.of("fileSystem", fileSystem));
-            }
-            baseDir = fileSystem.getPath("/");
-        }
-
-        @Override
-        public String getID() {
-            return "Test";
-        }
-
-        @Override
-        public String getPrefix() {
-            return getID() + "_";
-        }
-
-        @Override
-        public String getBaseDir() {
-            return baseDir.toUri().toString();
-        }
-
-        @Override
-        public String getSlotLayout() {
-            return "4-4-2";
-        }
-
-    }
 }

--- a/mycore-classeditor/src/test/java/org/mycore/frontend/classeditor/resources/MCRClassificationEditorResourceTest.java
+++ b/mycore-classeditor/src/test/java/org/mycore/frontend/classeditor/resources/MCRClassificationEditorResourceTest.java
@@ -21,6 +21,7 @@ package org.mycore.frontend.classeditor.resources;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.List;
@@ -45,6 +46,7 @@ import org.mycore.datamodel.classifications2.MCRCategoryID;
 import org.mycore.datamodel.common.MCRXMLMetadataEventHandler;
 import org.mycore.datamodel.ifs2.MCRMetadataStore;
 import org.mycore.datamodel.ifs2.MCRStoreManager;
+import org.mycore.datamodel.ifs2.test.MCRJimfsTestStoreConfig;
 import org.mycore.frontend.classeditor.json.MCRJSONCategory;
 import org.mycore.frontend.classeditor.mocks.CategoryDAOMock;
 import org.mycore.frontend.classeditor.mocks.CategoryLinkServiceMock;
@@ -87,13 +89,19 @@ public class MCRClassificationEditorResourceTest {
             MCRSessionHookFilter.class,
             MultiPartFeature.class));
 
+        String name = MCRClassificationEditorResourceTest.class.getSimpleName();
         try {
-            MCRStoreManager.createStore("ClasseditorTempStore", MCRMetadataStore.class);
-        } catch (ReflectiveOperationException e) {
-            LOGGER.error("while creating store ClasseditorTempStore", e);
-        }
+            MCRStoreManager.computeStoreIfAbsent(name, () -> {
+                try {
+                    MCRJimfsTestStoreConfig config = new MCRJimfsTestStoreConfig(name);
+                    return MCRStoreManager.buildStore(config, MCRMetadataStore.class);
+                } catch (ReflectiveOperationException | IOException e) {
+                    LOGGER.error("while creating store ClasseditorTempStore", e);
+                    fail();
+                    return null;
+                }
+            });
 
-        try {
             /* its important to set the daomock via this method because the factory could be called
              * by a previous test. In this case a class cast exception occur because MCRCategoryDAOImpl
              * was loaded. */

--- a/mycore-classeditor/src/test/java/org/mycore/frontend/classeditor/resources/MCRClassificationEditorResourceTest.java
+++ b/mycore-classeditor/src/test/java/org/mycore/frontend/classeditor/resources/MCRClassificationEditorResourceTest.java
@@ -96,7 +96,7 @@ public class MCRClassificationEditorResourceTest {
                     MCRJimfsTestStoreConfig config = new MCRJimfsTestStoreConfig(name);
                     return MCRStoreManager.buildStore(config, MCRMetadataStore.class);
                 } catch (ReflectiveOperationException | IOException e) {
-                    LOGGER.error("while creating store ClasseditorTempStore", e);
+                    LOGGER.error("Error while creating store: ", e);
                     fail();
                     return null;
                 }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [ ] Affected version is listed in the ticket.
- [ ] Minimal code changes were made (no refactoring).
- [ ] This PR truly fixes **only** the reported bug.
- [ ] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [ ] I have tested the changes locally.
- [ ] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [ ] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
