### PR TITLE
MCR-3738 Add xsl function to retrive owner id af a derivate

### DIFF
--- a/mycore-base/src/main/resources/xslt/functions/derivate.xsl
+++ b/mycore-base/src/main/resources/xslt/functions/derivate.xsl
@@ -3,6 +3,7 @@
   xmlns:fn="http://www.w3.org/2005/xpath-functions"
   xmlns:mcrderivate="http://www.mycore.de/xslt/derivate"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   exclude-result-prefixes="#all">
 
@@ -11,6 +12,13 @@
         <xsl:variable name="derivate" select="document(concat('mcrobject:', $derivID))" />
         <xsl:variable name="mainFile" select="$derivate/mycorederivate/derivate/internals/internal/@maindoc" />
         <xsl:value-of select="$mainFile" />
+    </xsl:function>
+
+    <xsl:function name="mcrderivate:get-owner-id" as="xs:string">
+      <xsl:param name="derivate-id" as="xs:string" />
+
+      <xsl:variable name="derivate" select="document('mcrobject:' || $derivate-id)" />
+      <xsl:sequence select="string($derivate/mycorederivate/derivate/linkmetas/linkmeta/@xlink:href)" />
     </xsl:function>
 
     <xsl:function name="mcrderivate:get-file-content-type" as="xs:string">


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3738).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [ ] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [ ] Affected version is listed in the ticket.
- [ ] Minimal code changes were made (no refactoring).
- [ ] This PR truly fixes **only** the reported bug.
- [ ] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [x] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
