### PR TITLE
MCR-3714 Additional MCRSolrFileIndexAccumulator of application module cannot not be found when using CLI

### DIFF
--- a/mycore-solr/src/main/java/org/mycore/solr/index/file/MCRSolrPathDocumentFactory.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/index/file/MCRSolrPathDocumentFactory.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.common.SolrInputDocument;
+import org.mycore.common.MCRClassTools;
 import org.mycore.common.MCRPersistenceException;
 import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.config.MCRConfigurationException;
@@ -61,7 +62,7 @@ public class MCRSolrPathDocumentFactory {
             .flatMap(MCRConfiguration2::splitValue)
             .map((accumulatorClassRef) -> {
                 try {
-                    Class<? extends MCRSolrFileIndexAccumulator> accumulatorClass = Class
+                    Class<? extends MCRSolrFileIndexAccumulator> accumulatorClass = MCRClassTools
                         .forName(accumulatorClassRef)
                         .asSubclass(MCRSolrFileIndexAccumulator.class);
 


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3714).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
