### PR TITLE
MCR-3119 Fix work contributor restriction and disable it by default

### DIFF
--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/v3/work/MCRORCIDWorkEventHandlerImpl.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/v3/work/MCRORCIDWorkEventHandlerImpl.java
@@ -77,9 +77,12 @@ public class MCRORCIDWorkEventHandlerImpl extends MCRORCIDWorkEventHandler<Work>
 
     @Override
     protected List<String> listRelatedOrcidIdentifiers(Work work) {
-        return work.getWorkContributors().getContributor().stream().filter(c -> c.getContributorOrcid() != null)
-            .filter(c -> c.getContributorAttributes() != null)
-            .filter(c -> c.getContributorAttributes().getContributorRole() != null)
-            .map(c -> c.getContributorOrcid().getPath()).toList();
+        if (work.getWorkContributors() != null && work.getWorkContributors().getContributor() != null) {
+            return work.getWorkContributors().getContributor().stream().filter(c -> c.getContributorOrcid() != null)
+                .filter(c -> c.getContributorAttributes() != null)
+                .filter(c -> c.getContributorAttributes().getContributorRole() != null)
+                .map(c -> c.getContributorOrcid().getPath()).toList();
+        }
+        return List.of();
     }
 }

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
@@ -154,8 +154,16 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
         toPublish.putAll(userOrcidPairFromObject);
         toPublish.keySet().removeAll(toDelete.keySet());
         final T work = transformObject(new MCRJDOMContent(filteredObject.createXML()));
-        if (RESTRICT_TO_WORK_CONTRIBUTORS) {
-            toPublish.keySet().retainAll(listRelatedOrcidIdentifiers(work));
+
+        if (toPublish.isEmpty()) {
+            LOGGER.debug("Publication work for {} has no contributors. "
+                + "Won't evaluate contributor mapping.", objectID);
+        } else if (RESTRICT_TO_WORK_CONTRIBUTORS) {
+            final List<String> relatedOrcids = listRelatedOrcidIdentifiers(work);
+            if (relatedOrcids.isEmpty()) {
+                LOGGER.info("Publication work for {} has no mapped contributors. ", objectID);
+            }
+            toPublish.keySet().retainAll(relatedOrcids);
         }
         if (toDelete.isEmpty() && toPublish.isEmpty()) {
             LOGGER.info("Nothing to delete or publish. Skipping {}...", objectID);

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
@@ -168,19 +168,17 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
                         "No mapped contributors and therefore no profiles found for publication work {}.",
                         objectID
                     );
-                } else {
-                    toPublish.keySet().retainAll(relatedOrcids);
                 }
+                toPublish.keySet().retainAll(relatedOrcids);
             }
         }
         if (toDelete.isEmpty() && toPublish.isEmpty()) {
             LOGGER.info("Nothing to delete or publish. Skipping {}...", objectID);
             tryCollectAndSaveExternalPutCodes(filteredObject);
             return;
-        } else {
-            LOGGER.info("Found {} profiles to publish.", toPublish.size());
-            LOGGER.info("Found {} profiles to delete.", toDelete.size());
         }
