### PR TITLE
MCR-3745 CLI Commands should use default XSL Transformer

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/content/transformer/MCRXSLTransformer.java
+++ b/mycore-base/src/main/java/org/mycore/common/content/transformer/MCRXSLTransformer.java
@@ -91,7 +91,7 @@ public class MCRXSLTransformer extends MCRParameterizedTransformer {
     private static final long CHECK_PERIOD = MCRConfiguration2.getLong("MCR.LayoutService.LastModifiedCheckPeriod")
         .orElse(60_000L);
 
-    protected static final Class<? extends TransformerFactory> DEFAULT_FACTORY_CLASS = MCRConfiguration2
+    public static final Class<? extends TransformerFactory> DEFAULT_FACTORY_CLASS = MCRConfiguration2
         .<TransformerFactory>getClass("MCR.LayoutService.TransformerFactoryClass")
         .orElseGet(TransformerFactory.newInstance()::getClass);
 

--- a/mycore-base/src/main/java/org/mycore/frontend/cli/MCRCommandUtils.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/cli/MCRCommandUtils.java
@@ -37,8 +37,10 @@ import org.jdom2.filter.Filters;
 import org.jdom2.transform.JDOMSource;
 import org.jdom2.xpath.XPathExpression;
 import org.jdom2.xpath.XPathFactory;
+import org.mycore.common.MCRClassTools;
 import org.mycore.common.MCRConstants;
 import org.mycore.common.MCRUsageException;
+import org.mycore.common.content.transformer.MCRXSLTransformer;
 import org.mycore.common.xsl.MCRXSLResourceHelper;
 import org.mycore.common.xsl.uriresolver.MCRURIResolver;
 import org.mycore.datamodel.common.MCRXMLMetadataManager;
@@ -198,7 +200,8 @@ public class MCRCommandUtils {
 
         try {
             if (element != null) {
-                TransformerFactory transformerFactory = TransformerFactory.newInstance();
+                TransformerFactory transformerFactory = TransformerFactory
+                    .newInstance(MCRXSLTransformer.DEFAULT_FACTORY_CLASS.getName(), MCRClassTools.getClassLoader());
                 transformerFactory.setURIResolver(MCRURIResolver.obtainInstance());
                 transformer = transformerFactory.newTransformer(new JDOMSource(element));
                 cache.put(style, transformer);

--- a/mycore-base/src/main/java/org/mycore/frontend/cli/MCRObjectCommands.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/cli/MCRObjectCommands.java
@@ -59,6 +59,7 @@ import org.jdom2.transform.JDOMResult;
 import org.jdom2.transform.JDOMSource;
 import org.mycore.access.MCRAccessException;
 import org.mycore.backend.jpa.MCREntityManagerProvider;
+import org.mycore.common.MCRClassTools;
 import org.mycore.common.MCRException;
 import org.mycore.common.MCRPersistenceException;
 import org.mycore.common.MCRStreamUtils;
@@ -69,6 +70,7 @@ import org.mycore.common.content.MCRJDOMContent;
 import org.mycore.common.content.MCRSourceContent;
 import org.mycore.common.content.transformer.MCRContentTransformer;
 import org.mycore.common.content.transformer.MCRContentTransformerFactory;
+import org.mycore.common.content.transformer.MCRXSLTransformer;
 import org.mycore.common.xml.MCREntityResolver;
 import org.mycore.common.xml.MCRLayoutTransformerFactory;
 import org.mycore.common.xml.MCRXMLHelper;
@@ -985,7 +987,8 @@ public class MCRObjectCommands extends MCRAbstractCommands {
         MCRObjectID mcrId = MCRObjectID.getInstance(objectId);
         Document document = MCRXMLMetadataManager.obtainInstance().retrieveXML(mcrId);
         // do XSL transform
-        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        TransformerFactory transformerFactory = TransformerFactory
+            .newInstance(MCRXSLTransformer.DEFAULT_FACTORY_CLASS.getName(), MCRClassTools.getClassLoader());
         transformerFactory.setErrorListener(new MCRErrorListener());
         transformerFactory.setURIResolver(MCRURIResolver.obtainInstance());
         XMLReader xmlReader = MCRXMLParserFactory.getNonValidatingParser().getXMLReader();


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3745).

## Problem

The CLI command `xslt {0} with file {1}` (`MCRObjectCommands.xslt`) created its
`TransformerFactory` via `TransformerFactory.newInstance()`. With both Xalan and
Saxon on the classpath the JAXP service lookup picked Xalan instead of the
configured MyCoRe default factory.

## Fix

Instantiate the factory from `MCRXSLTransformer.DEFAULT_FACTORY_CLASS`
(resolved from `MCR.LayoutService.TransformerFactoryClass`), so the CLI uses the
same default XSL transformer as the rest of MyCoRe. To reuse the existing
single source of truth, `MCRXSLTransformer.DEFAULT_FACTORY_CLASS` was widened
from `protected` to `public`.

# Pull Request Checklist (Author)

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [ ] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`2026.06.x`).

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible). Not feasible without both Xalan+Saxon on the classpath and an integration setup for the metadata manager.

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket. Verified in MIR: Saxon is now used.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [x] If the **public API** has changed:
  - [x] `MCRXSLTransformer.DEFAULT_FACTORY_CLASS` visibility widened from `protected` to `public` (non-breaking).
- [x] Java license headers are added where necessary.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required? No, MIR configuration already selects Saxon.
