### PR TITLE
MCR-3645 fix Solr field name stream_content_type in MCRSolrFileIndexBaseAccumulator

### DIFF
--- a/mycore-solr/src/main/java/org/mycore/solr/index/file/MCRSolrFileIndexBaseAccumulator.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/index/file/MCRSolrFileIndexBaseAccumulator.java
@@ -94,7 +94,7 @@ public class MCRSolrFileIndexBaseAccumulator implements MCRSolrFileIndexAccumula
         doc.setField("stream_size", attr.size());
         doc.setField("stream_name", absolutePath);
         doc.setField("stream_source_info", input.toString());
-        doc.setField("IN", MCRContentTypes.probeContentType(input));
+        doc.setField("stream_content_type", MCRContentTypes.probeContentType(input));
         doc.setField("extension", Files.getFileExtension(input.getFileName().toString()));
         MCRISO8601Date iDate = new MCRISO8601Date();
         iDate.setDate(new Date(attr.lastModifiedTime().toMillis()));


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3645).

In `MCRSolrFileIndexBaseAccumulator.accumulate(...)` the Solr field name `stream_content_type` was accidentally replaced with `IN` in commit 32ea164 (PR #2865). As a result the MIME type detected via `MCRContentTypes.probeContentType` was indexed under the field `IN`, breaking content-type filtering and searching of indexed files. This PR restores the original field name.

Affected versions: only `main` (2026.06.0-SNAPSHOT). Release branches `2025.12.x` and earlier are not affected, so the fix is reused under the original feature ticket per convention.

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [ ] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [x] Java license headers are added where necessary.
- [x] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [x] All configuration options are documented in Javadoc and `mycore.properties`.
- [x] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?