### PR TITLE
MCR-3688 Resolve URI resolver instances without .Class suffix

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/xml/MCRLayoutTransformerURIResolver.java
+++ b/mycore-base/src/main/java/org/mycore/common/xml/MCRLayoutTransformerURIResolver.java
@@ -49,7 +49,7 @@ public class MCRLayoutTransformerURIResolver implements URIResolver {
 
     public MCRLayoutTransformerURIResolver() {
         layoutTransformerFactory = MCRConfiguration2.getInstanceOfOrThrow(MCRLayoutTransformerFactory.class,
-            "MCR.Layout.Transformer.Factory.Class");
+            "MCR.Layout.Transformer.Factory");
     }
 
     /**

--- a/mycore-base/src/main/java/org/mycore/common/xsl/uriresolver/MCRURIResolver.java
+++ b/mycore-base/src/main/java/org/mycore/common/xsl/uriresolver/MCRURIResolver.java
@@ -87,7 +87,7 @@ public class MCRURIResolver implements URIResolver {
 
     private static MCRURIResolverProvider getExternalResolverProvider() {
         return MCRConfiguration2
-            .getInstanceOf(MCRURIResolverProvider.class, CONFIG_PREFIX + "ExternalResolver.Class")
+            .getInstanceOf(MCRURIResolverProvider.class, CONFIG_PREFIX + "ExternalResolver")
             .orElse(HashMap::new);
     }
 


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3688).

The refactoring in #2951 (commit `ff2b30a72c`, step "fix: add missing .Class") added a `.Class` suffix to two configurable-instance lookups that already receive the suffix implicitly via `MCRInstanceName.of(...)`. This deviates from the convention used by the other refactored resolvers (e.g. `MCRXSLIncludeURIResolver`), which pass the property name **without** the `.Class` suffix. The resolved property (`...Class`) is identical either way, so there is no behavioral change — this only restores consistency.

Fixed call sites:
- `MCRURIResolver#getExternalResolverProvider` → `MCR.URIResolver.ExternalResolver` (was `...ExternalResolver.Class`)
- `MCRLayoutTransformerURIResolver` constructor → `MCR.Layout.Transformer.Factory` (was `...Factory.Class`)

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [ ] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`2026.06.x`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [x] Does this change affect existing applications, data, or configurations?
  - [ ] No migration required; the looked-up property (`...Class`) is unchanged.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] No existing tests were modified.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [x] If the **public API** has changed:
  - [x] No public API change.
- [x] Java license headers are added where necessary.
- [x] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [x] All configuration options are documented in Javadoc and `mycore.properties`.
- [x] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [x] Is an equivalent PR in `MIR` required?
  - [ ] No.
