### PR TITLE
MCR-3828 make basic auth parsing in MCRSessionFilter more robust

### DIFF
--- a/mycore-restapi/pom.xml
+++ b/mycore-restapi/pom.xml
@@ -130,6 +130,10 @@
       <artifactId>jdom2</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mycore</groupId>
       <artifactId>mycore-base</artifactId>
     </dependency>
@@ -159,6 +163,16 @@
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-sse</artifactId>
       <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mycore</groupId>
+      <artifactId>mycore-base</artifactId>
+      <type>test-jar</type>
     </dependency>
   </dependencies>
 </project>

--- a/mycore-restapi/pom.xml
+++ b/mycore-restapi/pom.xml
@@ -173,6 +173,7 @@
       <groupId>org.mycore</groupId>
       <artifactId>mycore-base</artifactId>
       <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/mycore-restapi/src/main/java/org/mycore/restapi/MCRSessionFilter.java
+++ b/mycore-restapi/src/main/java/org/mycore/restapi/MCRSessionFilter.java
@@ -218,22 +218,34 @@ public class MCRSessionFilter implements ContainerRequestFilter, ContainerRespon
             .getBytes(StandardCharsets.ISO_8859_1);
         String userPwd = new String(Base64.getDecoder().decode(encodedAuth), StandardCharsets.ISO_8859_1);
         if (userPwd.contains(":") && userPwd.length() > 1) {
-            String[] upSplit = userPwd.split(":");
-            String username = upSplit[0];
-            String password = upSplit[1];
+
+            String[] parts = userPwd.split(":", 2);
+            if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+                throw getInvalidCredentialsException();
+            }
+            String username = parts[0];
+            String password = parts[1];
+
             return Optional.ofNullable(MCRUserManager.checkPassword(username, password))
                 .map(MCRUserInformation.class::cast)
-                .orElseThrow(() -> {
-                    Map<String, String> attrs = new LinkedHashMap<>();
-                    attrs.put("error", "invalid_login");
-                    attrs.put("error_description", "Wrong login or password.");
-                    return new NotAuthorizedException(Response.status(Response.Status.UNAUTHORIZED)
-                        .header(HttpHeaders.WWW_AUTHENTICATE,
-                            MCRRestAPIUtil.getWWWAuthenticateHeader(null, attrs, app))
-                        .build());
-                });
+                .orElseThrow(this::getInvalidCredentialsException);
         }
