### PR TITLE
MCR-3693 Bump datamodel-plugin to 0.10-SNAPSHOT to pick up structure schema order fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@ Applications based on MyCoRe use a common core, which provides the functionality
         <plugin>
           <groupId>org.mycore.plugins</groupId>
           <artifactId>datamodel-plugin</artifactId>
-          <version>0.9</version>
+          <version>0.10-SNAPSHOT</version>
         </plugin>
         <plugin>
           <groupId>com.github.eirslett</groupId>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3693)

## Summary

- Bumps `datamodel-plugin` from `0.9` to `0.10-SNAPSHOT` in the parent `pluginManagement` section.
- Picks up the structure complex type ordering fix from MCR-3692 (`childrenOrder` before `children`), so generated schemas validate expanded objects.
- Will be pinned to the released `0.10` once the plugin is published.

# Pull Request Checklist (Author)

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible). — N/A, dependency bump only.

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed.

## Multi-Repo Considerations
- [x] Is an equivalent PR in `MIR` required? — No.