### PR TITLE
MCR-3662 Change of servstate is not recognized as metadata change

### DIFF
--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/MCRORCIDUtils.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/MCRORCIDUtils.java
@@ -78,10 +78,11 @@ public class MCRORCIDUtils {
      * Checks if MCRObjects' state is ready to publish.
      *
      * @param object the MCRObject
-     * @return true if state is ready to publish or there is not state
+     * @return true if state is ready to publish or there is not a state present
      */
     public static boolean checkPublishState(MCRObject object) {
-        return getStateValue(object).map(MCRORCIDUtils::checkPublishState).orElse(true);
+        String stateValue = getStateValue(object);
+        return stateValue == null ? true : checkPublishState(stateValue);
     }
 
     /**
@@ -207,7 +208,14 @@ public class MCRORCIDUtils {
         return new MCRIdentifier(element.getAttributeValue("type"), element.getTextTrim());
     }
 
-    public static Optional<String> getStateValue(MCRObject object) {
-        return Optional.ofNullable(object.getService().getState()).map(MCRCategoryID::getId);
+    /**
+     * Retrieves the state value of the given {@link MCRObject}.
+     *
+     * @param object the {@link MCRObject} whose state value is to be retrieved
+     * @return the category id value of the object's state as a {@code String}, or {@code null} if no state is available
+     */
+    public static String getStateValue(MCRObject object) {
+        Optional<String> v = Optional.ofNullable(object.getService().getState()).map(MCRCategoryID::getId);
+        return v.isPresent() ? v.get() : null;
     }
 }

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/MCRORCIDUtils.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/MCRORCIDUtils.java
@@ -215,7 +215,6 @@ public class MCRORCIDUtils {
      * @return the category id value of the object's state as a {@code String}, or {@code null} if no state is available
      */
     public static String getStateValue(MCRObject object) {
-        Optional<String> v = Optional.ofNullable(object.getService().getState()).map(MCRCategoryID::getId);
-        return v.isPresent() ? v.get() : null;
+        return Optional.ofNullable(object.getService().getState()).map(MCRCategoryID::getId).orElse(null);
     }
 }

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/MCRORCIDUtils.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/MCRORCIDUtils.java
@@ -207,7 +207,7 @@ public class MCRORCIDUtils {
         return new MCRIdentifier(element.getAttributeValue("type"), element.getTextTrim());
     }
 
-    private static Optional<String> getStateValue(MCRObject object) {
+    public static Optional<String> getStateValue(MCRObject object) {
         return Optional.ofNullable(object.getService().getState()).map(MCRCategoryID::getId);
     }
 }

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
@@ -89,12 +89,6 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
     private static final boolean SAVE_OTHER_PUT_CODES = MCRConfiguration2
         .getBoolean("MCR.ORCID2.Metadata.WorkInfo.SaveOtherPutCodes").orElse(false);
 
