### PR TITLE
MCR-3733 Datacite client incompatible with test server

### DIFF
--- a/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteClient.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/doi/client/datacite/MCRDataciteClient.java
@@ -375,7 +375,7 @@ public class MCRDataciteClient {
                 case HttpStatus.SC_CREATED -> {
                     Header[] responseHeaders = response.getAllHeaders();
                     for (Header responseHeader : responseHeaders) {
-                        if (responseHeader.getName().equals("Location")) {
+                        if (responseHeader.getName().equalsIgnoreCase("Location")) {
                             return new URI(responseHeader.getValue());
                         }
                     }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3733).

`MCRDataciteClient#storeMetadata` checks the HTTP headers and, in case of a `201 Created`, expects to see a `Location` (capital `L`) header., However, the Datacite test server responds with headers like:

```
Date: Thu, 18 Jun 2026 17:31:13 GMT
...
location: https://mds.test.datacite.org/metadata/10.83914/2026-00000-7
...
Server: nginx/1.24.0 (Ubuntu) + Phusion Passenger(R) 6.1.5
```

This causes an `MCRDatacenterException` with message `Location header not found in response! - OK (…)` to be thrown.

We need to to compare the header name case insensitively. 

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [X] The issue in the ticket is clearly described and the solution is documented.
- [X] Design decisions (if any) are explained.
- [X] The ticket references the correct source and target branches.
- [X] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Bugfix-Specific Checks
- [X] Affected version is listed in the ticket.
- [X] Minimal code changes were made (no refactoring).
- [X] This PR truly fixes **only** the reported bug.
- [X] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [X] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [ ] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
