### PR TITLE
MCR-3726 fix MCRBuildXMLURIResolver dropping _rootName_ and parameters

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/xml/MCRBuildXMLURIResolver.java
+++ b/mycore-base/src/main/java/org/mycore/common/xml/MCRBuildXMLURIResolver.java
@@ -74,7 +74,7 @@ public class MCRBuildXMLURIResolver implements URIResolver {
         String key = href.substring(href.indexOf(':') + 1);
         LOGGER.debug("Building xml from {}", key);
 
-        Map<String, String> params = MCRURIResolverHelper.parseQueryParameters(href);
+        Map<String, String> params = MCRURIResolverHelper.parseQueryParameters(key);
 
         Element defaultRoot = new Element("root");
         Element root = defaultRoot;

--- a/mycore-base/src/test/java/org/mycore/common/xml/MCRBuildXMLURIResolverTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/xml/MCRBuildXMLURIResolverTest.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.xml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import javax.xml.transform.Source;
+
+import org.jdom2.Element;
+import org.jdom2.transform.JDOMSource;
+import org.junit.jupiter.api.Test;
+import org.mycore.common.MCRConstants;
+import org.mycore.test.MyCoReTest;
+
+@MyCoReTest
+public class MCRBuildXMLURIResolverTest {
+
+    /**
+     * Regression test for MCR-3726: the scheme prefix must be stripped before the query is parsed,
+     * otherwise {@code _rootName_} and all parameters are lost.
+     */
+    @Test
+    public void resolveBuildsRootWithNamespacedChildAndAttribute() {
+        Source source = new MCRBuildXMLURIResolver().resolve(
+            "buildxml:_rootName_=mods:mods&mods:identifier=10.1000/xyz&mods:identifier/@type=doi", null);
+
+        Element root = (Element) ((JDOMSource) source).getNodes().getFirst();
+
+        assertNotNull(root);
+        assertEquals("mods", root.getName());
+        assertEquals(MCRConstants.MODS_NAMESPACE, root.getNamespace());
+
+        Element identifier = root.getChild("identifier", MCRConstants.MODS_NAMESPACE);
+        assertNotNull(identifier);
+        assertEquals("10.1000/xyz", identifier.getText());
+        assertEquals("doi", identifier.getAttributeValue("type"));
+    }
+
+}


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3726).

`MCRBuildXMLURIResolver` parsed the full `href` (including the `buildxml:` scheme prefix) instead of the query part. As a result the first parameter key became e.g. `buildxml:_rootName_` instead of `_rootName_`, so `_rootName_` was no longer recognized and the built XML was wrong (only the bogus first child was returned). Regression from the URI resolver refactoring (MCR-3688). In MIR this broke the metadata import build chain, so DOI/PPN imports lost all metadata (MIR-1600).

Fix: parse `key` (scheme stripped) instead of `href`.

# Pull Request Checklist (Author)

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch. **Note: target branch is `2026.06.x`, not `main`.**

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [x] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket (DOI import works again).
- [ ] Were existing tests modified? No, a new regression test was added.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [x] Java license headers are added where necessary.

## Multi-Repo Considerations
- [x] Is an equivalent PR in `MIR` required? No — the bug is in MyCoRe; MIR is fixed transitively.
