### PR TITLE
MCR-3757 use xml:lang instead of lang() for classification label sele…

### DIFF
--- a/mycore-base/src/main/resources/xslt/functions/classification.xsl
+++ b/mycore-base/src/main/resources/xslt/functions/classification.xsl
@@ -47,14 +47,14 @@
       <xsl:when test="$class[@classid and @categid]">
         <xsl:sequence select="mcrclass:label($lang, document(concat('classification:metadata:0:children:',$class/@classid,':',$class/@categid))//category)" />
       </xsl:when>
-      <xsl:when test="string-length($lang) > 0 and $class/label[lang($lang)]">
-        <xsl:sequence select="$class/label[lang($lang)]" />
+      <xsl:when test="string-length($lang) > 0 and $class/label[@xml:lang = $lang]">
+        <xsl:sequence select="$class/label[@xml:lang = $lang]" />
       </xsl:when>
-      <xsl:when test="$class/label[lang($CurrentLang)]">
-        <xsl:sequence select="$class/label[lang($CurrentLang)]" />
+      <xsl:when test="$class/label[@xml:lang = $CurrentLang]">
+        <xsl:sequence select="$class/label[@xml:lang = $CurrentLang]" />
       </xsl:when>
-      <xsl:when test="$class/label[lang($DefaultLang)]">
-        <xsl:sequence select="$class/label[lang($DefaultLang)]" />
+      <xsl:when test="$class/label[@xml:lang = $DefaultLang]">
+        <xsl:sequence select="$class/label[@xml:lang = $DefaultLang]" />
       </xsl:when>
       <xsl:otherwise>
         <xsl:sequence select="$class/label[1]" />

--- a/mycore-base/src/test/java/org/mycore/frontend/xsl/MCRXSLClassificationTest.java
+++ b/mycore-base/src/test/java/org/mycore/frontend/xsl/MCRXSLClassificationTest.java
@@ -45,7 +45,7 @@ public class MCRXSLClassificationTest extends MCRJPATestCase {
         // existing classification: return category with respective labels
         assertEquals(1, result.getChildren("category").size());
         assertEquals("junit_1", result.getChild("category").getAttributeValue("ID"));
-        assertEquals(3, result.getChild("category").getChildren("label").size());
+        assertEquals(4, result.getChild("category").getChildren("label").size());
         assertEquals("de",
             result.getChild("category").getChildren("label").get(0).getAttributeValue("lang", Namespace.XML_NAMESPACE));
         assertEquals("junit_1 (de)",

--- a/mycore-base/src/test/resources/classification/TestClassification.xml
+++ b/mycore-base/src/test/resources/classification/TestClassification.xml
@@ -6,6 +6,7 @@
             <label xml:lang="de" text="junit_1 (de)"/>
             <label xml:lang="en" text="junit_1 (en)"/>
             <label xml:lang="x-xxx" text="abc"/>
+            <label xml:lang="x-xxx-abc" text="def"/>
         </category>
         <category ID="junit_2">
             <label xml:lang="en" text="junit_2 (en)"/>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3757).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [ ] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [ ] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [x] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [x] Were existing tests modified?
  - [x] Yes: added a category to the classification for causing the error

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
