### PR TITLE
MCR-3724 Fix command order in MCRJobQueueCommands so reset with id/action works

### DIFF
--- a/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/MCRJobQueueCommands.java
+++ b/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/MCRJobQueueCommands.java
@@ -65,7 +65,7 @@ public class MCRJobQueueCommands {
     @MCRCommand(
         syntax = "reset max try jobs",
         help = "Reset all jobs with status MAX_TRIES to status NEW",
-        order = 20)
+        order = 40)
     public static void resetMaxTryJobs() {
         EntityManager em = MCREntityManagerProvider.getCurrentEntityManager();
         int count = em
@@ -85,7 +85,7 @@ public class MCRJobQueueCommands {
     @MCRCommand(
         syntax = "reset max try jobs with action {0}",
         help = "Reset all jobs with status MAX_TRIES and action {0} to status NEW",
-        order = 30)
+        order = 20)
     public static void resetMaxTryJobsWithAction(String action) {
         if (action == null || action.isEmpty()) {
             LOGGER.error("Action is required!");
@@ -110,7 +110,7 @@ public class MCRJobQueueCommands {
     @MCRCommand(
         syntax = "reset max try jobs with id {0}",
         help = "reset all jobs with status MAX_TRIES and id {0} to status NEW",
-        order = 40)
+        order = 30)
     public static void resetMaxTryJobsWithId(String id) {
         if (id == null || id.isEmpty()) {
             LOGGER.error("Id is required!");


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3724).

## Problem

`reset max try jobs with id {0}` and `reset max try jobs with action {0}` never executed their intended behaviour. Entering e.g. `reset max try jobs with id 4711` silently reset **all** `MAX_TRIES` jobs (the behaviour of the bare `reset max try jobs` command) and ignored the `id`/`action` argument.

## Root cause

The CLI tries commands in ascending `@MCRCommand(order = ...)` and runs the first whose syntax matches. `MCRCommand.invoke` only checks `input.startsWith(suffix)` plus `MessageFormat.parse`, which does **not** require the whole input to be consumed. The bare `reset max try jobs` (`order = 20`, no arguments) therefore matched the parameterized inputs first, because its `order` was lower than the `with action`/`with id` variants.

## Fix

Reorder only the `@MCRCommand(order = ...)` values so the parameterized commands are tried before the unparameterized one (`with action` → 20, `with id` → 30, bare `reset max try jobs` → 40). Three lines changed, no refactoring.

# Pull Request Checklist (Author)

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`2023.06.x`).

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally (`CI=true mvn -pl mycore-jobqueue -am clean install` passes).
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified? — No.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [x] Public API has **not** changed.
- [x] Java license headers are present (file unchanged in that respect).

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required? — No.
