### PR TITLE
MCR-3717 Fix NPE in MCRORCIDWorkSummaryUtils when WorkSummary has no external identifiers

### DIFF
--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/v3/work/MCRORCIDWorkSummaryUtils.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/v3/work/MCRORCIDWorkSummaryUtils.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.jdom2.Element;
@@ -76,11 +75,7 @@ public class MCRORCIDWorkSummaryUtils {
             return Stream.empty();
         }
         return workSummaries.stream()
-            .filter(
-                w -> hasMatch(
-                    w.getExternalIdentifiers().getExternalIdentifier().stream()
-                        .map(i -> new MCRIdentifier(i.getType(), i.getValue())).collect(Collectors.toSet()),
-                    identifiers));
+            .filter(w -> hasMatch(MCRORCIDWorkUtils.toMCRIdentifiers(w.getExternalIdentifiers()), identifiers));
     }
 
     /**

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/v3/work/MCRORCIDWorkUtils.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/v3/work/MCRORCIDWorkUtils.java
@@ -20,6 +20,7 @@ package org.mycore.orcid2.v3.work;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -89,6 +90,21 @@ public class MCRORCIDWorkUtils {
         return work.getExternalIdentifiers().getExternalIdentifier().stream()
             .filter(i -> Objects.equals(i.getRelationship(), Relationship.SELF))
             .filter(i -> MCRORCIDUtils.checkTrustedIdentifier(i.getType()))
+            .map(i -> new MCRIdentifier(i.getType(), i.getValue())).collect(Collectors.toSet());
+    }
+
+    /**
+     * Converts {@link ExternalIDs} to a Set of {@link MCRIdentifier}.
+     * A work may have no external identifiers at all, in which case ORCID returns {@code null}.
+     *
+     * @param externalIDs the ExternalIDs, may be {@code null}
+     * @return Set of MCRIdentifier, empty if externalIDs is {@code null}
+     */
+    static Set<MCRIdentifier> toMCRIdentifiers(ExternalIDs externalIDs) {
+        if (externalIDs == null) {
+            return new HashSet<>();
+        }
+        return externalIDs.getExternalIdentifier().stream()
             .map(i -> new MCRIdentifier(i.getType(), i.getValue())).collect(Collectors.toSet());
     }
 


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3717).

## Summary

`MCRORCIDWorkSummaryUtils.findMatchingSummariesByIdentifiers` dereferences `WorkSummary.getExternalIdentifiers().getExternalIdentifier()` without a null check. ORCID returns `null` from `getExternalIdentifiers()` for works without any external identifier (e.g. a work with only a title, no DOI/ISBN), causing a `NullPointerException` when the ORCID work event handler iterates over all works in the author's profile (e.g. on object delete).

Minimal, bugfix-only change: a null-safe `MCRORCIDWorkUtils.toMCRIdentifiers(ExternalIDs)` helper (empty set on `null`) is used in `findMatchingSummariesByIdentifiers` instead of dereferencing `getExternalIdentifiers()` directly. No other methods are touched. A work without external identifiers can never match by identifier, so filtering it out is semantically correct.

This is the oldest fix branch (`2023.06.x`); it will be merged up to the newer branches separately.

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (here: `2023.06.x`, plus the branches it is merged up into).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation). _(N/A — bugfix)_
- [ ] For UI changes: before & after screenshots are attached. _(N/A — no UI change)_
- [ ] New features or migrations are documented. _(N/A)_
- [x] Does this change affect existing applications, data, or configurations? **No.**
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible). _(not yet — see note below)_

## Testing
- [ ] I have tested the changes locally. _(module `mycore-orcid2` compiles; not yet runtime-tested against a live ORCID profile)_
- [ ] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [x] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [x] If not, no action needed. _(new helper is package-private; no public API change)_
- [x] Java license headers are added where necessary. _(no new files)_
- [x] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [x] All configuration options are documented in Javadoc and `mycore.properties`. _(N/A — no config)_
- [x] No default properties are hardcoded — all set via `mycore.properties`. _(N/A — no config)_

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required? **No.**
  - [ ] If yes, is it already created?
