### PR TITLE
MCR-3716 disallow Solr-internal _forwardedCount parameter in MCRSolrProxyServlet

### DIFF
--- a/mycore-solr/src/main/resources/components/solr/config/mycore.properties
+++ b/mycore-solr/src/main/resources/components/solr/config/mycore.properties
@@ -146,7 +146,7 @@ MCR.Solr.AddDerivates.Fields=id,returnId,derivateMaindoc,iviewFile,derivateType
 #MCR.Solr.Disallowed.Facets=
 
 # comma separated list of disallowed parameters the proxy servlet will not forward to solr
-#MCR.Solr.Proxy.Disallowed.Parameter=
+MCR.Solr.Proxy.Disallowed.Parameter=_forwardedCount
 
 # mapper, that retrieves an MCRObjectID from string 
 #MCR.Object.IDMapper.Class=org.mycore.solr.idmapper.MCRSolrIDMapper


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3716).

Ship `_forwardedCount` as the default value of `MCR.Solr.Proxy.Disallowed.Parameter` so the proxy strips it before forwarding a request to Solr. In a SolrCloud setup `_forwardedCount` is a Solr-internal node-to-node forwarding loop guard; `MCRSolrProxyServlet` echoes request parameters back into the rendered result page (e.g. pagination links), so the client resends it and the proxy forwards it to Solr again, breaking operation in a SolrCloud cluster. Filtering already exists since MCR-3595 (`MCRSolrProxyServlet#filterParams`); this only adds the sensible default value.

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`2024.06.x`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [x] Does this change affect existing applications, data, or configurations?
  - [x] Yes: it changes the default of `MCR.Solr.Proxy.Disallowed.Parameter`. No migration required; applications that already override this property keep their value.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible). — not feasible for a property default value.

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [x] If not, no action needed.
- [ ] Java license headers are added where necessary. — no Java change.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code). — no Java change.
- [x] All configuration options are documented in Javadoc and `mycore.properties`.
- [x] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
