### PR TITLE
MCR-3729 SolrProxyServlet does not forward duplicate parameters correctly

### DIFF
--- a/mycore-solr/src/main/java/org/mycore/solr/proxy/MCRSolrProxyServlet.java
+++ b/mycore-solr/src/main/java/org/mycore/solr/proxy/MCRSolrProxyServlet.java
@@ -45,10 +45,10 @@ import javax.xml.transform.TransformerException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.solr.client.solrj.request.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.response.InputStreamResponseParser;
 import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.request.SolrQuery;
+import org.apache.solr.client.solrj.response.InputStreamResponseParser;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.MultiMapSolrParams;
 import org.apache.solr.common.util.NamedList;
@@ -197,7 +197,13 @@ public class MCRSolrProxyServlet extends MCRServlet {
         for (Element param : children) {
             String attribute = param.getAttributeValue("name");
             if (attribute != null) {
-                parameters.put(attribute, new String[] { param.getTextTrim() });
+                String value = param.getTextTrim();
+                parameters.merge(attribute, new String[] { value }, (existing, newVal) -> {
+                    String[] merged = new String[existing.length + 1];
+                    System.arraycopy(existing, 0, merged, 0, existing.length);
+                    merged[existing.length] = newVal[0];
+                    return merged;
+                });
             }
         }
         String queryHandlerPath = parameters.get(QUERY_HANDLER_PAR_NAME)[0];


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3729).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [ ] I have tested the changes locally.
- [ ] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [x] Java license headers are added where necessary.
- [x] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
