### PR TITLE
MCR-3791 Fix veraPDF vulnerabilities and exclude unused MIME4J

### DIFF
--- a/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAValidator.java
+++ b/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAValidator.java
@@ -29,6 +29,7 @@ import org.verapdf.gf.foundry.VeraGreenfieldFoundryProvider;
 import org.verapdf.pdfa.Foundries;
 import org.verapdf.pdfa.PDFAParser;
 import org.verapdf.pdfa.PDFAValidator;
+import org.verapdf.pdfa.flavours.PDFAFlavour;
 import org.verapdf.pdfa.results.ValidationResult;
 
 /**
@@ -64,7 +65,8 @@ public class MCRPDFAValidator {
      */
     public ValidationResult validate(InputStream inputStream) throws MCRPDFAValidationException, IOException {
         initialise();
-        try (PDFAParser parser = Foundries.defaultInstance().createParser(inputStream);
+        try (PDFAParser parser = Foundries.defaultInstance().createParser(inputStream, PDFAFlavour.NO_FLAVOUR,
+            Foundries.defaultInstance().defaultFlavour());
             PDFAValidator validator = Foundries.defaultInstance().createValidator(parser.getFlavour(), false)) {
             return validator.validate(parser);
         } catch (ValidationException | ModelParsingException | EncryptedPdfException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@ Applications based on MyCoRe use a common core, which provides the functionality
     <site.suffix />
     <swagger.version>2.2.30</swagger.version>
     <uniqueVersion>false</uniqueVersion>
-    <verapdf.version>1.28.2</verapdf.version>
+    <verapdf.version>1.30.2</verapdf.version>
     <vis-network.version>9.1.2</vis-network.version>
     <xalan.version>2.7.3</xalan.version>
     <xsonify.version>1.1.1</xsonify.version>
@@ -1972,6 +1972,10 @@ Applications based on MyCoRe use a common core, which provides the functionality
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-mime4j-core</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3791).

 # Validation

  * veraPDF validation model and parser resolve to 1.30.2.
  * `apache-mime4j-core` is absent from the resolved SWORD dependency tree.
  * Standard Abdera Atom parsing works without MIME4J.

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [ ] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [ ] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
