### PR TITLE
MCR-3673 DNBRegister make date parsing more robust (2023.06.x)

### DIFF
--- a/mycore-pi/src/main/java/org/mycore/pi/urn/MCRURNUtils.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/urn/MCRURNUtils.java
@@ -19,9 +19,8 @@
 package org.mycore.pi.urn;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Date;
-import java.util.Locale;
 import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
@@ -53,11 +52,14 @@ public class MCRURNUtils {
             .map(JsonElement::getAsString)
             .orElse(null);
 
+        return parseDNBRegisterDate(date);
+    }
+
+    static Date parseDNBRegisterDate(String date) {
         if (date == null) {
             return null;
         }
-
-        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.GERMAN).parse(date);
+        return Date.from(Instant.parse(date));
     }
 
 }

--- a/mycore-pi/src/test/java/org/mycore/pi/urn/MCRURNUtilsTest.java
+++ b/mycore-pi/src/test/java/org/mycore/pi/urn/MCRURNUtilsTest.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.pi.urn;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MCRURNUtilsTest {
+
+    private static final String[] VALID_DATES = {
+        "2025-11-07T15:00:21.000Z",
+        "2025-11-07T15:00:21Z",
+        "2025-11-07T15:00:21.1Z",
+        "2025-11-07T15:00:21-12:00",
+        "2025-11-07T15:00:21+01:00",
+        "2025-11-07T15:00:21.123456Z",
+    };
+
+    @Test
+    public void parseValidDates() {
+        for (String date : VALID_DATES) {
+            Date result = MCRURNUtils.parseDNBRegisterDate(date);
+            Assert.assertNotNull("should parse: " + date, result);
+            Assert.assertEquals("parsed date should match Instant.parse for: " + date,
+                Date.from(Instant.parse(date)), result);
+        }
+    }
+
+    @Test
+    public void parseNullReturnsNull() {
+        Assert.assertNull(MCRURNUtils.parseDNBRegisterDate(null));
+    }
+
+    @Test(expected = DateTimeParseException.class)
+    public void parseInvalidThrows() {
+        MCRURNUtils.parseDNBRegisterDate("invalidDate");
+    }
+
+}


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3673).

Backport of #2905 to `2023.06.x`.

## Summary
- Replace `SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.GERMAN)` with `Instant.parse(...)` in `MCRURNUtils.getDNBRegisterDate(String)` so any ISO-8601 timestamp returned by the DNB URN service is accepted (no fractional seconds, microseconds, `+hh:mm` offsets, etc.).
- Extract the parse logic into a package-private helper `parseDNBRegisterDate(String)` to allow unit testing without mocking the static REST client (this branch has no Mockito dependency available in `mycore-pi`).

# Pull Request Checklist (Author)

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`2023.06.x`).

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [x] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally (`CI=true mvn -pl mycore-pi -am clean install` — `MCRURNUtilsTest`: 3 tests, 0 failures).
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [x] If the **public API** has changed:
  - No public API change. New helper is package-private.
- [x] Java license headers are added where necessary.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - Not required.