+        LOGGER.info("Found {} profiles to publish.", toPublish.size());
+        LOGGER.info("Found {} profiles to delete.", toDelete.size());
         try {
             final Set<MCRIdentifier> identifiers = listTrustedIdentifiers(work);
             if (!toDelete.isEmpty()) {

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
@@ -155,20 +155,31 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
         toPublish.keySet().removeAll(toDelete.keySet());
         final T work = transformObject(new MCRJDOMContent(filteredObject.createXML()));
 
-        if (toPublish.isEmpty()) {
-            LOGGER.debug("Publication work for {} has no contributors. "
-                + "Won't evaluate contributor mapping.", objectID);
-        } else if (RESTRICT_TO_WORK_CONTRIBUTORS) {
-            final List<String> relatedOrcids = listRelatedOrcidIdentifiers(work);
-            if (relatedOrcids.isEmpty()) {
-                LOGGER.info("Publication work for {} has no mapped contributors. ", objectID);
+        if (RESTRICT_TO_WORK_CONTRIBUTORS) {
+            if (toPublish.isEmpty()) {
+                LOGGER.debug(
+                    "No profiles found to publish for publication work {}. Ignoring contributor mapping...",
+                    objectID
+                );
+            } else {
+                final List<String> relatedOrcids = listRelatedOrcidIdentifiers(work);
+                if (relatedOrcids.isEmpty()) {
+                    LOGGER.debug(
+                        "No mapped contributors and therefore no profiles found for publication work {}.",
+                        objectID
+                    );
+                } else {
+                    toPublish.keySet().retainAll(relatedOrcids);
+                }
             }
-            toPublish.keySet().retainAll(relatedOrcids);
         }
         if (toDelete.isEmpty() && toPublish.isEmpty()) {
             LOGGER.info("Nothing to delete or publish. Skipping {}...", objectID);
             tryCollectAndSaveExternalPutCodes(filteredObject);
             return;
+        } else {
+            LOGGER.info("Found {} profiles to publish.", toPublish.size());
+            LOGGER.info("Found {} profiles to delete.", toDelete.size());
         }
         try {
             final Set<MCRIdentifier> identifiers = listTrustedIdentifiers(work);

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
@@ -69,8 +69,13 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
+    private static final String CONF_PREFIX = "MCR.ORCID2.WorkEventHandler.";
+
     private static final boolean COLLECT_EXTERNAL_PUT_CODES = MCRConfiguration2
-        .getBoolean("MCR.ORCID2.WorkEventHandler.CollectExternalPutCodes").orElse(false);
+        .getBoolean(CONF_PREFIX + "CollectExternalPutCodes").orElse(false);
+
+    private static final boolean RESTRICT_TO_WORK_CONTRIBUTORS = MCRConfiguration2
+        .getBoolean(CONF_PREFIX + "RestrictToWorkContributors").orElse(false);
 
     private static final boolean SAVE_OTHER_PUT_CODES = MCRConfiguration2
         .getBoolean("MCR.ORCID2.Metadata.WorkInfo.SaveOtherPutCodes").orElse(false);
@@ -149,7 +154,9 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
         toPublish.putAll(userOrcidPairFromObject);
         toPublish.keySet().removeAll(toDelete.keySet());
         final T work = transformObject(new MCRJDOMContent(filteredObject.createXML()));
-        toPublish.keySet().removeAll(listRelatedOrcidIdentifiers(work));
+        if (RESTRICT_TO_WORK_CONTRIBUTORS) {
+            toPublish.keySet().retainAll(listRelatedOrcidIdentifiers(work));
+        }
         if (toDelete.isEmpty() && toPublish.isEmpty()) {
             LOGGER.info("Nothing to delete or publish. Skipping {}...", objectID);
             tryCollectAndSaveExternalPutCodes(filteredObject);

--- a/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
+++ b/mycore-orcid2/src/main/java/org/mycore/orcid2/work/MCRORCIDWorkEventHandler.java
@@ -71,14 +71,17 @@ public abstract class MCRORCIDWorkEventHandler<T> extends MCREventHandlerBase {
 
     private static final String CONF_PREFIX = "MCR.ORCID2.WorkEventHandler.";
 
-    private static final boolean COLLECT_EXTERNAL_PUT_CODES = MCRConfiguration2
-        .getBoolean(CONF_PREFIX + "CollectExternalPutCodes").orElse(false);
+    private static final boolean COLLECT_EXTERNAL_PUT_CODES =
+        MCRConfiguration2.getBoolean(CONF_PREFIX + "CollectExternalPutCodes")
+            .orElseThrow(() -> MCRConfiguration2.createConfigurationException(CONF_PREFIX + "CollectExternalPutCodes"));
 
-    private static final boolean RESTRICT_TO_WORK_CONTRIBUTORS = MCRConfiguration2
-        .getBoolean(CONF_PREFIX + "RestrictToWorkContributors").orElse(false);
+    private static final boolean RESTRICT_TO_WORK_CONTRIBUTORS =
+        MCRConfiguration2.getBoolean(CONF_PREFIX + "RestrictToWorkContributors").orElseThrow(
+            () -> MCRConfiguration2.createConfigurationException(CONF_PREFIX + "RestrictToWorkContributors"));
 
-    private static final boolean SAVE_OTHER_PUT_CODES = MCRConfiguration2
-        .getBoolean("MCR.ORCID2.Metadata.WorkInfo.SaveOtherPutCodes").orElse(false);
+    private static final boolean SAVE_OTHER_PUT_CODES =
+        MCRConfiguration2.getBoolean("MCR.ORCID2.Metadata.WorkInfo.SaveOtherPutCodes").orElseThrow(
+            () -> MCRConfiguration2.createConfigurationException("MCR.ORCID2.Metadata.WorkInfo.SaveOtherPutCodes"));
 
     @Override
     protected void handleObjectCreated(MCREvent evt, MCRObject object) {

--- a/mycore-orcid2/src/main/resources/components/orcid2/config/mycore.properties
+++ b/mycore-orcid2/src/main/resources/components/orcid2/config/mycore.properties
@@ -76,6 +76,9 @@ MCR.ORCID2.API.Resource.Packages=org.mycore.orcid2.rest.resources
 # of users that have authorized us as trusted party
 # and that occur in the publication's metadata (name identifier match)
 #MCR.EventHandler.MCRObject.019.Class=org.mycore.orcid2.v3.work.MCRORCIDWorkEventHandlerImpl
+# Specifies whether works may only be written to profiles that are ultimately considered work contributors.
+# This is derived from the resulting work and may require accurate mapping.
+#MCR.ORCID2.WorkEventHandler.RestrictToWorkContributors=false
 # Specifies whether a work in a profile should continously be updated once it has been created by the application.
 #MCR.ORCID2.WorkEventHandler.AlwaysUpdateWork=true
 # Specifies whether a work should be created in a profile even if a matching work created from an other application is already present.

--- a/mycore-orcid2/src/main/resources/components/orcid2/config/mycore.properties
+++ b/mycore-orcid2/src/main/resources/components/orcid2/config/mycore.properties
@@ -78,7 +78,7 @@ MCR.ORCID2.API.Resource.Packages=org.mycore.orcid2.rest.resources
 #MCR.EventHandler.MCRObject.019.Class=org.mycore.orcid2.v3.work.MCRORCIDWorkEventHandlerImpl
 # Specifies whether works may only be written to profiles that are ultimately considered work contributors.
 # This is derived from the resulting work and may require accurate mapping.
-#MCR.ORCID2.WorkEventHandler.RestrictToWorkContributors=false
+MCR.ORCID2.WorkEventHandler.RestrictToWorkContributors=false
 # Specifies whether a work in a profile should continously be updated once it has been created by the application.
 #MCR.ORCID2.WorkEventHandler.AlwaysUpdateWork=true
 # Specifies whether a work should be created in a profile even if a matching work created from an other application is already present.
@@ -88,7 +88,7 @@ MCR.ORCID2.API.Resource.Packages=org.mycore.orcid2.rest.resources
 # Specifies whether an outdated work should recreated.
 #MCR.ORCID2.WorkEventHandler.RecreateDeletedWork=false
 # Specifies whether external put codes should be saved in ORCID servflag. Requieres MCR.ORCID2.Metadata.WorkInfo.SaveOtherPutCodes=true
-#MCR.ORCID2.WorkEventHandler.CollectExternalPutCodes=false
+MCR.ORCID2.WorkEventHandler.CollectExternalPutCodes=false
 
 # Specifies the state when an object is ready to be published to ORCID. '*' is wildcard
 MCR.ORCID2.Work.PublishStates=published,

--- a/mycore-orcid2/src/main/resources/xslt/orcid2/orcid-object-filter.xsl
+++ b/mycore-orcid2/src/main/resources/xslt/orcid2/orcid-object-filter.xsl
@@ -4,7 +4,7 @@
   xmlns:mods="http://www.loc.gov/mods/v3"
   exclude-result-prefixes="xsl">
 
-  <xsl:include href="copynodes.xsl" />
+  <xsl:mode on-no-match="shallow-copy" />
 
   <xsl:template match="/">
     <xsl:apply-templates />


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3119).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [ ] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [ ] I have tested the changes locally.
- [ ] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [x] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [x] All configuration options are documented in Javadoc and `mycore.properties`.
- [x] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
