### PR TITLE
MCR-3805 clear expanded object cache on object repair

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/MCRExpandedObjectCacheEventHandler.java
+++ b/mycore-base/src/main/java/org/mycore/common/MCRExpandedObjectCacheEventHandler.java
@@ -9,7 +9,7 @@ import org.mycore.datamodel.metadata.MCRObjectID;
 
 /**
  * Event handler that clears the {@link MCRExpandedObjectCache} for affected objects
- * when certain events occur (delete, update, link update, ancestor update, derivate link update).
+ * when certain events occur (delete, update, repair, link update, ancestor update, derivate link update).
  * This ensures that the cache does not contain stale expanded object data.
  */
 public class MCRExpandedObjectCacheEventHandler extends MCREventHandlerBase {
@@ -47,6 +47,18 @@ public class MCRExpandedObjectCacheEventHandler extends MCREventHandlerBase {
      */
     @Override
     protected void handleObjectUpdated(MCREvent evt, MCRObject obj) {
+        MCRExpandedObjectCache.getInstance().clear(obj.getId());
+    }
+
+    /**
+     * Clears the cache for the repaired object.
+     * The metadata of the object may have been changed without an update event, e.g. by an import.
+     *
+     * @param evt the repair event
+     * @param obj the repaired object
+     */
+    @Override
+    protected void handleObjectRepaired(MCREvent evt, MCRObject obj) {
         MCRExpandedObjectCache.getInstance().clear(obj.getId());
     }
 


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3805).

`MCRExpandedObjectCacheEventHandler` overrides `handleObjectDeleted`, `handleObjectUpdated`, `handleObjectLinkUpdated`, `handleAncestorUpdated` and `handleDerivateLinkUpdated`, but not `handleObjectRepaired`. The inherited implementation in `MCREventHandlerBase` does nothing, so a `MCREvent.EventType.REPAIR` for an object leaves the entry in `MCRExpandedObjectCache` untouched.

If object metadata is changed without a regular update event, for example by an import that overwrites existing objects on disk, `repair metadata` does not invalidate the expanded object. `MCRExpandedObjectManager.getExpandedObject(MCRObject)` keeps returning the stale expanded object, so the outdated state stays visible in the frontend and in every other consumer of the expanded object.

This PR overrides `handleObjectRepaired` and clears the cache for the repaired object, analogous to `MCRObjectCacheFactory.handleObjectRepaired`.

Derivate repair events do not need a separate override: `MCRLinkTableEventHandler.handleDerivateRepaired` fires a `LINKED_UPDATED` event for the owner object, which is already handled by `handleObjectLinkUpdated`.

The class was introduced with MCR-3375 and is present in 2025.12.x, 2026.06.x and main. 2025.06.x and older are not affected, so this PR targets 2025.12.x.

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`2025.12.x`, plus `2026.06.x` and `main` for the forward merges).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

Not applicable, this is a bugfix. No configuration, data or API change.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

No test was added. There is currently no test fixture that fires `MCREvent.EventType.REPAIR` through the event manager against a filled `MCRExpandedObjectCache`; `MCRObjectUtilsTest` only registers the handler as a side effect. Happy to add one if a reviewer prefers it.

## Testing
- [ ] I have tested the changes locally.
- [ ] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

`mvn compile -pl mycore-base` passes. The stale-cache behaviour after `repair metadata` was traced in the code, not reproduced in a running application. No existing tests were modified. The reporter of the bug can confirm against their import scenario.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [x] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [x] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [x] All configuration options are documented in Javadoc and `mycore.properties`.
- [x] No default properties are hardcoded — all set via `mycore.properties`.

No new file was added. `MCRExpandedObjectCacheEventHandler` has no license header on this branch; that is pre-existing and covered by MCR-3804, which added the missing headers on `main`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?

No, `MIR` is not affected.
