### PR TITLE
MCR-3701 Fix OOM in thumbnail gneration for large input files

### DIFF
--- a/mycore-iview2/src/main/java/org/mycore/iview2/backend/MCRPDFThumbnailJobAction.java
+++ b/mycore-iview2/src/main/java/org/mycore/iview2/backend/MCRPDFThumbnailJobAction.java
@@ -29,7 +29,10 @@ import java.util.Locale;
 
 import javax.imageio.ImageIO;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.mycore.common.MCRException;
+import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.datamodel.metadata.MCRDerivate;
 import org.mycore.datamodel.metadata.MCRMetadataManager;
 import org.mycore.datamodel.metadata.MCRObjectID;
@@ -42,7 +45,12 @@ import org.mycore.services.queuedjob.MCRJobAction;
 
 public class MCRPDFThumbnailJobAction extends MCRJobAction {
 
+    private static final Logger LOGGER = LogManager.getLogger();
+
     public static final String DERIVATE_PARAMETER = "derivate";
+
+    private static final Long MAX_INPUT_FILE_SIZE =
+        MCRConfiguration2.getLong("MCR.IView2.PDF.Thumbnail.MaxInputFileSize").orElse(null);
 
     public MCRPDFThumbnailJobAction(MCRJob job) {
         super(job);
@@ -72,6 +80,16 @@ public class MCRPDFThumbnailJobAction extends MCRJobAction {
         if (tileInfo.getImagePath().toLowerCase(Locale.ROOT).endsWith(".pdf")) {
             try {
                 Path p = MCRPath.getPath(tileInfo.getDerivate(), tileInfo.getImagePath());
+
+                if (MAX_INPUT_FILE_SIZE != null) {
+                    long fileSize = Files.size(p);
+                    if (fileSize > MAX_INPUT_FILE_SIZE) {
+                        LOGGER.warn("Skipping thumbnail generation for {}, file size {} exceeds limit of {} bytes", p,
+                            fileSize, MAX_INPUT_FILE_SIZE);
+                        return;
+                    }
+                }
+
                 BufferedImage bImage = MCRPDFTools.getThumbnail(-1, p, false);
                 Path pImg = Files.createTempFile("MyCoRe-Thumbnail-", ".png");
                 try (OutputStream os = Files.newOutputStream(pImg)) {

--- a/mycore-iview2/src/main/resources/components/iview2/config/mycore.properties
+++ b/mycore-iview2/src/main/resources/components/iview2/config/mycore.properties
@@ -49,3 +49,6 @@ MCR.IIIFImage.thumbnail.Derivate.Types=derivate_types:thumbnail,derivate_types:c
 MCR.IIIFImage.Iview.ThumbnailForPdfEventHandler.Derivate.Types=derivate_types:content
 MCR.EventHandler.MCRDerivate.080.Class=org.mycore.iview2.events.MCRThumbnailForPdfEventHandler
 MCR.Media.Thumbnail.Generators=%MCR.Media.Thumbnail.Generators%,org.mycore.iview2.services.MCRImageThumbnailGenerator
+
+# Maximum input file size in bytes for PDF thumbnail generation. If empty, no limit is applied.
+MCR.IView2.PDF.Thumbnail.MaxInputFileSize=


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3701).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [x] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [x] All configuration options are documented in Javadoc and `mycore.properties`.
- [x] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
