### PR TITLE
MCR-3670 Improve error message

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/config/instantiator/MCRInstantiatorUtils.java
+++ b/mycore-base/src/main/java/org/mycore/common/config/instantiator/MCRInstantiatorUtils.java
@@ -143,8 +143,8 @@ public final class MCRInstantiatorUtils {
 
     public static MCRConfigurationException missingException(String property, Class<?> superClass) {
         return new MCRConfigurationException("Missing or empty property: " + property
-            + " (instance is required and expected class " + superClass.getName()
-            + " is not final, therefore, the class name cannot be determined implicitly)");
+            + " (intended super class " + superClass.getName() + " is not \"required and final\""
+            + " and therefore cannot be used implicitly)");
     }
 
     public static MCRConfigurationException missingException(String property, MCRTarget target,


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3670). Follow-Up to the follow-up, probably due to extreme heat in the office :)

The original version was technically correct but confusing, the "fixed" version incorrectly described the exception that allows to omit a .Class property. A version that is a bit sloppy, but describes the essence of that exception distinctly, might be better.

The original version was

>  Missing or empty property: MCR.Foo.Bar.Class (and instance is not required or expected class foo.bar.Baz is not final, therefore, the class name cannot be determined implicitly)

The "fixed" version was

>  Missing or empty property: MCR.Foo.Bar.Class (instance is required and expected class foo.bar.Baz is not final, therefore, the class name cannot be determined implicitly)

A correct version is

> Missing or empty property: MCR.Foo.Bar.Class (intended super class foo.bar.Baz is not "required and final" and therefore cannot be used implicitly)

