### PR TITLE
MCR-3735 Datacite unable to process media URLs with non-ASCII characters

### DIFF
--- a/mycore-pi/src/main/java/org/mycore/pi/doi/MCRDOIService.java
+++ b/mycore-pi/src/main/java/org/mycore/pi/doi/MCRDOIService.java
@@ -246,7 +246,7 @@ public class MCRDOIService extends MCRDOIBaseService {
                 String contentType = Optional.ofNullable(MCRContentTypes.probeContentType(mainDocumentPath))
                     .orElse("application/octet-stream");
                 entryList.add(new AbstractMap.SimpleEntry<>(contentType, new URI(this.registerURL + MCRXMLFunctions
-                    .encodeURIPath("/servlets/MCRFileNodeServlet/" + derivateId + "/" + mainDoc))));
+                    .encodeURIPath("/servlets/MCRFileNodeServlet/" + derivateId + "/" + mainDoc, true))));
             } catch (IOException | URISyntaxException e) {
                 LOGGER.error("Error while detecting the file to register!", e);
             }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3735).

With a main-doc file name like `Täst.pdf`, `MCRDoiService#getMediaList` creates a URL like 
`http://localhost:8080/servlets/MCRFileNodeServlet/fred_derivate_00000005/Täst.pdf`.

However, that causes the Datacite API to fail and report `400 - Bad Request - "\xC3" from ASCII-8BIT to UTF-8`.

The generated URL needs to be ASCII-only, i.e.
`http://localhost:8080/servlets/MCRFileNodeServlet/fred_derivate_00000005/T%C3%A4st.pdf`.

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [X] The issue in the ticket is clearly described and the solution is documented.
- [X] Design decisions (if any) are explained.
- [X] The ticket references the correct source and target branches.
- [X] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Bugfix-Specific Checks
- [X] Affected version is listed in the ticket.
- [X] Minimal code changes were made (no refactoring).
- [X] This PR truly fixes **only** the reported bug.
- [X] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [X] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [ ] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
