### PR TITLE
MCR-3741 MCRQueryParser throws StringIndexOutOfBoundsException on a lone single quote in a contains query

### DIFF
--- a/mycore-base/src/main/java/org/mycore/services/fieldquery/MCRQueryParser.java
+++ b/mycore-base/src/main/java/org/mycore/services/fieldquery/MCRQueryParser.java
@@ -240,20 +240,22 @@ public class MCRQueryParser extends MCRBooleanClauseParser<Void> {
                     }
                 } else if (value.startsWith("'")) {
                     // begin of phrase
-                    if (value.endsWith("'")) {
+                    if (value.length() > 1 && value.endsWith("'")) {
                         // one-word phrase
                         values.add(value.substring(1, value.length() - 1));
-                    } else {
+                    } else if (value.length() > 1) {
                         phrase = new StringBuilder(value);
                     }
+                    // else: lone single quote, ignore it
                 } else if (value.startsWith("-'")) {
                     // begin of NOT phrase
-                    if (value.endsWith("'")) {
+                    if (value.length() > 2 && value.endsWith("'")) {
                         // one-word phrase
                         values.add("-" + value.substring(2, value.length() - 1));
-                    } else {
+                    } else if (value.length() > 2) {
                         phrase = new StringBuilder(value);
                     }
+                    // else: lone "-'", ignore it
                 } else {
                     values.add(value);
                 }

--- a/mycore-base/src/test/java/org/mycore/services/fieldquery/MCRQueryParserTest.java
+++ b/mycore-base/src/test/java/org/mycore/services/fieldquery/MCRQueryParserTest.java
@@ -141,4 +141,26 @@ public class MCRQueryParserTest extends MCRTestCase {
             queryStringParsed.toString());
     }
 
+    /**
+     * Test method for a lone single quote in a "contains" condition. A standalone single quote (or "-'") must not
+     * raise a {@link StringIndexOutOfBoundsException} and must not swallow the remaining query terms, but simply be
+     * ignored as noise.
+     */
+
+    @Test
+    public final void testQueryWithLoneSingleQuote() {
+        Element c = new Element("condition");
+        c.setAttribute("field", "title");
+        c.setAttribute("operator", "contains");
+
+        String expected = "(title contains \"this\") AND (title contains \"is\") AND (title contains \"a\") "
+            + "AND (title contains \"test\")";
+
+        c.setAttribute("value", "this ' is a test");
+        assertEquals("Returned value is not", expected, queryParser.parse(c).toString());
+
+        c.setAttribute("value", "this -' is a test");
+        assertEquals("Returned value is not", expected, queryParser.parse(c).toString());
+    }
+
 }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3741).

## What does this PR do?

Fixes a `StringIndexOutOfBoundsException` in `MCRQueryParser.normalizeCondition` when a `contains` query value contains a standalone single quote (e.g. the simple/allMeta search string `this ' is a test`).

**Root cause:** the value is tokenized by whitespace; a lone `'` token (length 1) both starts and ends with `'`, so it is treated as a one-word phrase and stripped via `value.substring(1, value.length() - 1)` → `substring(1, 0)` → exception. Same for a lone `-'` token (length 2). Additionally the lone quote opened a phrase that was never closed, silently swallowing all following terms.

**Fix:** guard the one-word-phrase `substring` calls with a length check and treat a standalone `'` / `-'` token as noise (ignore it), so the remaining terms are preserved. `this ' is a test` now yields `this AND is AND a AND test`. Regression test `MCRQueryParserTest#testQueryWithLoneSingleQuote` added.

Reported downstream in MIR-1624.

# Pull Request Checklist (Author)

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`). _(Target branch is `2023.06.x`; fixed-version includes `2023.06.x` and merges up to `main`.)_

## Feature & Improvement Specific Checks
- [x] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached. _(N/A — no UI change.)_
- [ ] New features or migrations are documented. _(N/A — bugfix.)_
- [x] Does this change affect existing applications, data, or configurations? — **No.**
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [x] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [x] Were existing tests modified? — **No, only a new test was added.**
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [x] If the **public API** has changed: _(No public API change.)_
  - [ ] Old API is deprecated or a migration is documented.
  - [x] If not, no action needed.
- [x] Java license headers are added where necessary.
- [x] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [x] All configuration options are documented in Javadoc and `mycore.properties`. _(N/A — no configuration.)_
- [x] No default properties are hardcoded — all set via `mycore.properties`. _(N/A — no configuration.)_

## Multi-Repo Considerations
- [x] Is an equivalent PR in `MIR` required? — **No.** The fix lives entirely in MyCoRe; MIR (MIR-1624) picks it up via the MyCoRe dependency bump.
  - [ ] If yes, is it already created?