### PR TITLE
MCR-3770 Local PDF full-text search broken: use native textContent instead of jQuery text()

### DIFF
--- a/mycore-viewer/src/main/typescript/modules/desktop/components/model/MyCoReLocalIndexSearcher.ts
+++ b/mycore-viewer/src/main/typescript/modules/desktop/components/model/MyCoReLocalIndexSearcher.ts
@@ -60,7 +60,7 @@ export class MyCoReLocalIndexSearcher extends MyCoReViewerSearcher {
   private clearDoubleResults(searchResults) {
     let contextExists = {};
     return searchResults.filter((el) => {
-      let key = (Utils.hash(el.context.text() + el.matchWords.join("")));
+      let key = (Utils.hash(el.context.textContent + el.matchWords.join("")));
       if (key in contextExists) {
         return false;
       } else {


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3770).

## What does this PR change?

Fixes the local PDF full-text search in the mycore-viewer, which threw
`TypeError: s.context.text is not a function` on every search.

`MyCoReLocalIndexSearcher.clearDoubleResults()` called the jQuery-only `.text()`
method on `el.context`. Since MCR-3314 (Bootstrap v5 upgrade), `TextIndex.getContext()`
returns a native `HTMLElement` instead of a jQuery object, so `.text()` no longer
exists. Replaced with the native `HTMLElement.textContent` property.

## Notes

- One-line fix, verified locally on 2026.06.
- Targets `2025.06.x`; forward-merges into `2025.12.x` and `2026.06.x`.
