### PR TITLE
MCR-3700 record externally supplied IDs in MCRFileBaseCacheObjectIDGenerator

### DIFF
--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRFileBaseCacheObjectIDGenerator.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRFileBaseCacheObjectIDGenerator.java
@@ -47,7 +47,7 @@ import org.mycore.datamodel.metadata.MCRObjectID;
  * given base id. The cache file is located in the data directory of MyCoRe and is named "id_cache" and contains one
  * file for each base id. The file contains the last generated id as a string.
  */
-public class MCRFileBaseCacheObjectIDGenerator implements MCRObjectIDGenerator {
+public class MCRFileBaseCacheObjectIDGenerator implements MCRTrackingObjectIDGenerator {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
@@ -64,7 +64,7 @@ public class MCRFileBaseCacheObjectIDGenerator implements MCRObjectIDGenerator {
         synchronized (MCRFileBaseCacheObjectIDGenerator.class) {
             if (!Files.exists(cacheFile)) {
                 try {
-                   return Files.createFile(cacheFile);
+                    return Files.createFile(cacheFile);
                 } catch (IOException e) {
                     throw new MCRException("Could not create " + cacheFile.toAbsolutePath(), e);
                 }
@@ -126,14 +126,61 @@ public class MCRFileBaseCacheObjectIDGenerator implements MCRObjectIDGenerator {
         int idLengthInBytes = MCRObjectID.formatID(baseId, 1).getBytes(StandardCharsets.UTF_8).length;
         try (
             FileChannel channel = FileChannel.open(cacheFile, StandardOpenOption.WRITE,
-                StandardOpenOption.SYNC, StandardOpenOption.CREATE);){
+                StandardOpenOption.SYNC, StandardOpenOption.CREATE);) {
             ByteBuffer buffer = ByteBuffer.allocate(idLengthInBytes);
             channel.position(0);
-            writeNewID(MCRObjectID.getInstance(MCRObjectID.formatID(baseId, next-1)), buffer, channel, cacheFile);
+            writeNewID(MCRObjectID.getInstance(MCRObjectID.formatID(baseId, next - 1)), buffer, channel, cacheFile);
         } catch (FileNotFoundException e) {
             throw new MCRException("Could not create " + cacheFile.toAbsolutePath(), e);
         } catch (IOException e) {
             throw new MCRException("Could not open " + cacheFile.toAbsolutePath(), e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * If the cache file for the base ID of {@code id} is missing, empty or contains an ID lower
+     * than {@code id}, the cache file is updated to {@code id}. Otherwise the call is a no-op.
+     */
+    @Override
+    public void recordID(MCRObjectID id) {
+        String baseId = id.getBase();
+        Path cacheFile = getCacheFilePath(baseId);
+
+        ReentrantReadWriteLock lock = locks.computeIfAbsent(baseId, k -> new ReentrantReadWriteLock());
+        ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
+
+        try {
+            writeLock.lock();
+            try (
+                FileChannel channel = FileChannel.open(cacheFile, StandardOpenOption.READ, StandardOpenOption.WRITE,
+                    StandardOpenOption.SYNC);
+                FileLock fileLock = channel.lock()) {
+
+                int idLengthInBytes = MCRObjectID.formatID(baseId, 1).getBytes(StandardCharsets.UTF_8).length;
+                ByteBuffer buffer = ByteBuffer.allocate(idLengthInBytes);
+                buffer.clear();
+                channel.position(0);
+                int bytesRead = channel.read(buffer);
+                if (bytesRead > 0 && bytesRead != idLengthInBytes) {
+                    throw new MCRException("Content has different id length " + cacheFile.toAbsolutePath());
+                }
+                if (bytesRead == idLengthInBytes) {
+                    buffer.flip();
+                    MCRObjectID cached = readObjectIDFromBuffer(idLengthInBytes, buffer);
+                    if (cached.getNumberAsInteger() >= id.getNumberAsInteger()) {
+                        return;
+                    }
+                }
+                writeNewID(id, buffer, channel, cacheFile);
+            } catch (FileNotFoundException e) {
+                throw new MCRException("Could not create " + cacheFile.toAbsolutePath(), e);
+            } catch (IOException e) {
+                throw new MCRException("Could not open " + cacheFile.toAbsolutePath(), e);
+            }
+        } finally {
+            writeLock.unlock();
         }
     }
 
@@ -228,8 +275,8 @@ public class MCRFileBaseCacheObjectIDGenerator implements MCRObjectIDGenerator {
 
         try (Stream<Path> list = Files.list(cacheDir);) {
             List<String> baseIdList = list.filter(Files::isRegularFile)
-                    .map(Path::getFileName).map(Path::toString)
-                    .collect(Collectors.toList());
+                .map(Path::getFileName).map(Path::toString)
+                .collect(Collectors.toList());
             return baseIdList;
         } catch (IOException e) {
             throw new MCRException("Could not detect cache files!", e);

--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRTrackingObjectIDGenerator.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRTrackingObjectIDGenerator.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mycore.datamodel.common;
+
+import org.mycore.datamodel.metadata.MCRObjectID;
+
+/**
+ * Optional extension of {@link MCRObjectIDGenerator} for generators that maintain their own
+ * "last used ID" state (e.g. a cache file) instead of deriving it from the underlying object store
+ * on every call.
+ * <p>
+ * Such generators must be informed about IDs that have been assigned outside of
+ * {@link #getNextFreeId(String, int)}, e.g. when an object is created with a fixed, externally
+ * supplied ID. Otherwise their internal state would lag behind the actual store and subsequent
+ * calls to {@link #getNextFreeId(String, int)} could return colliding IDs.
+ */
+public interface MCRTrackingObjectIDGenerator extends MCRObjectIDGenerator {
+
+    /**
+     * Records that the given ID has been used. Implementations must update their internal
+     * "last used ID" state for the corresponding base ID so that subsequent calls to
+     * {@link #getNextFreeId(String, int)} return values strictly greater than {@code id}.
+     * <p>
+     * Calls with an ID lower than or equal to the currently tracked last ID must be ignored.
+     *
+     * @param id the ID that has been used
+     */
+    void recordID(MCRObjectID id);
+
+}

--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetadataManager.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetadataManager.java
@@ -53,6 +53,7 @@ import org.mycore.datamodel.common.MCRLinkTableManager;
 import org.mycore.datamodel.common.MCRMarkManager;
 import org.mycore.datamodel.common.MCRMarkManager.Operation;
 import org.mycore.datamodel.common.MCRObjectIDGenerator;
+import org.mycore.datamodel.common.MCRTrackingObjectIDGenerator;
 import org.mycore.datamodel.common.MCRXMLMetadataManager;
 import org.mycore.datamodel.metadata.share.MCRMetadataShareAgent;
 import org.mycore.datamodel.metadata.share.MCRMetadataShareAgentFactory;
@@ -80,8 +81,8 @@ public final class MCRMetadataManager {
 
     private static final MCRXMLMetadataManager XML_MANAGER = MCRXMLMetadataManager.instance();
 
-    private static final MCRObjectIDGenerator MCROBJECTID_GENERATOR
-        = MCRConfiguration2.getSingleInstanceOf("MCR.Metadata.ObjectID.Generator.Class",
+    private static final MCRObjectIDGenerator MCROBJECTID_GENERATOR =
+        MCRConfiguration2.getSingleInstanceOf("MCR.Metadata.ObjectID.Generator.Class",
             MCRDefaultObjectIDGenerator.class).get();
 
     private MCRMetadataManager() {
@@ -90,6 +91,19 @@ public final class MCRMetadataManager {
 
     public static MCRObjectIDGenerator getMCRObjectIDGenerator() {
         return MCROBJECTID_GENERATOR;
+    }
+
+    /**
+     * If the configured {@link MCRObjectIDGenerator} implements {@link MCRTrackingObjectIDGenerator},
+     * notify it that the given ID has been assigned externally (i.e. not via
+     * {@link MCRObjectIDGenerator#getNextFreeId(String, int)}). This keeps the generator's internal
+     * "last used ID" state in sync with the actual store, so that subsequent calls to
+     * {@code getNextFreeId} cannot return colliding IDs.
+     */
+    private static void recordIDIfTracking(MCRObjectID id) {
+        if (MCROBJECTID_GENERATOR instanceof MCRTrackingObjectIDGenerator tracking) {
+            tracking.recordID(id);
+        }
     }
 
     /**
@@ -192,6 +206,8 @@ public final class MCRMetadataManager {
             derivateId = MCRMetadataManager.getMCRObjectIDGenerator().getNextFreeId(derivateId.getBase());
             mcrDerivate.setId(derivateId);
             LOGGER.info("Assigned new derivate id {}", derivateId);
+        } else {
+            recordIDIfTracking(derivateId);
         }
 
         try {
@@ -334,6 +350,8 @@ public final class MCRMetadataManager {
             if (Objects.equals(mcrObject.getLabel(), oldId.toString())) {
                 mcrObject.setLabel(objectId.toString());
             }
+        } else {
+            recordIDIfTracking(objectId);
         }
 
         // create this object in datastore

--- a/mycore-base/src/test/java/org/mycore/datamodel/common/MCRFileBaseCacheObjectIDGeneratorTest.java
+++ b/mycore-base/src/test/java/org/mycore/datamodel/common/MCRFileBaseCacheObjectIDGeneratorTest.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class MCRFileBaseCacheObjectIDGeneratorTest extends MCRTestCase {
 
@@ -38,6 +39,44 @@ public class MCRFileBaseCacheObjectIDGeneratorTest extends MCRTestCase {
     public static final int TEST_IDS = 100;
 
     private static final Logger LOGGER = LogManager.getLogger();
+
+    @Test
+    public void recordIDAdvancesCacheWhenIdIsHigher() throws IOException {
+        Files.createDirectories(MCRFileBaseCacheObjectIDGenerator.getDataDirPath());
+
+        MCRFileBaseCacheObjectIDGenerator generator = new MCRFileBaseCacheObjectIDGenerator();
+        String baseId = "trackone_test";
+
+        // initial state: no cache file populated
+        assertNull(generator.getLastID(baseId));
+
+        // simulate an externally supplied fixed ID being used
+        MCRObjectID externalId = MCRObjectID.getInstance(MCRObjectID.formatID(baseId, 42));
+        generator.recordID(externalId);
+
+        assertEquals(42, generator.getLastID(baseId).getNumberAsInteger());
+
+        // next generated ID must be strictly greater than the externally supplied one
+        MCRObjectID next = generator.getNextFreeId(baseId);
+        assertEquals(43, next.getNumberAsInteger());
+    }
+
+    @Test
+    public void recordIDIgnoresLowerOrEqualId() throws IOException {
+        Files.createDirectories(MCRFileBaseCacheObjectIDGenerator.getDataDirPath());
+
+        MCRFileBaseCacheObjectIDGenerator generator = new MCRFileBaseCacheObjectIDGenerator();
+        String baseId = "tracktwo_test";
+
+        generator.recordID(MCRObjectID.getInstance(MCRObjectID.formatID(baseId, 100)));
+        // lower ID must be ignored
+        generator.recordID(MCRObjectID.getInstance(MCRObjectID.formatID(baseId, 50)));
+        // equal ID must be ignored
+        generator.recordID(MCRObjectID.getInstance(MCRObjectID.formatID(baseId, 100)));
+
+        assertEquals(100, generator.getLastID(baseId).getNumberAsInteger());
+        assertEquals(101, generator.getNextFreeId(baseId).getNumberAsInteger());
+    }
 
     @Test
     public void getNextFreeId() throws IOException {
@@ -59,7 +98,6 @@ public class MCRFileBaseCacheObjectIDGeneratorTest extends MCRTestCase {
                 generatedIds.add(id);
             });
 
-
         // check if all ids are unique
         assertEquals(TEST_IDS, generatedIds.size());
         assertEquals(TEST_IDS, generatedIds.stream().distinct().count());
@@ -68,7 +106,7 @@ public class MCRFileBaseCacheObjectIDGeneratorTest extends MCRTestCase {
         var sortedIds = new ArrayList<>(generatedIds);
         Collections.sort(sortedIds);
         for (int i = 0; i < sortedIds.size() - 1; i++) {
-            assertEquals(i+1, sortedIds.get(i).getNumberAsInteger());
+            assertEquals(i + 1, sortedIds.get(i).getNumberAsInteger());
         }
 
     }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3700)

## Problem

`MCRFileBaseCacheObjectIDGenerator` (introduced in MCR-3046) only updates its per-base-id cache file from inside `getNextFreeId(...)`. `MCRMetadataManager.create(MCRObject|MCRDerivate)` skips the generator when the caller supplies a fixed (non-zero) ID, so the cache stays behind the actual store. Subsequent `getNextFreeId(...)` calls then return IDs that collide with already-stored objects (`MCRPersistenceException("... already exists")`).

The default `MCRDefaultObjectIDGenerator` is unaffected because it reconciles against `MCRXMLMetadataManager.getHighestStoredID(...)`. The cache-based generator deliberately avoids that scan (expensive on OCFL because of hashed paths) and therefore cannot self-heal.

## Fix

- New optional sub-interface `MCRTrackingObjectIDGenerator` extends `MCRObjectIDGenerator` with `recordID(MCRObjectID id)`. Existing third-party `MCRObjectIDGenerator` implementations are unaffected.
- `MCRFileBaseCacheObjectIDGenerator` implements the new interface. `recordID` acquires the existing per-base-id write lock + file lock and writes the ID into the cache file iff it is greater than the currently cached value (otherwise no-op).
- `MCRMetadataManager.create(MCRObject)` and `create(MCRDerivate)` call a new private helper `recordIDIfTracking(...)` after the ID has been determined; the helper uses `instanceof MCRTrackingObjectIDGenerator` and is a no-op for generators that do not opt in.
- Two new unit tests: `recordIDAdvancesCacheWhenIdIsHigher`, `recordIDIgnoresLowerOrEqualId`.

## Repository healing

Existing repositories with corrupted caches can be repaired with the existing CLI command `generate id cache`, which rebuilds the cache files from the stored objects.

## Forward merge

This PR targets `2023.06.x` (where the bug originated). After merge it must be merged forward to `2024.06.x`, `2025.06.x`, `2025.12.x` and `main`.

## Test plan

- [x] `mvn -pl mycore-base -am test` (608/608 green incl. the two new tests)
- [ ] `CI=true mvn clean install` (full multi-module build)
- [ ] manual verification on an OCFL deployment: create object with fixed ID, then create object with id `0`, confirm no collision