### PR TITLE
MCR-3756 invalidate ExpandedObjectCache to fix ExtendedDerivateLink

### DIFF
--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetadataManager.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetadataManager.java
@@ -43,7 +43,6 @@ import org.mycore.access.MCRAccessManager;
 import org.mycore.access.MCRMissingPermissionException;
 import org.mycore.access.MCRMissingPrivilegeException;
 import org.mycore.common.MCRException;
-import org.mycore.common.MCRExpandedObjectCache;
 import org.mycore.common.MCRExpandedObjectManager;
 import org.mycore.common.MCRPersistenceException;
 import org.mycore.common.config.MCRConfiguration2;
@@ -133,7 +132,7 @@ public final class MCRMetadataManager {
 
         createDataInIFS(mcrDerivate, derivateId, objectId, objectBackup);
 
-        MCRExpandedObjectCache.getInstance().clear(mcrDerivate.getOwnerID());
+        fireLinkedUpdatedEvent(mcrDerivate);
     }
 
     private static MCRObjectID assignNewIdIfNecessary(MCRDerivate mcrDerivate) {
@@ -696,7 +695,7 @@ public final class MCRMetadataManager {
 
         updateIFS(fileSourceDirectory, derivateId);
 
-        MCRExpandedObjectCache.getInstance().clear(mcrDerivate.getOwnerID());
+        fireLinkedUpdatedEvent(mcrDerivate);
     }
 
     private static Path handleFileSourceDirectory(MCRDerivate mcrDerivate) {
@@ -900,6 +899,13 @@ public final class MCRMetadataManager {
         } else {
             MCREventManager.getInstance().handleEvent(evt);
         }
+    }
+
+    private static void fireLinkedUpdatedEvent(MCRDerivate derivate) {
+        final MCREvent evt = new MCREvent(MCREvent.ObjectType.DERIVATE, MCREvent.EventType.LINKED_UPDATED);
+        evt.put(MCREvent.DERIVATE_KEY, derivate);
+        evt.put(MCREvent.RELATED_OBJECT_KEY, derivate.getOwnerID());
+        MCREventManager.getInstance().handleEvent(evt);
     }
 
     public static List<MCRObjectID> getChildren(MCRObjectID id) {

--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetadataManager.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetadataManager.java
@@ -43,6 +43,7 @@ import org.mycore.access.MCRAccessManager;
 import org.mycore.access.MCRMissingPermissionException;
 import org.mycore.access.MCRMissingPrivilegeException;
 import org.mycore.common.MCRException;
+import org.mycore.common.MCRExpandedObjectCache;
 import org.mycore.common.MCRExpandedObjectManager;
 import org.mycore.common.MCRPersistenceException;
 import org.mycore.common.config.MCRConfiguration2;
@@ -132,6 +133,7 @@ public final class MCRMetadataManager {
 
         createDataInIFS(mcrDerivate, derivateId, objectId, objectBackup);
 
+        MCRExpandedObjectCache.getInstance().clear(mcrDerivate.getOwnerID());
     }
 
     private static MCRObjectID assignNewIdIfNecessary(MCRDerivate mcrDerivate) {
@@ -694,6 +696,7 @@ public final class MCRMetadataManager {
 
         updateIFS(fileSourceDirectory, derivateId);
 
+        MCRExpandedObjectCache.getInstance().clear(mcrDerivate.getOwnerID());
     }
 
     private static Path handleFileSourceDirectory(MCRDerivate mcrDerivate) {


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3756).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [ ] I have tested the changes locally.
- [ ] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [ ] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
