### PR TITLE
MCR-3758 XML editor is broken, essentially unusable

### DIFF
--- a/mycore-base/src/main/java/org/mycore/frontend/support/MCRObjectIDLockTable.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/support/MCRObjectIDLockTable.java
@@ -71,8 +71,12 @@ public final class MCRObjectIDLockTable implements MCRSessionListener {
      */
     public void clearTable(MCRSession session) {
         String sessionId = session.getID();
+        String userId = session.getUserInformation().getUserID();
         List<MCRObjectID> toRemoveList = lockMap.entrySet().stream()
-            .filter(entry -> entry.getValue().id.equals(sessionId))
+            .filter(entry -> {
+                MCRObjectLock objectLock = entry.getValue();
+                return objectLock.id.equals(sessionId) || objectLock.createdBy.equals(userId);
+            })
             .map(ConcurrentMap.Entry::getKey)
             .toList();
         for (MCRObjectID objectId : toRemoveList) {
@@ -190,9 +194,11 @@ public final class MCRObjectIDLockTable implements MCRSessionListener {
      * @return {@code true} if the object is locked and the lock's ID matches the current session ID.
      */
     public static boolean isLockedByCurrentSession(MCRObjectID objectId) {
-        String sessionId = MCRSessionMgr.getCurrentSession().getID();
+        MCRSession session = MCRSessionMgr.getCurrentSession();
+        String sessionId = session.getID();
+        String userId = session.getUserInformation().getUserID();
         MCRObjectLock objectLock = getInstance().lockMap.get(objectId);
-        return objectLock != null && sessionId.equals(objectLock.id);
+        return objectLock != null && (sessionId.equals(objectLock.id) || userId.equals(objectLock.createdBy));
     }
 
     /**

--- a/mycore-webtools/src/main/vue/texteditor/src/apis/ObjectsContentHandler.ts
+++ b/mycore-webtools/src/main/vue/texteditor/src/apis/ObjectsContentHandler.ts
@@ -28,6 +28,7 @@ export class ObjectsContentHandler extends BaseContentHandler {
     const expanded = options?.expanded ?? false;
     const response = await fetch(`${this.mcrApplicationBaseURL}api/v2/objects/${path}?expanded=${expanded}`, {
       method: "GET",
+      cache: "no-store",
       headers: {
         "Authorization": authorizationHeader
       },
@@ -115,6 +116,7 @@ export class ObjectsContentHandler extends BaseContentHandler {
     console.log("unlock " + objectId);
     const response = await fetch(`${this.mcrApplicationBaseURL}api/v2/objects/${objectId}/lock`, {
       method: "DELETE",
+      keepalive: true,
       headers: {
         "Authorization": authorizationHeader
       }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3758).

3 Problems found and fixed
* "keep: alive" not set for unlock. chrome keeps the fetch alive, firefox does not -> leads to blocked object
* load fetch did not use "no-store" -> leads to cached xml in the browser. You can see in the video that it shows the old xml
* MCRObjectIDLockTable#clearTable() did not check for the user, only for the sessionId. The objectlock was user bound and not session bound. So a logout didn't clean up.

For the future, not part of this fix:
* We should remove the session lock entirly and only lock by user. This makes everything much simpler and also seems more correct.

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [ ] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
