### PR TITLE
MCR-3687 set RenderingHints on Graphics2D for IIIF image scaling

### DIFF
--- a/mycore-iview2/src/main/java/org/mycore/iview2/iiif/MCRIVIEWIIIFImageImpl.java
+++ b/mycore-iview2/src/main/java/org/mycore/iview2/iiif/MCRIVIEWIIIFImageImpl.java
@@ -192,10 +192,6 @@ public class MCRIVIEWIIIFImageImpl extends MCRIIIFImageImpl {
             Graphics2D graphics = targetImage.createGraphics();
             graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
                 RenderingHints.VALUE_INTERPOLATION_BICUBIC);
-            graphics.setRenderingHint(RenderingHints.KEY_RENDERING,
-                RenderingHints.VALUE_RENDER_QUALITY);
-            graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
-                RenderingHints.VALUE_ANTIALIAS_ON);
             if (rotation.mirrored()) {
                 graphics.scale(-1, 1);
                 graphics.translate(-width, 0);

--- a/mycore-iview2/src/main/java/org/mycore/iview2/iiif/MCRIVIEWIIIFImageImpl.java
+++ b/mycore-iview2/src/main/java/org/mycore/iview2/iiif/MCRIVIEWIIIFImageImpl.java
@@ -19,6 +19,7 @@
 package org.mycore.iview2.iiif;
 
 import java.awt.Graphics2D;
+import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.file.FileSystem;
@@ -189,6 +190,12 @@ public class MCRIVIEWIIIFImageImpl extends MCRIIIFImageImpl {
             Path rootPath = zipFileSystem.getPath("/");
 
             Graphics2D graphics = targetImage.createGraphics();
+            graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+            graphics.setRenderingHint(RenderingHints.KEY_RENDERING,
+                RenderingHints.VALUE_RENDER_QUALITY);
+            graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                RenderingHints.VALUE_ANTIALIAS_ON);
             if (rotation.mirrored()) {
                 graphics.scale(-1, 1);
                 graphics.translate(-width, 0);


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3687).

## Summary

`MCRIVIEWIIIFImageImpl.provide()` created a `Graphics2D` without setting `KEY_INTERPOLATION`, so Java2D fell back to `VALUE_INTERPOLATION_NEAREST_NEIGHBOR`. Any IIIF image that required scaling between tile resolution and the requested target size was rendered blocky/pixelated.

This PR sets `KEY_INTERPOLATION` → `VALUE_INTERPOLATION_BICUBIC`, matching the hint already used by `MCRPDFTools` and `MCRThumbnailServlet`.

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [ ] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [ ] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [x] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?