### PR TITLE
MCR-3820 add missing label to expanded object

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/MCRBasicObjectExpander.java
+++ b/mycore-base/src/main/java/org/mycore/common/MCRBasicObjectExpander.java
@@ -91,6 +91,7 @@ public class MCRBasicObjectExpander implements MCRObjectExpander {
         expandedObject.setId(mcrObject.getId());
         expandedObject.setVersion(mcrObject.getVersion());
         expandedObject.setSchema(mcrObject.getSchema());
+        expandedObject.setLabel(mcrObject.getLabel());
 
         expandClassifications(mcrObject);
 

--- a/mycore-base/src/test/java/org/mycore/common/MCRBasicObjectExpanderTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/MCRBasicObjectExpanderTest.java
@@ -1,0 +1,37 @@
+package org.mycore.common;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mycore.datamodel.classifications2.mapping.MCRNoOpClassificationMapper;
+import org.mycore.datamodel.metadata.MCRExpandedObject;
+import org.mycore.datamodel.metadata.MCRMetadataManager;
+import org.mycore.datamodel.metadata.MCRObject;
+import org.mycore.test.MCRJPAExtension;
+import org.mycore.test.MyCoReTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MyCoReTest
+@ExtendWith(MCRJPAExtension.class)
+@MCRTestConfiguration(properties = {
+    @MCRTestProperty(key = "MCR.Metadata.Type.test", string = "true"),
+    @MCRTestProperty(key = "MCR.Metadata.Type.junit", string = "true")
+})
+public class MCRBasicObjectExpanderTest {
+    @Test
+    void testExpandedObjectContainsAttributes() {
+        final MCRObject mcrObject = new MCRObject();
+        mcrObject.setId(MCRMetadataManager.getMCRObjectIDGenerator().getNextFreeId("MyCoRe_test"));
+        mcrObject.setSchema("my_schema.xsd");
+        mcrObject.setVersion("2026.06");
+        mcrObject.setLabel("my_label");
+
+        final MCRExpandedObject expandedObject =
+            new MCRBasicObjectExpander(new MCRNoOpClassificationMapper()).expand(mcrObject);
+
+        assertEquals(mcrObject.getId(), expandedObject.getId());
+        assertEquals(mcrObject.getSchema(), expandedObject.getSchema());
+        assertEquals(mcrObject.getVersion(), expandedObject.getVersion());
+        assertEquals(mcrObject.getLabel(), expandedObject.getLabel());
+    }
+}


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3820).

2025.12 solution from https://github.com/MyCoRe-Org/mycore/pull/3120

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [x] A relevant test was added (if feasible).

## Testing
- [ ] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [x] Were existing tests modified?
  - [x] Yes: added test classMCRBasicObjectExpanderTest

## MCR Conventions & Metadata
- [ ] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
