### PR TITLE
MCR-3706 restore inter-process FileLock in getNextFreeId

### DIFF
--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRFileBaseCacheObjectIDGenerator.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRFileBaseCacheObjectIDGenerator.java
@@ -189,7 +189,6 @@ public class MCRFileBaseCacheObjectIDGenerator implements MCRTrackingObjectIDGen
         }
     }
 
-
     @Override
     public MCRObjectID getNextFreeId(String baseId, int maxInWorkflow) {
         Path cacheFile = getCacheFilePath(baseId);
@@ -203,7 +202,9 @@ public class MCRFileBaseCacheObjectIDGenerator implements MCRTrackingObjectIDGen
             writeLock.lock();
             try (
                 FileChannel channel = FileChannel.open(cacheFile, StandardOpenOption.READ, StandardOpenOption.WRITE,
-                    StandardOpenOption.SYNC)) {
+                    StandardOpenOption.SYNC);
+                @SuppressWarnings("PMD.UnusedLocalVariable")
+                FileLock fileLock = channel.lock()) {
 
                 int idLengthInBytes = MCRObjectID.formatID(baseId, 1).getBytes(StandardCharsets.UTF_8).length;
                 ByteBuffer buffer = ByteBuffer.allocate(idLengthInBytes);


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3706).

## Problem
`MCRFileBaseCacheObjectIDGenerator.getNextFreeId(String, int)` performs a read-modify-write on the per-base-id cache file. The original implementation (MCR-3046) made this atomic across processes/JVMs sharing the same `MCR.datadir` via an OS advisory lock `channel.lock()`.

The PMD cleanup MCR-2997 (`c3fc3167d4`) removed this `FileLock`: the `UnusedLocalVariables` rule flagged the try-with-resources `FileLock fileLock` as unused. It is not unused — it is held for its locking side effect and auto-unlocked at block end. Since then `getNextFreeId` only held the in-JVM `ReentrantReadWriteLock`, giving no protection between multiple processes sharing the data directory → possible duplicate IDs / lost updates.

`recordID(...)` (MCR-3700) kept the lock correctly with `@SuppressWarnings("PMD.UnusedLocalVariable")`.

## Fix
Re-acquire the lock in `getNextFreeId` analogous to `recordID`, suppressing the PMD rule.

## Affected versions
PMD removal only present from `2024.06.x` onward (`2023.06.x` and earlier are unaffected). Targets `2024.06.x`, then forward-merge to `2025.06.x`, `2025.12.x`, `main`.

## Checklist
- [x] Code compiles and tests pass (`CI=true mvn clean install -pl mycore-base -am`)
- [x] Java files formatted with Eclipse Formatter
- [x] Naming conventions followed
- [ ] Documentation (n/a — internal locking fix)
