### PR TITLE
MCR-3824 wake job manager when a thread is freed

### DIFF
--- a/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/MCRJobThreadStarter.java
+++ b/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/MCRJobThreadStarter.java
@@ -316,8 +316,11 @@ public class MCRJobThreadStarter implements Runnable, Closeable {
         }
 
         synchronized void awaitSignal(long timeoutMillis) throws InterruptedException {
-            if (!signalled) {
-                wait(timeoutMillis);
+            long deadline = System.currentTimeMillis() + timeoutMillis;
+            long remaining = timeoutMillis;
+            while (!signalled && remaining > 0) {
+                wait(remaining);
+                remaining = deadline - System.currentTimeMillis();
             }
             signalled = false;
         }

--- a/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/MCRJobThreadStarter.java
+++ b/mycore-jobqueue/src/main/java/org/mycore/services/queuedjob/MCRJobThreadStarter.java
@@ -102,7 +102,7 @@ public class MCRJobThreadStarter implements Runnable, Closeable {
         Duration timeTillReset = config.timeTillReset(action).orElseGet(config::timeTillReset);
 
         jobExecutor = new ActiveCountingThreadPoolExecutor(maxJobThreadCount, workQueue,
-            new JobThreadFactory(getSimpleActionName()), activeThreads);
+            new JobThreadFactory(getSimpleActionName()), activeThreads, listener);
 
         processableCollection = new MCRProcessableDefaultCollection(getName());
         processableCollection.setProperty("activated", activated);
@@ -144,9 +144,7 @@ public class MCRJobThreadStarter implements Runnable, Closeable {
                         break;
                     }
                 }