-    /**
-     * The list of states when an object is ready to be published to ORCID.
-     * */
-    private static final List<String> PUBLISH_STATES = MCRConfiguration2.getOrThrow("MCR.ORCID2.Work.PublishStates",
-        MCRConfiguration2::splitValue).toList();
-
     @Override
     protected void handleObjectCreated(MCREvent evt, MCRObject object) {
         handlePublication(object);
@@ -153,13 +147,13 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
         if (MCRMetadataManager.exists(objectID)) {
             final MCRObject outdatedObject = MCRMetadataManager.retrieveMCRObject(objectID);
 
-            boolean changedStateToPublished = changedToPublished(MCRORCIDUtils.getStateValue(object),
+            boolean stateChanged = statesDiffer(MCRORCIDUtils.getStateValue(object),
                 MCRORCIDUtils.getStateValue(outdatedObject));
 
             boolean changedMetadata = MCRXMLHelper.deepEqual(new MCRMODSWrapper(object).getMODS(),
                 new MCRMODSWrapper(outdatedObject).getMODS());
 
-            if (!changedMetadata && !changedStateToPublished) {
+            if (!changedMetadata && !stateChanged) {
                 LOGGER.info("Neither metadata nor state of publication changed. Skipping {}...", objectID);
                 tryCollectAndSaveExternalPutCodes(filteredObject);
                 return;
@@ -205,7 +199,7 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
         }
     }
 
-    private boolean changedToPublished(Optional<String> newState, Optional<String> oldState) {
+    private boolean statesDiffer(Optional<String> newState, Optional<String> oldState) {
         if (!newState.isPresent() || !oldState.isPresent()) {
             return false;
         }
@@ -213,7 +207,7 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
         String s1 = newState.get();
         String s2 = oldState.get();
 
-        return PUBLISH_STATES.contains(s1) && !s1.equals(s2);
+        return !s1.equals(s2);
     }
 
     private void deleteWorks(Map<String, MCRORCIDUser> userOrcidPair, Set<MCRIdentifier> identifiers,

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
@@ -160,7 +160,7 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
                 new MCRMODSWrapper(outdatedObject).getMODS());
 
             if (!changedMetadata && !changedStateToPublished) {
-                LOGGER.info("Metadata did not change. Skipping {}...", objectID);
+                LOGGER.info("Neither metadata nor state of publication changed. Skipping {}...", objectID);
                 tryCollectAndSaveExternalPutCodes(filteredObject);
                 return;
             }

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
@@ -147,7 +147,7 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
         if (MCRMetadataManager.exists(objectID)) {
             final MCRObject outdatedObject = MCRMetadataManager.retrieveMCRObject(objectID);
 
-            boolean stateChanged = statesDiffer(MCRORCIDUtils.getStateValue(object),
+            boolean stateChanged = !Objects.equals(MCRORCIDUtils.getStateValue(object),
                 MCRORCIDUtils.getStateValue(outdatedObject));
 
             boolean changedMetadata = MCRXMLHelper.deepEqual(new MCRMODSWrapper(object).getMODS(),
@@ -197,10 +197,6 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
                 LOGGER.warn("Error while setting ORCID flag content to {}.", objectID, e);
             }
         }
-    }
-
-    private boolean statesDiffer(String newState, String oldState) {
-        return !Objects.equals(newState, oldState);
     }
 
     private void deleteWorks(Map<String, MCRORCIDUser> userOrcidPair, Set<MCRIdentifier> identifiers,

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
@@ -89,6 +89,12 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
     private static final boolean SAVE_OTHER_PUT_CODES = MCRConfiguration2
         .getBoolean("MCR.ORCID2.Metadata.WorkInfo.SaveOtherPutCodes").orElse(false);
 
+    /**
+     * The list of states when an object is ready to be published to ORCID.
+     * */
+    private static final List<String> PUBLISH_STATES = MCRConfiguration2.getOrThrow("MCR.ORCID2.Work.PublishStates",
+        MCRConfiguration2::splitValue).toList();
+
     @Override
     protected void handleObjectCreated(MCREvent evt, MCRObject object) {
         handlePublication(object);
@@ -146,9 +152,15 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
         }
         if (MCRMetadataManager.exists(objectID)) {
             final MCRObject outdatedObject = MCRMetadataManager.retrieveMCRObject(objectID);
-            if (MCRXMLHelper.deepEqual(new MCRMODSWrapper(object).getMODS(),
-                new MCRMODSWrapper(outdatedObject).getMODS())) {
-                LOGGER.info("Metadata does not changed. Skipping {}...", objectID);
+
+            boolean changedStateToPublished = changedToPublished(MCRORCIDUtils.getStateValue(object),
+                MCRORCIDUtils.getStateValue(outdatedObject));
+
+            boolean changedMetadata = MCRXMLHelper.deepEqual(new MCRMODSWrapper(object).getMODS(),
+                new MCRMODSWrapper(outdatedObject).getMODS());
+
+            if (!changedMetadata && !changedStateToPublished) {
+                LOGGER.info("Metadata did not change. Skipping {}...", objectID);
                 tryCollectAndSaveExternalPutCodes(filteredObject);
                 return;
             }
@@ -191,6 +203,17 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
                 LOGGER.warn("Error while setting ORCID flag content to {}.", objectID, e);
             }
         }
+    }
+
+    private boolean changedToPublished(Optional<String> newState, Optional<String> oldState) {
+        if (!newState.isPresent() || !oldState.isPresent()) {
+            return false;
+        }
+
+        String s1 = newState.get();
+        String s2 = oldState.get();
+
+        return PUBLISH_STATES.contains(s1) && !s1.equals(s2);
     }
 
     private void deleteWorks(Map<String, MCRORCIDUser> userOrcidPair, Set<MCRIdentifier> identifiers,

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
@@ -200,7 +200,7 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
     }
 
     private boolean statesDiffer(String newState, String oldState) {
-        return newState != null && !newState.equals(oldState);
+        return !Objects.equals(newState, oldState);
     }
 
     private void deleteWorks(Map<String, MCRORCIDUser> userOrcidPair, Set<MCRIdentifier> identifiers,

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
@@ -199,15 +199,8 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
         }
     }
 
-    private boolean statesDiffer(Optional<String> newState, Optional<String> oldState) {
-        if (!newState.isPresent() || !oldState.isPresent()) {
-            return false;
-        }
-
-        String s1 = newState.get();
-        String s2 = oldState.get();
-
-        return !s1.equals(s2);
+    private boolean statesDiffer(String newState, String oldState) {
+        return newState != null && !newState.equals(oldState);
     }
 
     private void deleteWorks(Map<String, MCRORCIDUser> userOrcidPair, Set<MCRIdentifier> identifiers,


### PR DESCRIPTION
[MCR-3662](https://mycore.atlassian.net/browse/MCR-3662).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [ ] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [x] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [x] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?


[MCR-3662]: https://mycore.atlassian.net/browse/MCR-3662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