### PR TITLE
MCR-3681 Processing UI: Keep task name stable during and after execution

### DIFF
--- a/mycore-base/src/main/java/org/mycore/util/concurrent/processing/MCRProcessableSupplier.java
+++ b/mycore-base/src/main/java/org/mycore/util/concurrent/processing/MCRProcessableSupplier.java
@@ -91,6 +91,9 @@ public final class MCRProcessableSupplier<R> extends MCRProcessableTask<Callable
     @Override
     public R get() {
         try {
+            if (super.getName() == null) {
+                setName(resolveTaskName());
+            }
             this.setStatus(MCRProcessableStatus.PROCESSING);
             this.startTime = Instant.now();
             R result = getTask().call();
@@ -175,15 +178,16 @@ public final class MCRProcessableSupplier<R> extends MCRProcessableTask<Callable
     @Override
     public String getName() {
         String name = super.getName();
-        if (name == null) {
-            return MCRDecorator.resolve(this.task).map(object -> {
-                if (object instanceof MCRProcessable processable) {
-                    return processable.getName();
-                }
-                return object.toString();
-            }).orElse(this.task.toString());
-        }
-        return name;
+        return name == null ? resolveTaskName() : name;
+    }
+
+    private String resolveTaskName() {
+        return MCRDecorator.resolve(this.task).map(object -> {
+            if (object instanceof MCRProcessable processable) {
+                return processable.getName();
+            }
+            return object.toString();
+        }).orElse(this.task.toString());
     }
 
 }

--- a/mycore-base/src/test/java/org/mycore/util/concurrent/processing/MCRProcessableSupplierTest.java
+++ b/mycore-base/src/test/java/org/mycore/util/concurrent/processing/MCRProcessableSupplierTest.java
@@ -20,6 +20,7 @@ package org.mycore.util.concurrent.processing;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -75,13 +76,28 @@ public class MCRProcessableSupplierTest extends MCRTestCase {
             supplier.getStatus());
         assertEquals("the progressable should be at 100", Integer.valueOf(100), supplier.getProgress());
         assertEquals("end", supplier.getProgressText());
-        assertEquals("there shouldn't be any error", null, supplier.getError());
+        assertNull("there shouldn't be any error", supplier.getError());
         assertNotEquals("there should be a start time", null, supplier.getStartTime());
         assertNotEquals("there should be an end time", null, supplier.getEndTime());
         assertNotEquals(null, supplier.took());
 
         assertNotEquals("the status listener wasn't called", 0, STATUS_LISTENER_COUNTER);
         assertNotEquals("the progressable listener wasn't called", 0, PROGRESS_LISTENER_COUNTER);
+
+        es.shutdown();
+        es.awaitTermination(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void nameStaysStableAfterExecution() throws Exception {
+        ExecutorService es = Executors.newSingleThreadExecutor();
+        MCRProcessableExecutor pes = MCRProcessableFactory.newPool(es);
+        DynamicNameCallable task = new DynamicNameCallable();
+
+        MCRProcessableSupplier<?> supplier = pes.submit(task, 0);
+        supplier.getFuture().get();
+
+        assertEquals("Name should keep the value from the start of the task", "list selected", supplier.getName());
 
         es.shutdown();
         es.awaitTermination(10, TimeUnit.SECONDS);
@@ -94,12 +110,29 @@ public class MCRProcessableSupplierTest extends MCRTestCase {
             setProgress(0);
             setProgressText("start");
             try {
-                Thread.sleep(100);
+                Thread.sleep(10);
                 setProgress(100);
                 setProgressText("end");
             } catch (InterruptedException e) {
                 LOGGER.warn("test thread interrupted", e);
             }
+        }
+
+    }
+
+    private static class DynamicNameCallable implements java.util.concurrent.Callable<Boolean> {
+
+        private String name = "list selected";
+
+        @Override
+        public Boolean call() {
+            name = "no active command";
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return name;
         }
 
     }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3681).

Currently,  MCRProcessableSupplier  resolves the task name dynamically via  getName()  by calling  toString()  on the underlying task. If the task's state changes during or after execution (for example, in webcli commands where the state/description might clear), the resolved name becomes unstable.

This PR resolves and sets the task name permanently via  setName(...)  when the task execution begins in  get() .

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [x] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [ ] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