-        return null;
+        throw getInvalidCredentialsException();
+    }
+
+    private NotAuthorizedException getInvalidCredentialsException() {
+        Map<String, String> attrs = new LinkedHashMap<>();
+        attrs.put("error", "invalid_login");
+        attrs.put("error_description", "Wrong login or password.");
+
+        return new NotAuthorizedException(
+            Response.status(Response.Status.UNAUTHORIZED)
+                .header(
+                    HttpHeaders.WWW_AUTHENTICATE,
+                    MCRRestAPIUtil.getWWWAuthenticateHeader(null, attrs, app)
+                )
+                .build()
+        );
     }
 
     private MCRUserInformation extractUserFromBearerAuth(ContainerRequestContext requestContext,

--- a/mycore-restapi/src/test/java/org/mycore/restapi/MCRSessionFilterTest.java
+++ b/mycore-restapi/src/test/java/org/mycore/restapi/MCRSessionFilterTest.java
@@ -1,0 +1,169 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.restapi;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.SecurityContext;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mycore.common.MCRSession;
+import org.mycore.common.MCRSessionMgr;
+import org.mycore.common.MCRTransactionManager;
+import org.mycore.frontend.MCRFrontendUtil;
+import org.mycore.test.MyCoReTest;
+import org.mycore.user2.MCRUser;
+import org.mycore.user2.MCRUserManager;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@MyCoReTest
+public class MCRSessionFilterTest {
+
+    private MCRSessionFilter filter;
+    private ContainerRequestContext requestContext;
+    private HttpServletRequest servletRequest;
+    private MCRSession session;
+    private MCRUser user;
+
+    private MockedStatic<MCRSessionMgr> sessionManager;
+    private MockedStatic<MCRTransactionManager> transactionManager;
+    private MockedStatic<MCRFrontendUtil> frontendUtil;
+    private MockedStatic<MCRUserManager> userManager;
+
+    @BeforeEach
+    void setUp() {
+        filter = new MCRSessionFilter();
+
+        filter.app = mock(Application.class);
+        requestContext = mock(ContainerRequestContext.class);
+        SecurityContext securityContext = mock(SecurityContext.class);
+        servletRequest = mock(HttpServletRequest.class);
+        session = mock(MCRSession.class);
+        user = mock(MCRUser.class);
+
+        filter.httpServletRequest = servletRequest;
+
+        when(requestContext.getSecurityContext()).thenReturn(securityContext);
+        when(securityContext.isSecure()).thenReturn(false);
+        when(session.getUserInformation()).thenReturn(user);
+
+        sessionManager = mockStatic(MCRSessionMgr.class);
+        transactionManager = mockStatic(MCRTransactionManager.class);
+        frontendUtil = mockStatic(MCRFrontendUtil.class);
+        userManager = mockStatic(MCRUserManager.class);
+
+        sessionManager.when(MCRSessionMgr::hasCurrentSession)
+            .thenReturn(false);
+        sessionManager.when(MCRSessionMgr::getCurrentSession)
+            .thenReturn(session);
+
+        frontendUtil.when(() -> MCRFrontendUtil.getRemoteAddr(servletRequest))
+            .thenReturn("127.0.0.1");
+    }
+
+    @AfterEach
+    void tearDown() {
+        userManager.close();
+        frontendUtil.close();
+        transactionManager.close();
+        sessionManager.close();
+    }
+
+    @Test
+    void testBasicAuthenticationFullUserAndPw() {
+        setBasicAuthorization("alice", "password");
+
+        userManager.when(() -> MCRUserManager.checkPassword("alice", "password"))
+            .thenReturn(user);
+
+        assertDoesNotThrow(() -> filter.filter(requestContext));
+
+        userManager.verify(() -> MCRUserManager.checkPassword("alice", "password"));
+        verify(session).setUserInformation(user);
+        verify(requestContext).setSecurityContext(any(SecurityContext.class));
+    }
+
+    @Test
+    void testBasicAuthenticationNoPw() {
+        setBasicAuthorization("alice", "");
+
+        userManager.when(() -> MCRUserManager.checkPassword("alice", ""))
+            .thenReturn(user);
+
+        assertThrows(NotAuthorizedException.class, () -> filter.filter(requestContext));
+
+        userManager.verify(() -> MCRUserManager.checkPassword("alice", ""), never());
+        verify(session, never()).setUserInformation(user);
+        verify(requestContext, never()).setSecurityContext(any(SecurityContext.class));
+    }
+
+    @Test
+    void testBasicAuthenticationNoUser() {
+        setBasicAuthorization("", "password");
+
+        userManager.when(() -> MCRUserManager.checkPassword("", "password"))
+            .thenReturn(user);
+
+        assertThrows(NotAuthorizedException.class, () -> filter.filter(requestContext));
+
+        userManager.verify(() -> MCRUserManager.checkPassword("", "password"), never());
+        verify(session, never()).setUserInformation(user);
+        verify(requestContext, never()).setSecurityContext(any(SecurityContext.class));
+    }
+
+    @Test
+    void testBasicAuthenticationNoUserNoPW() {
+        setBasicAuthorization("", "");
+
+        userManager.when(() -> MCRUserManager.checkPassword("", ""))
+            .thenReturn(user);
+
+        assertThrows(NotAuthorizedException.class, () -> filter.filter(requestContext));
+
+        userManager.verify(() -> MCRUserManager.checkPassword("", ""), never());
+        verify(session, never()).setUserInformation(user);
+        verify(requestContext, never()).setSecurityContext(any(SecurityContext.class));
+    }
+
+    private void setBasicAuthorization(String username, String password) {
+        String credentials = username + ":" + password;
+
+        String authorization = "Basic " + Base64.getEncoder()
+            .encodeToString(credentials.getBytes(StandardCharsets.ISO_8859_1));
+
+        when(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION))
+            .thenReturn(authorization);
+    }
+}


### PR DESCRIPTION
[Link to jira](https://mycore.atlassian.net/browse/MCR-3828).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [ ] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [x] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally (through a new unit test)
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [ ] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [ ] If the **public API** has changed:
  - [ ] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [x] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
