### PR TITLE
MCR-3750 CSL export format chooser: use form-select for Bootstrap 5 dropdown arrow

### DIFF
--- a/mycore-mods/src/main/resources/xsl/csl-export-gui.xsl
+++ b/mycore-mods/src/main/resources/xsl/csl-export-gui.xsl
@@ -65,7 +65,7 @@
         </script>
         <script src="{$WebApplicationBaseURL}js/csl-export.js"/>
         <div class="input-group mb-3 flex-wrap" data-export="{$type}">
-            <select name="format" class="form-control">
+            <select name="format" class="form-select">
                 <option value="">
                     <xsl:value-of select="i18n:translate('component.mods.csl.export.format')"/>
                 </option>
@@ -86,7 +86,7 @@
             </select>
             <select name="style">
                 <xsl:attribute name="class">
-                    <xsl:text>form-control</xsl:text>
+                    <xsl:text>form-select</xsl:text>
                     <xsl:if test="$type = 'basket'">
                         <xsl:text> d-none</xsl:text>
                     </xsl:if>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3750).

In Bootstrap 5 the `<select>` dropdown caret is provided by the `.form-select` class, not `.form-control`. The CSL export **format** and **style** selects in `mycore-mods/src/main/resources/xsl/csl-export-gui.xsl` still used `.form-control` after the Bootstrap 5 migration, so the dropdown arrow was missing on the search result and basket export UI.

Fix: use `.form-select` on both selects. Verified in MIR 2025.06.x.