### PR TITLE
MCR-3771 set internal sourcepath of derivate to NULL on create

### DIFF
--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetadataManager.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetadataManager.java
@@ -206,11 +206,11 @@ public final class MCRMetadataManager {
 
         setDerivateMetadata(mcrDerivate);
 
-        createDataInIFS(mcrDerivate, derivateId, objectId, objectBackup);
-        
-        handleFileSourceDirectory(mcrDerivate);
-        
+        Path sourcePath = removeSourcePathFromInternals(mcrDerivate);
+
         fireEvent(mcrDerivate, null, MCREvent.EventType.CREATE);
+
+        createDataInIFS(mcrDerivate, derivateId, objectId, objectBackup, sourcePath);
 
         addLinkToMetadata(mcrDerivate, objectId, objectBackup);
     }
@@ -272,9 +272,9 @@ public final class MCRMetadataManager {
     }
 
     private static void createDataInIFS(MCRDerivate mcrDerivate, MCRObjectID derivateId, MCRObjectID objectId,
-        byte[] objectBackup) throws MCRPersistenceException {
+        byte[] objectBackup, Path sourcePath) throws MCRPersistenceException {
         try {
-            processDerivate(mcrDerivate, derivateId, objectBackup);
+            processDerivate(mcrDerivate, derivateId, objectBackup, sourcePath);
         } catch (Exception e) {
             restore(mcrDerivate, objectId, objectBackup);
             throw new MCRPersistenceException("Error during data creation in IFS.", e);
@@ -296,11 +296,11 @@ public final class MCRMetadataManager {
     }
 
     private static void processDerivate(MCRDerivate mcrDerivate, MCRObjectID objectId,
-        byte[] objectBackup) {
+        byte[] objectBackup, final Path sourcePath) {
         MCRObjectID derivateId = mcrDerivate.getId();
         if (mcrDerivate.getDerivate().getInternals() != null) {
             MCRPath rootPath = MCRPath.getPath(derivateId.toString(), "/");
-            if (mcrDerivate.getDerivate().getInternals().getSourcePath() == null) {
+            if (sourcePath == null) {
                 try {
                     rootPath.getFileSystem().createRoot(rootPath.getOwner());
                 } catch (IOException ioExc) {
@@ -308,14 +308,12 @@ public final class MCRMetadataManager {
                         "Cannot create root of '" + rootPath.getOwner() + "'.", ioExc);
                 }
             } else {
-                final String sourcepath = mcrDerivate.getDerivate().getInternals().getSourcePath();
-                final Path f = Paths.get(sourcepath);
-                if (Files.exists(f)) {
+                if (Files.exists(sourcePath)) {
                     try {
                         if (LOGGER.isDebugEnabled()) {
                             LOGGER.debug("Starting File-Import");
                         }
-                        importDerivate(derivateId.toString(), f);
+                        importDerivate(derivateId.toString(), sourcePath);
                     } catch (final Exception e) {
                         if (Files.exists(rootPath)) {
                             deleteDerivate(derivateId.toString());
@@ -324,7 +322,7 @@ public final class MCRMetadataManager {
                         throw new MCRPersistenceException("Can't add derivate to the IFS", e);
                     }
                 } else {
-                    LOGGER.warn("Empty derivate, the File or Directory -->{}<--  was not found.", sourcepath);
+                    LOGGER.warn("Empty derivate, the File or Directory -->{}<--  was not found.", sourcePath);
                 }
             }
         }
@@ -855,7 +853,7 @@ public final class MCRMetadataManager {
 
         checkUpdatePermission(derivateId);
 
-        Path fileSourceDirectory = handleFileSourceDirectory(mcrDerivate);
+        Path fileSourceDirectory = removeSourcePathFromInternals(mcrDerivate);
 
         MCRDerivate old = retrieveMCRDerivate(derivateId);
 
@@ -868,7 +866,7 @@ public final class MCRMetadataManager {
         addLinkToMetadata(mcrDerivate);
     }
 
-    private static Path handleFileSourceDirectory(MCRDerivate mcrDerivate) {
+    private static Path removeSourcePathFromInternals(MCRDerivate mcrDerivate) {
         MCRMetaIFS internals = mcrDerivate.getDerivate().getInternals();
         if (internals != null && internals.getSourcePath() != null) {
             Path fileSourceDirectory = Paths.get(internals.getSourcePath());

--- a/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetadataManager.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/metadata/MCRMetadataManager.java
@@ -206,9 +206,11 @@ public final class MCRMetadataManager {
 
         setDerivateMetadata(mcrDerivate);
 
-        fireEvent(mcrDerivate, null, MCREvent.EventType.CREATE);
-
         createDataInIFS(mcrDerivate, derivateId, objectId, objectBackup);
+        
+        handleFileSourceDirectory(mcrDerivate);
+        
+        fireEvent(mcrDerivate, null, MCREvent.EventType.CREATE);
 
         addLinkToMetadata(mcrDerivate, objectId, objectBackup);
     }


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3771).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [ ] Affected version is listed in the ticket.
- [ ] Minimal code changes were made (no refactoring).
- [ ] This PR truly fixes **only** the reported bug.
- [ ] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [ ] I have tested the changes locally.
- [ ] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [ ] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
