### PR TITLE
MCR-3678 refactor MCRJanitorEventHandlerBase to use MCRScopedSession

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/events/MCRJanitorEventHandlerBase.java
+++ b/mycore-base/src/main/java/org/mycore/common/events/MCRJanitorEventHandlerBase.java
@@ -18,13 +18,10 @@
 
 package org.mycore.common.events;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
+import org.mycore.common.MCRScopedSession;
 import org.mycore.common.MCRSession;
 import org.mycore.common.MCRSessionMgr;
 import org.mycore.common.MCRSystemUserInformation;
-import org.mycore.common.MCRUserInformation;
 
 /**
  * A EventHandler which runs as {@link MCRSystemUserInformation#JANITOR}.
@@ -33,73 +30,12 @@ public class MCRJanitorEventHandlerBase extends MCREventHandlerBase {
 
     @Override
     public void doHandleEvent(MCREvent evt) {
-        NonThrowingAutoClosable closer = MCRThreadBoundUserInformation.attach(MCRSystemUserInformation.JANITOR);
-        try (closer) {
-            super.doHandleEvent(evt);
+        MCRSession session = MCRSessionMgr.getCurrentSession();
+        if (!(session instanceof MCRScopedSession scopedSession)) {
+            throw new IllegalStateException("require an instance of MCRScopedSession");
         }
+        scopedSession.doAs(new MCRScopedSession.ScopedValues(MCRSystemUserInformation.JANITOR),
+            () -> super.doHandleEvent(evt));
     }
 
-    private interface NonThrowingAutoClosable extends AutoCloseable {
-        @Override
-        void close();
-    }
-
-    private static final class MCRThreadBoundUserInformation implements MCRUserInformation {
-
-        private final Map<Thread, MCRUserInformation> threads = new ConcurrentHashMap<>();
-        private final MCRUserInformation originalUserInformation;
-
-        private MCRThreadBoundUserInformation(MCRUserInformation originalUserInformation) {
-            this.originalUserInformation = originalUserInformation;
-        }
-
-        public static NonThrowingAutoClosable attach(MCRUserInformation newUserInformation) {
-            MCRSession session = MCRSessionMgr.getCurrentSession();
-            synchronized (session) {
-                if (session.getUserInformation() instanceof MCRThreadBoundUserInformation threadBound) {
-                    threadBound.threads.put(Thread.currentThread(), newUserInformation);
-                    return () -> detach(session);
-                } else {
-                    MCRUserInformation oldUserInformation = session.getUserInformation();
-                    session.setUserInformation(MCRSystemUserInformation.GUEST);
-                    MCRThreadBoundUserInformation threadBound =
-                        new MCRThreadBoundUserInformation(oldUserInformation);
-                    threadBound.threads.put(Thread.currentThread(), newUserInformation);
-                    session.setUserInformation(threadBound);
-                    return () -> detach(session);
-                }
-            }
-        }
-
-        public static void detach(MCRSession session) {
-            synchronized (session) {
-                if (session.getUserInformation() instanceof MCRThreadBoundUserInformation threadBound) {
-                    threadBound.threads.remove(Thread.currentThread());
-                    if (threadBound.threads.isEmpty()) {
-                        session.setUserInformation(MCRSystemUserInformation.GUEST);
-                        session.setUserInformation(threadBound.originalUserInformation);
-                    }
-                }
-            }
-        }
-
-        @Override
-        public String getUserID() {
-            MCRUserInformation ui = threads.get(Thread.currentThread());
-            return ui != null ? ui.getUserID() : originalUserInformation.getUserID();
-        }
-
-        @Override
-        public boolean isUserInRole(String role) {
-            MCRUserInformation ui = threads.get(Thread.currentThread());
-            return ui != null ? ui.isUserInRole(role) : originalUserInformation.isUserInRole(role);
-        }
-
-        @Override
-        public String getUserAttribute(String attribute) {
-            MCRUserInformation ui = threads.get(Thread.currentThread());
-            return ui != null ? ui.getUserAttribute(attribute) : originalUserInformation.getUserAttribute(attribute);
-        }
-
-    }
 }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3678).

## Summary

Replace the thread-bound user information hack in `MCRJanitorEventHandlerBase` with a `doAs` call on `MCRScopedSession`. The scoped session was introduced in 2024.06 and already provides per-thread user information via `ThreadLocal`, making the manual `synchronized` attach/detach map and the `MCRThreadBoundUserInformation` inner class obsolete (-64 lines).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [ ] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`2024.06.x`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [ ] Affected version is listed in the ticket.
- [ ] Minimal code changes were made (no refactoring).
- [ ] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [x] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?