### PR TITLE
MCR-3727 migrate WCMS2 provider properties to .Class suffix

### DIFF
--- a/mycore-wcms2/src/main/resources/components/wcms2/config/deprecated.properties
+++ b/mycore-wcms2/src/main/resources/components/wcms2/config/deprecated.properties
@@ -1,1 +1,3 @@
- MCR.WCMS2.navigationProvider= MCR.WCMS2.NavigationProvider
+MCR.WCMS2.navigationProvider=MCR.WCMS2.NavigationProvider.Class
+MCR.WCMS2.NavigationProvider=MCR.WCMS2.NavigationProvider.Class
+MCR.WCMS2.sectionProvider=MCR.WCMS2.sectionProvider.Class

--- a/mycore-wcms2/src/main/resources/components/wcms2/config/mycore.properties
+++ b/mycore-wcms2/src/main/resources/components/wcms2/config/mycore.properties
@@ -5,8 +5,8 @@
 MCR.NavigationFile.SaveInOldFormat = true
 
 MCR.WCMS2.DataDir=%MCR.Save.FileSystem%/webpages
-MCR.WCMS2.sectionProvider=org.mycore.wcms2.navigation.MCRWCMSDefaultSectionProvider
-MCR.WCMS2.NavigationProvider=org.mycore.wcms2.navigation.MCRWCMSDefaultNavigationProvider
+MCR.WCMS2.sectionProvider.Class=org.mycore.wcms2.navigation.MCRWCMSDefaultSectionProvider
+MCR.WCMS2.NavigationProvider.Class=org.mycore.wcms2.navigation.MCRWCMSDefaultNavigationProvider
 
 MCR.Jersey.Resource.Packages=%MCR.Jersey.Resource.Packages%,org.mycore.wcms2.resources
 MCR.LayoutTransformerFactory.Default.Ignore=%MCR.LayoutTransformerFactory.Default.Ignore%,wcms2


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3727).

## Problem

Opening WCMS2 failed to start with:

```
org.mycore.common.config.MCRConfigurationException: Configuration property MCR.WCMS2.NavigationProvider is not set.
```

## Root cause

MCR-3670 changed the configured-instance convention so that the implementation class must be configured under the `.Class` suffix. The `mycore-wcms2` component configuration was not migrated and still used the suffix-less property names:

- `MCR.WCMS2.NavigationProvider` (loaded in `MCRWCMSNavigationUtils`)
- `MCR.WCMS2.sectionProvider` (loaded in `MCRWCMSContentManager`)

`MCRConfiguration2.getInstanceOfOrThrow(..., "MCR.WCMS2.NavigationProvider")` now resolves the value class from `MCR.WCMS2.NavigationProvider.Class`, which was unset, so instantiation threw.

Reported downstream in MIR-1596.

## Fix

Rename the properties in `mycore-wcms2` to use the `.Class` suffix and add `deprecated.properties` mappings for the old names so existing overlay configurations keep working:

- `MCR.WCMS2.NavigationProvider` → `MCR.WCMS2.NavigationProvider.Class`
- `MCR.WCMS2.sectionProvider` → `MCR.WCMS2.sectionProvider.Class`

# Pull Request Checklist (Author)

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`2026.06.x`).

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible). — config-only change, covered by existing startup.

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [x] No default properties are hardcoded — all set via `mycore.properties`.
- [x] Deprecated property names are mapped in `deprecated.properties` (migration for existing configs).

## Multi-Repo Considerations
- [x] Is an equivalent PR in `MIR` required? No — the fix lives entirely in `mycore-wcms2`; MIR-1596 is resolved by this change.
