### PR TITLE
MCR-3752 use default XSL Transformer factory in non-CLI places

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/content/transformer/MCRXSLTransformer.java
+++ b/mycore-base/src/main/java/org/mycore/common/content/transformer/MCRXSLTransformer.java
@@ -159,6 +159,16 @@ public class MCRXSLTransformer extends MCRParameterizedTransformer {
         return instance;
     }
 
+    /**
+     * Creates a new {@link TransformerFactory} instance of the configured default implementation
+     * (see <code>MCR.LayoutService.TransformerFactoryClass</code>).
+     *
+     * @return a new transformer factory
+     */
+    public static TransformerFactory getDefaultTransformerFactory() {
+        return TransformerFactory.newInstance(DEFAULT_FACTORY_CLASS.getName(), MCRClassTools.getClassLoader());
+    }
+
     @Override
     public void init(String id) {
         super.init(id);

--- a/mycore-base/src/main/java/org/mycore/common/content/transformer/MCRXSLTransformer.java
+++ b/mycore-base/src/main/java/org/mycore/common/content/transformer/MCRXSLTransformer.java
@@ -165,7 +165,7 @@ public class MCRXSLTransformer extends MCRParameterizedTransformer {
      *
      * @return a new transformer factory
      */
-    public static TransformerFactory getDefaultTransformerFactory() {
+    public static TransformerFactory createDefaultTransformerFactory() {
         return TransformerFactory.newInstance(DEFAULT_FACTORY_CLASS.getName(), MCRClassTools.getClassLoader());
     }
 

--- a/mycore-base/src/main/java/org/mycore/common/xml/MCRLayoutService.java
+++ b/mycore-base/src/main/java/org/mycore/common/xml/MCRLayoutService.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 
 import org.apache.logging.log4j.LogManager;
@@ -40,6 +39,7 @@ import org.mycore.common.config.annotation.MCRFactory;
 import org.mycore.common.content.MCRContent;
 import org.mycore.common.content.transformer.MCRContentTransformer;
 import org.mycore.common.content.transformer.MCRParameterizedTransformer;
+import org.mycore.common.content.transformer.MCRXSLTransformer;
 import org.mycore.common.xsl.MCRParameterCollector;
 import org.xml.sax.SAXException;
 
@@ -74,7 +74,7 @@ public class MCRLayoutService {
     public void sendXML(HttpServletRequest req, HttpServletResponse res, MCRContent xml) throws IOException {
         res.setContentType("text/xml; charset=UTF-8");
         try {
-            Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            Transformer transformer = MCRXSLTransformer.getDefaultTransformerFactory().newTransformer();
             transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
             transformer.setOutputProperty(OutputKeys.INDENT, "no");
             StreamResult result = new StreamResult(res.getOutputStream());

--- a/mycore-base/src/main/java/org/mycore/common/xml/MCRLayoutService.java
+++ b/mycore-base/src/main/java/org/mycore/common/xml/MCRLayoutService.java
@@ -74,7 +74,7 @@ public class MCRLayoutService {
     public void sendXML(HttpServletRequest req, HttpServletResponse res, MCRContent xml) throws IOException {
         res.setContentType("text/xml; charset=UTF-8");
         try {
-            Transformer transformer = MCRXSLTransformer.getDefaultTransformerFactory().newTransformer();
+            Transformer transformer = MCRXSLTransformer.createDefaultTransformerFactory().newTransformer();
             transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
             transformer.setOutputProperty(OutputKeys.INDENT, "no");
             StreamResult result = new StreamResult(res.getOutputStream());

--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRDataURL.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRDataURL.java
@@ -222,7 +222,7 @@ public class MCRDataURL implements Serializable {
             .orElseGet(() -> Optional.of(nodeList).filter(nl -> nl.getLength() == 1).map(nl -> nl.item(0))
                 .orElseThrow(() -> new IllegalArgumentException("Nodelist must have an single root element.")));
 
-        final TransformerFactory transformerFactory = MCRXSLTransformer.getDefaultTransformerFactory();
+        final TransformerFactory transformerFactory = MCRXSLTransformer.createDefaultTransformerFactory();
         final Transformer transformer = transformerFactory.newTransformer();
 
         MCRDataURLEncoding enc = encoding != null ? MCRDataURLEncoding.fromValue(encoding) : null;

--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRDataURL.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRDataURL.java
@@ -47,6 +47,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 import org.mycore.common.MCRException;
+import org.mycore.common.content.transformer.MCRXSLTransformer;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -221,7 +222,7 @@ public class MCRDataURL implements Serializable {
             .orElseGet(() -> Optional.of(nodeList).filter(nl -> nl.getLength() == 1).map(nl -> nl.item(0))
                 .orElseThrow(() -> new IllegalArgumentException("Nodelist must have an single root element.")));
 
-        final TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        final TransformerFactory transformerFactory = MCRXSLTransformer.getDefaultTransformerFactory();
         final Transformer transformer = transformerFactory.newTransformer();
 
         MCRDataURLEncoding enc = encoding != null ? MCRDataURLEncoding.fromValue(encoding) : null;

--- a/mycore-base/src/main/java/org/mycore/frontend/MCRLayoutUtilities.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/MCRLayoutUtilities.java
@@ -399,7 +399,7 @@ public class MCRLayoutUtilities {
         if (LOGGER.isDebugEnabled()) {
             try {
                 String encoding = "UTF-8";
-                TransformerFactory tf = MCRXSLTransformer.getDefaultTransformerFactory();
+                TransformerFactory tf = MCRXSLTransformer.createDefaultTransformerFactory();
                 Transformer transformer = tf.newTransformer();
                 transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
                 transformer.setOutputProperty(OutputKeys.METHOD, "xml");

--- a/mycore-base/src/main/java/org/mycore/frontend/MCRLayoutUtilities.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/MCRLayoutUtilities.java
@@ -67,6 +67,7 @@ import org.mycore.common.MCRException;
 import org.mycore.common.MCRSessionMgr;
 import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.content.MCRURLContent;
+import org.mycore.common.content.transformer.MCRXSLTransformer;
 import org.mycore.common.xml.MCRXMLFunctions;
 import org.mycore.resource.MCRResourceHelper;
 import org.w3c.dom.Attr;
@@ -398,7 +399,7 @@ public class MCRLayoutUtilities {
         if (LOGGER.isDebugEnabled()) {
             try {
                 String encoding = "UTF-8";
-                TransformerFactory tf = TransformerFactory.newInstance();
+                TransformerFactory tf = MCRXSLTransformer.getDefaultTransformerFactory();
                 Transformer transformer = tf.newTransformer();
                 transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
                 transformer.setOutputProperty(OutputKeys.METHOD, "xml");

--- a/mycore-base/src/main/java/org/mycore/frontend/cli/MCRCommandUtils.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/cli/MCRCommandUtils.java
@@ -199,7 +199,7 @@ public class MCRCommandUtils {
 
         try {
             if (element != null) {
-                TransformerFactory transformerFactory = MCRXSLTransformer.getDefaultTransformerFactory();
+                TransformerFactory transformerFactory = MCRXSLTransformer.createDefaultTransformerFactory();
                 transformerFactory.setURIResolver(MCRURIResolver.obtainInstance());
                 transformer = transformerFactory.newTransformer(new JDOMSource(element));
                 cache.put(style, transformer);

--- a/mycore-base/src/main/java/org/mycore/frontend/cli/MCRCommandUtils.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/cli/MCRCommandUtils.java
@@ -37,7 +37,6 @@ import org.jdom2.filter.Filters;
 import org.jdom2.transform.JDOMSource;
 import org.jdom2.xpath.XPathExpression;
 import org.jdom2.xpath.XPathFactory;
-import org.mycore.common.MCRClassTools;
 import org.mycore.common.MCRConstants;
 import org.mycore.common.MCRUsageException;
 import org.mycore.common.content.transformer.MCRXSLTransformer;
@@ -200,8 +199,7 @@ public class MCRCommandUtils {
 
         try {
             if (element != null) {
-                TransformerFactory transformerFactory = TransformerFactory
-                    .newInstance(MCRXSLTransformer.DEFAULT_FACTORY_CLASS.getName(), MCRClassTools.getClassLoader());
+                TransformerFactory transformerFactory = MCRXSLTransformer.getDefaultTransformerFactory();
                 transformerFactory.setURIResolver(MCRURIResolver.obtainInstance());
                 transformer = transformerFactory.newTransformer(new JDOMSource(element));
                 cache.put(style, transformer);

--- a/mycore-base/src/main/java/org/mycore/frontend/cli/MCRObjectCommands.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/cli/MCRObjectCommands.java
@@ -59,7 +59,6 @@ import org.jdom2.transform.JDOMResult;
 import org.jdom2.transform.JDOMSource;
 import org.mycore.access.MCRAccessException;
 import org.mycore.backend.jpa.MCREntityManagerProvider;
-import org.mycore.common.MCRClassTools;
 import org.mycore.common.MCRException;
 import org.mycore.common.MCRPersistenceException;
 import org.mycore.common.MCRStreamUtils;
@@ -987,8 +986,7 @@ public class MCRObjectCommands extends MCRAbstractCommands {
         MCRObjectID mcrId = MCRObjectID.getInstance(objectId);
         Document document = MCRXMLMetadataManager.obtainInstance().retrieveXML(mcrId);
         // do XSL transform
-        TransformerFactory transformerFactory = TransformerFactory
-            .newInstance(MCRXSLTransformer.DEFAULT_FACTORY_CLASS.getName(), MCRClassTools.getClassLoader());
+        TransformerFactory transformerFactory = MCRXSLTransformer.getDefaultTransformerFactory();
         transformerFactory.setErrorListener(new MCRErrorListener());
         transformerFactory.setURIResolver(MCRURIResolver.obtainInstance());
         XMLReader xmlReader = MCRXMLParserFactory.getNonValidatingParser().getXMLReader();

--- a/mycore-base/src/main/java/org/mycore/frontend/cli/MCRObjectCommands.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/cli/MCRObjectCommands.java
@@ -986,7 +986,7 @@ public class MCRObjectCommands extends MCRAbstractCommands {
         MCRObjectID mcrId = MCRObjectID.getInstance(objectId);
         Document document = MCRXMLMetadataManager.obtainInstance().retrieveXML(mcrId);
         // do XSL transform
-        TransformerFactory transformerFactory = MCRXSLTransformer.getDefaultTransformerFactory();
+        TransformerFactory transformerFactory = MCRXSLTransformer.createDefaultTransformerFactory();
         transformerFactory.setErrorListener(new MCRErrorListener());
         transformerFactory.setURIResolver(MCRURIResolver.obtainInstance());
         XMLReader xmlReader = MCRXMLParserFactory.getNonValidatingParser().getXMLReader();


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3752).

## Problem

Follow-up to MCR-3745. Several places still created their `TransformerFactory` via the raw JAXP lookup
`TransformerFactory.newInstance()`, which picks Xalan when both Xalan and Saxon are on the classpath instead of the
centrally configured default factory. MCR-3745 already fixed the CLI export/xslt commands, but repeated the verbose
`TransformerFactory.newInstance(DEFAULT_FACTORY_CLASS.getName(), classLoader)` pattern at every call site.

## Fix

- Added a single factory method `MCRXSLTransformer.getDefaultTransformerFactory()` that returns a new
  `TransformerFactory` of the configured default implementation
  (`MCR.LayoutService.TransformerFactoryClass`).
- Switched all call sites to this method:
  - `MCRLayoutService#sendXML` (serializes XML into the servlet response)
  - `MCRLayoutUtilities` (identity transform in a debug-only block of the personal navigation)
  - `MCRDataURL#build` (transformer used in the data URL codec)
  - `MCRObjectCommands#xslt` and `MCRCommandUtils#getTransformer` (previously introduced in MCR-3745, now using the
    shared method instead of duplicating the lookup)

`MCRTemplatesCompiler` is intentionally left on Xalan (XSL1 flavor) and is out of scope.

# Pull Request Checklist (Author)

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [ ] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`2026.06.x`).

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible). Not feasible without both Xalan+Saxon on the classpath.

## Testing
- [x] I have tested the changes locally (`mvn install -pl mycore-base -am`).

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [x] If the **public API** has changed:
  - [x] New method `MCRXSLTransformer.getDefaultTransformerFactory()` added (additive, non-breaking).
- [x] Java license headers are added where necessary.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required? No.
