### PR TITLE
MCR-3709 REST API v2 classifications JSON serializes "id" instead of "ID"

### DIFF
--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClass.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClass.java
@@ -96,7 +96,7 @@ public class MCRClass {
         this.categories = value;
     }
 
-    @JsonGetter
+    @JsonGetter("ID")
     public String getID() {
         return id;
     }
@@ -139,7 +139,7 @@ public class MCRClass {
                 .toList());
         category.setChildren(new ArrayList<>());
         this.getCategories()
-                .forEach((c) -> buildCategory(getID(), c, category));
+            .forEach((c) -> buildCategory(getID(), c, category));
 
         return category;
     }

--- a/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClassCategory.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/classifications2/model/MCRClassCategory.java
@@ -87,7 +87,7 @@ public class MCRClassCategory {
         return this.category;
     }
 
-    @JsonGetter
+    @JsonGetter("ID")
     public String getID() {
         return id;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1040,6 +1040,11 @@ Applications based on MyCoRe use a common core, which provides the functionality
         <version>${jackson.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.github.java-json-tools</groupId>
         <artifactId>json-patch</artifactId>
         <version>1.13</version>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3709).

## Problem

The REST API v2 classification endpoints (e.g. `GET /api/v2/classifications/{classid}`) serialize the classification/category identifier with the JSON key `"id"` (lowercase) instead of `"ID"` (uppercase) as in previous releases. The XML representation is unaffected (still `ID`).

- 2025.12: `{"ID":"...","labels":[...]}`
- 2026.06: `{"id":"...","labels":[...],"categories":[...]}`

This is a breaking change for API consumers relying on the `ID` key.

## Cause

`MCRClass.getID()` / `MCRClassCategory.getID()` use `@JsonGetter` without an explicit name. The resulting JSON key therefore depends on whether JAXB annotation introspection (honoring `@XmlAttribute(name = "ID")`) is active for the serializing `ObjectMapper`:

- with JAXB introspection → `ID`
- without → Jackson default bean-name mangling of `getID()` → `id`

The Jersey upgrade 3.1.10 → 4.0.2 (introduced in 2026.06) changed JSON provider selection so that a JACKSON-only `ObjectMapper` (no JAXB introspection) serializes the response instead of the explicitly registered `JacksonXmlBindJsonProvider`, flipping the key to `id`.

## Fix

Use `@JsonGetter("ID")` on `getID()` in `MCRClass` and `MCRClassCategory`. This pins the JSON key to `ID` for both serialization and deserialization, independent of the active provider/introspector. Verified locally and in MIR.

Additionally, `jackson-module-jakarta-xmlbind-annotations` is now managed to `${jackson.version}` in the parent POM. It was leaking in transitively at 2.19.1 (via `jersey-media-json-jackson` 4.0.2) while the rest of Jackson was 2.21.1. This is dependency hygiene and does not by itself fix the bug.

# Pull Request Checklist (Author)

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [ ] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`2026.06.x`).

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced (restores the prior `ID` key).
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified? No.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed.
- [x] Public API: the JSON key returns to its prior value `ID`; no Java API change.
- [x] Java license headers are unchanged (no new files).

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required? No (MIR consumes the fixed mycore artifact).
