### PR TITLE
MCR-3728 remove redundant intern-genre to marcgt mapping from mods-enhancer.xsl

### DIFF
--- a/mycore-mods/src/main/resources/xslt/utils/mods-enhancer.xsl
+++ b/mycore-mods/src/main/resources/xslt/utils/mods-enhancer.xsl
@@ -101,39 +101,6 @@
   <xsl:template match="mods:location" mode="mods2mods">
   </xsl:template>
 
-  <xsl:template match="mods:genre[@type='intern']" mode="mods2mods">
-    <xsl:choose>
-      <xsl:when test="contains(@valueURI,'#journal')">
-      <!-- additional journals data -->
-        <mods:originInfo eventType="publication">
-          <mods:issuance>continuing</mods:issuance>
-        </mods:originInfo>
-        <mods:genre authority="marcgt">journal</mods:genre>
-      </xsl:when>
-      <xsl:when test="contains(@valueURI,'#article')">
-      <!-- additional journals data -->
-        <mods:genre authority="marcgt">article</mods:genre>
-      </xsl:when>
-      <xsl:when test="contains(@valueURI,'#book')">
-      <!-- additional journals data -->
-        <mods:genre authority="marcgt">book</mods:genre>
-      </xsl:when>
-      <xsl:when
-        test="contains(@valueURI,'thesis') or contains(@valueURI,'#dissertation') or contains(@valueURI,'#habilitation') or contains(@valueURI,'#student_resarch_project')">
-      <!-- additional journals data -->
-        <mods:genre authority="marcgt">thesis</mods:genre>
-      </xsl:when>
-      <xsl:when test="contains(@valueURI,'#confpub')">
-      <!-- additional journals data -->
-        <mods:genre authority="marcgt">conference publication</mods:genre>
-      </xsl:when>
-    </xsl:choose>
-    <xsl:copy>
-      <xsl:copy-of select="@*" />
-      <xsl:apply-templates mode="mods2mods" />
-    </xsl:copy>
-  </xsl:template>
-
   <xsl:template match="mods:role" mode="mods2mods">
     <xsl:copy>
       <xsl:copy-of select="@*" />


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3728).

## Summary

`mods-enhancer.xsl` hard-coded a second marcgt genre for every internal genre (intern -> marcgt table). This duplicates what the classification-mapping mechanism already produces (mapped marcgt classification -> genre via the `mods2mods` chain), so the enhancer emitted a redundant marcgt genre. Downstream this caused duplicate output, e.g. three identical `dc:type` `article` entries in the DC export (MIR-1595).

This PR removes the whole `mods:genre[@type='intern']` template. The internal genre is preserved (it falls through the generic `mods:*` copy template); only the redundant marcgt derivation is gone.

The template also injected `issuance=continuing` for journals (originally added in 2012 to steer the bibutils BibTeX type). This was verified to be irrelevant: bibutils determines the type genre-first and only consults issuance as a fallback, and the BibTeX issuance table does not even contain `continuing` (only `monographic`). The marcgt genre itself keeps coming from the classification mapping (and `mods2bibmods.xsl` still adds `academic journal`). See the ticket for the full code analysis and an empirical `xml2bib` check.

# Pull Request Checklist (Author)

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [ ] The `fixed-version` is correctly set in the ticket and matches the PR's target branch.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced for objects saved through the normal workflow (the mapped marcgt classification is created on save). Legacy objects lacking that classification would lose the marcgt genre — noted in the ticket.

## Testing
- [x] I have tested the changes locally (Saxon reproduction of the DC export: 3x -> 2x `article`; bibutils `xml2bib` 7.2 before/after: identical output).
- [ ] A relevant test was added — not feasible without a fixture for the full mods2mods/classification-mapping chain; the removed template had no dedicated test.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed.
- [x] No public API change, no Java, no new configuration.

## Multi-Repo Considerations
- [x] An equivalent/follow-up change in `MIR` is planned (MIR-1595): a `distinct-values` de-duplication of `dc:type` so the remaining two equal genre representations collapse to one in the DC export.