-                synchronized (listener) {
-                    listener.wait(ONE_MINUTE_IN_MS);
-                }
+                listener.awaitSignal(ONE_MINUTE_IN_MS);
             } catch (PersistenceException e) {
                 LOGGER.warn("We have an database error, sleep and run later.", e);
                 try {
@@ -226,10 +224,8 @@ public class MCRJobThreadStarter implements Runnable, Closeable {
         //signal manager thread to stop now
         running = false;
         //Wake up, Neo!
-        synchronized (listener) {
-            LOGGER.debug("Wake up queue");
-            listener.notifyAll();
-        }
+        LOGGER.debug("Wake up queue");
+        listener.signal();
         runLock.lock();
         try {
             if (processableExecutor != null) {
@@ -308,35 +304,43 @@ public class MCRJobThreadStarter implements Runnable, Closeable {
      */
     private static final class ListenerNotifier implements MCRJobQueueEventListener, MCRJobStatusListener {
 
+        private boolean signalled;
+
+        /**
+         * Wakes up the job manager. A signal that arrives while the manager is scheduling instead of waiting is
+         * remembered, so it is not lost.
+         */
+        synchronized void signal() {
+            signalled = true;
+            notifyAll();
+        }
+
+        synchronized void awaitSignal(long timeoutMillis) throws InterruptedException {
+            if (!signalled) {
+                wait(timeoutMillis);
+            }
+            signalled = false;
+        }
+
         @Override
         public void onJobAdded(MCRJob job) {
             // a job was added to the queue, but the transaction is not yet committed, so we have to wait for it.
-            MCRSessionMgr.getCurrentSession().onCommit(() -> {
-                synchronized (this) {
-                    this.notifyAll();
-                }
-            });
+            MCRSessionMgr.getCurrentSession().onCommit(this::signal);
         }
 
         @Override
         public void onError(MCRJob job, Exception e) {
-            synchronized (this) {
-                this.notifyAll();
-            }
+            signal();
         }
 
         @Override
         public void onSuccess(MCRJob job) {
-            synchronized (this) {
-                this.notifyAll();
-            }
+            signal();
         }
 
         @Override
         public void onProcessing(MCRJob job) {
-            synchronized (this) {
-                this.notifyAll();
-            }
+            signal();
         }
     }
 
@@ -366,18 +370,25 @@ public class MCRJobThreadStarter implements Runnable, Closeable {
 
         private final AtomicInteger activeThreads;
 
+        private final ListenerNotifier jobThreadFreed;
+
         ActiveCountingThreadPoolExecutor(int maxJobThreadCount,
             BlockingQueue<Runnable> workQueue,
             JobThreadFactory jobThreadFactory,
-            AtomicInteger activeThreads) {
+            AtomicInteger activeThreads,
+            ListenerNotifier jobThreadFreed) {
             super(maxJobThreadCount, maxJobThreadCount, 1, TimeUnit.DAYS, workQueue, jobThreadFactory);
             this.activeThreads = activeThreads;
+            this.jobThreadFreed = jobThreadFreed;
         }
 
         @Override
         protected void afterExecute(Runnable r, Throwable t) {
             super.afterExecute(r, t);
             activeThreads.decrementAndGet();
+            // the listeners were notified while this job still occupied its thread, so notify again now that the
+            // thread is actually free, otherwise the manager only notices it after ONE_MINUTE_IN_MS
+            jobThreadFreed.signal();
         }
 
         @Override

--- a/mycore-jobqueue/src/test/java/org/mycore/services/queuedjob/MCRJobThreadStarterTest.java
+++ b/mycore-jobqueue/src/test/java/org/mycore/services/queuedjob/MCRJobThreadStarterTest.java
@@ -21,6 +21,9 @@ package org.mycore.services.queuedjob;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -30,6 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mycore.common.MCRException;
 import org.mycore.common.MCRJPATestCase;
+import org.mycore.common.MCRTransactionManager;
 import org.mycore.common.processing.impl.MCRCentralProcessableRegistry;
 import org.mycore.services.queuedjob.action.MCRTestJobAction1;
 import org.mycore.services.queuedjob.config2.MCRConfiguration2JobConfig;
@@ -40,6 +44,26 @@ public class MCRJobThreadStarterTest extends MCRJPATestCase {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
+    private static final int JOB_THREADS = 2;
+
+    /**
+     * Time a job thread is kept inside {@link MCRJobRunnable#run()} after it notified the job manager about the
+     * completed job. Only has to outlast one scheduling round trip of the manager thread; a longer hold can never
+     * turn a failing run into a passing one, it only widens the window in which the manager is able to notice the
+     * freed job thread.
+     */
+    private static final long COMPLETION_HOLD_MS = 2000;
+
+    private static final AtomicInteger HANDED_OUT_JOBS = new AtomicInteger();
+
+    private static CountDownLatch allJobThreadsBusy;
+
+    private static CountDownLatch pendingJobIsPollable;
+
+    private static CountDownLatch managerIsScheduling;
+
+    private static CountDownLatch signalDelivered;
+
     private static List<MCRJob> getAllJobs(MCRJobDAOJPAImpl dao, Class<? extends MCRJobAction> action) {
         return dao.getJobs(action, null, null, null, null);
     }
@@ -48,6 +72,11 @@ public class MCRJobThreadStarterTest extends MCRJPATestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
+        HANDED_OUT_JOBS.set(0);
+        allJobThreadsBusy = new CountDownLatch(JOB_THREADS);
+        pendingJobIsPollable = new CountDownLatch(1);
+        managerIsScheduling = new CountDownLatch(1);
+        signalDelivered = new CountDownLatch(1);
     }
 
     @Override
@@ -59,7 +88,7 @@ public class MCRJobThreadStarterTest extends MCRJPATestCase {
     @Test
     public void testRun() {
         MCRConfiguration2JobConfig config = new MCRConfiguration2JobConfig();
-        MCRJobDAOJPAImpl dao = new MCRJobDAOJPAImpl();
+        MCRJobDAOJPAImpl dao = new GatedJobDAO();
         MCRJobQueue queue = new MCRJobQueue(MCRTestJobAction1.class, config, dao);
         MCRJobThreadStarter starter = new MCRJobThreadStarter(MCRTestJobAction1.class, config, queue);
 
@@ -94,7 +123,12 @@ public class MCRJobThreadStarterTest extends MCRJPATestCase {
         thread.start();
 
         try {
-            final int maxWait = 60000;
+            // The manager may not hand out more jobs than it has threads, so job3 is still NEW and the manager is
+            // waiting for a job thread to become free. Release job3 before any running job can complete.
+            Assert.assertTrue("job threads did not start", allJobThreadsBusy.await(30, TimeUnit.SECONDS));
+            pendingJobIsPollable.countDown();
+
+            final int maxWait = 5000; //lower than MCRJobThreadStarter.ONE_MINUTE_IN_MS to show slow throughput
             long startTime = System.currentTimeMillis();
             int stepTime = 100;
             while (getAllJobs(dao, job1.getAction()).stream()
@@ -109,9 +143,16 @@ public class MCRJobThreadStarterTest extends MCRJPATestCase {
             }
         } catch (InterruptedException e) {
             throw new MCRException(e);
+        } finally {
+            // fixes Thread leak: the manager thread and its job threads outlived this test otherwise
+            pendingJobIsPollable.countDown();
+            starter.prepareClose();
+            starter.close();
         }
 
         long allJobCount = getAllJobs(dao, job1.getAction()).stream().count();
+        long pendingJobCount =
+            getAllJobs(dao, job1.getAction()).stream().filter(j -> j.getStatus() == MCRJobStatus.NEW).count();
         long finishedJobCount =
             getAllJobs(dao, job1.getAction()).stream().filter(j -> j.getStatus() == MCRJobStatus.FINISHED).count();
         long errorJobCount =
@@ -120,14 +161,147 @@ public class MCRJobThreadStarterTest extends MCRJPATestCase {
         getAllJobs(dao, job1.getAction())
             .forEach(j -> LOGGER.info("Job in queue: {}", j));
         Assert.assertEquals("There should be 3 jobs", 3, allJobCount);
+        Assert.assertEquals("Job manager must not leave a job pending while its job threads are idle",
+            0, pendingJobCount);
         Assert.assertEquals("Finished Job count should be 2", 2, finishedJobCount);
         Assert.assertEquals("Error Job count should be 1", 1, errorJobCount);
+    }
+
+    /**
+     * A job offered while the job manager is scheduling must not have to wait for the fallback poll.
+     */
+    @Test
+    public void testSignalWhileScheduling() throws InterruptedException {
+        pendingJobIsPollable.countDown(); // no job thread has to be held back in this test
+        MCRConfiguration2JobConfig config = new MCRConfiguration2JobConfig();
+        MCRJobDAOJPAImpl dao = new BlockingJobDAO();
+        MCRJobQueue queue = new MCRJobQueue(MCRTestJobAction1.class, config, dao);
+        MCRJobThreadStarter starter = new MCRJobThreadStarter(MCRTestJobAction1.class, config, queue);
+
+        EntityTransaction transaction = getEntityManager().get().getTransaction();
+        transaction.commit();
+        transaction.begin();
+
+        Thread thread = new Thread(starter);
+        thread.start();
+        try {
+            // the manager is inside its poll now: past its last check for free job threads, but not yet waiting
+            Assert.assertTrue("manager did not start", managerIsScheduling.await(30, TimeUnit.SECONDS));
+
+            MCRJob job = new MCRJob(MCRTestJobAction1.class);
+            job.setParameter("count", "1");
+            job.setParameter("error", "false");
+            job.setStatus(MCRJobStatus.NEW);
+            job.setAdded(new Date());
+            queue.offer(job);
+            transaction.commit();
+            transaction.begin();
+            MCRTransactionManager.commitTransactions(); // runs the on-commit task that notifies the manager
+            signalDelivered.countDown();
+
+            final int maxWait = 5000; //lower than MCRJobThreadStarter.ONE_MINUTE_IN_MS to show slow throughput
+            long startTime = System.currentTimeMillis();
+            while (getAllJobs(dao, MCRTestJobAction1.class).stream()
+                .noneMatch(j -> j.getStatus() == MCRJobStatus.FINISHED)
+                && startTime + maxWait >= System.currentTimeMillis()) {
+                Thread.sleep(100);
+                transaction.rollback(); // rollback to get new data in the next iteration
+                transaction.begin();
+            }
+        } finally {
+            // fixes Thread leak: the manager thread and its job threads outlived this test otherwise
+            signalDelivered.countDown();
+            starter.prepareClose();
+            starter.close();
+        }
+
+        long finishedJobCount =
+            getAllJobs(dao, MCRTestJobAction1.class).stream().filter(j -> j.getStatus() == MCRJobStatus.FINISHED)
+                .count();
+        Assert.assertEquals("Job offered while the manager was scheduling should be run", 1, finishedJobCount);
     }
 
     @Override
     protected Map<String, String> getTestProperties() {
         Map<String, String> props = super.getTestProperties();
         props.put("MCR.Processable.Registry.Class", MCRCentralProcessableRegistry.class.getName());
+        props.put("MCR.QueuedJob.MCRTestJobAction1.JobThreads", Integer.toString(JOB_THREADS));
+        props.put("MCR.QueuedJob.MCRTestJobAction1.Listeners", SchedulingProbe.class.getName());
         return props;
+    }
+
+    /**
+     * Hands out no more jobs than the manager has threads until the test opened the gate. Without this the manager
+     * pre-fetches all three jobs while its threads are still starting up, which hides the scheduling defect.
+     */
+    private static final class GatedJobDAO extends MCRJobDAOJPAImpl {
+
+        @Override
+        public List<MCRJob> getNextJobs(Class<? extends MCRJobAction> action, Integer amount) {
+            if (HANDED_OUT_JOBS.get() >= JOB_THREADS && pendingJobIsPollable.getCount() > 0) {
+                return List.of();
+            }
+            List<MCRJob> jobs = super.getNextJobs(action, amount);
+            HANDED_OUT_JOBS.addAndGet(jobs.size());
+            return jobs;
+        }
+    }
+
+    /**
+     * Blocks the job manager inside its poll, so that the test can deliver a signal while the manager is
+     * scheduling rather than waiting.
+     */
+    private static final class BlockingJobDAO extends MCRJobDAOJPAImpl {
+
+        @Override
+        public List<MCRJob> getNextJobs(Class<? extends MCRJobAction> action, Integer amount) {
+            List<MCRJob> jobs = super.getNextJobs(action, amount);
+            managerIsScheduling.countDown();
+            SchedulingProbe.await(signalDelivered, 30000);
+            return jobs;
+        }
+    }
+
+    /**
+     * Registered via <code>MCR.QueuedJob.MCRTestJobAction.Listeners</code> and therefore called by
+     * {@link MCRJobRunnable} right after the job manager's own listener, on the job thread and still inside
+     * {@link MCRJobRunnable#run()}.
+     */
+    public static final class SchedulingProbe implements MCRJobStatusListener {
+
+        @Override
+        public void onProcessing(MCRJob job) {
+            // ThreadPoolExecutor#beforeExecute() already counted this thread as active
+            allJobThreadsBusy.countDown();
+            await(pendingJobIsPollable, 30000);
+        }
+
+        @Override
+        public void onSuccess(MCRJob job) {
+            holdJobThread();
+        }
+
+        @Override
+        public void onError(MCRJob job, Exception e) {
+            holdJobThread();
+        }
+
+        /**
+         * The manager has just been notified about this job. Stay inside {@link MCRJobRunnable#run()} so that
+         * {@link java.util.concurrent.ThreadPoolExecutor#afterExecute} cannot release this job thread yet: the
+         * manager has to decide about the pending job while the completed job still occupies its thread.
+         */
+        private static void holdJobThread() {
+            await(new CountDownLatch(1), COMPLETION_HOLD_MS);
+        }
+
+        static void await(CountDownLatch latch, long millis) {
+            try {
+                latch.await(millis, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new MCRException(e);
+            }
+        }
     }
 }

--- a/mycore-jobqueue/src/test/java/org/mycore/services/queuedjob/MCRJobThreadStarterTest.java
+++ b/mycore-jobqueue/src/test/java/org/mycore/services/queuedjob/MCRJobThreadStarterTest.java
@@ -52,7 +52,7 @@ public class MCRJobThreadStarterTest extends MCRJPATestCase {
      * turn a failing run into a passing one, it only widens the window in which the manager is able to notice the
      * freed job thread.
      */
-    private static final long COMPLETION_HOLD_MS = 2000;
+    private static final long COMPLETION_HOLD_MS = 200;
 
     private static final AtomicInteger HANDED_OUT_JOBS = new AtomicInteger();
 
@@ -263,7 +263,7 @@ public class MCRJobThreadStarterTest extends MCRJPATestCase {
     }
 
     /**
-     * Registered via <code>MCR.QueuedJob.MCRTestJobAction.Listeners</code> and therefore called by
+     * Registered via <code>MCR.QueuedJob.MCRTestJobAction1.Listeners</code> and therefore called by
      * {@link MCRJobRunnable} right after the job manager's own listener, on the job thread and still inside
      * {@link MCRJobRunnable#run()}.
      */
@@ -292,7 +292,12 @@ public class MCRJobThreadStarterTest extends MCRJPATestCase {
          * manager has to decide about the pending job while the completed job still occupies its thread.
          */
         private static void holdJobThread() {
-            await(new CountDownLatch(1), COMPLETION_HOLD_MS);
+            try {
+                Thread.sleep(COMPLETION_HOLD_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new MCRException(e);
+            }
         }
 
         static void await(CountDownLatch latch, long millis) {


### PR DESCRIPTION
MCRJobThreadStarter learned about finished jobs only through ListenerNotifier. MCRJobRunnable calls onSuccess/onError before ThreadPoolExecutor.afterExecute() decrements activeThreads, so the manager woke up, still saw all threads busy and went back to wait(). The decrement itself notified nobody, so a pending job was only picked up by the 60s fallback poll.

The wait() also had no condition variable, so a notification arriving between hasFreeJobThreads() and entering the monitor was lost.

afterExecute() now signals the manager after the decrement, and ListenerNotifier remembers a signal in a flag, so awaitSignal() returns at once when a signal arrived while the manager was scheduling. prepareClose() and the four on* methods share the same signal().

MCRJobThreadStarterTest covers both defects. testRun keeps the manager from pre-fetching more jobs than it has threads and holds a job thread inside MCRJobRunnable.run() after the notification. The second test blocks the manager inside its poll while a job is offered.

[Link to jira](https://mycore.atlassian.net/browse/MCR-3824).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [x] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [x] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
