### PR TITLE
MCR-3803 fix Base path of Solr ConfigSet mycore_classification

### DIFF
--- a/mycore-solr/src/main/resources/components/solr/config/mycore.properties
+++ b/mycore-solr/src/main/resources/components/solr/config/mycore.properties
@@ -34,7 +34,7 @@ MCR.Solr.ConfigSet.mycore_main.Base=configset/mycore_main/conf/
 
 MCR.Solr.ConfigSet.mycore_classification.Class=org.mycore.solr.cloud.configsets.MCRSolrResourceConfigSetProvider
 MCR.Solr.ConfigSet.mycore_classification.Files=managed-schema,solrconfig.xml,stopwords.txt,synonyms.txt
-MCR.Solr.ConfigSet.mycore_classification.Base=configset/mycore_main/conf/
+MCR.Solr.ConfigSet.mycore_classification.Base=configset/mycore_classification/conf/
 
 MCR.Solr.Core.main.ConfigSetTemplate=mycore_main
 MCR.Solr.Core.main.Type=main


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3803).

The ConfigSet `mycore_classification` resolved its files against `configset/mycore_main/conf/`, so `MCRSolrResourceConfigSetProvider` packed the schema and the solrconfig of the main index into the classification ConfigSet. The dedicated resources in `configset/mycore_classification/conf/` were never used.

Introduced with MCR-3113 (commit 23e12d1f77), so the bug is present in 2024.06.x and all newer branches. This PR targets 2024.06.x as the lowest affected branch.

All four files listed in `MCR.Solr.ConfigSet.mycore_classification.Files` exist in the new base directory.
