### PR TITLE
MCR-3830 Share XSL transformer factories

### DIFF
--- a/mycore-base/src/main/java/org/mycore/common/content/transformer/MCRXSL2XMLTransformer.java
+++ b/mycore-base/src/main/java/org/mycore/common/content/transformer/MCRXSL2XMLTransformer.java
@@ -38,6 +38,7 @@ import org.mycore.common.config.MCRConfigurationException;
 import org.mycore.common.content.MCRContent;
 import org.mycore.common.content.MCRJDOMContent;
 import org.mycore.common.xml.MCRXMLHelper;
+import org.mycore.common.xsl.MCRTransformerFactorySelector;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 
@@ -52,6 +53,7 @@ import org.xml.sax.XMLReader;
  * @author Thomas Scheffler (yagee)
  *
  */
+@SuppressWarnings("removal")
 public class MCRXSL2XMLTransformer extends MCRXSLTransformer {
 
     private static final MCRCache<String, MCRXSL2XMLTransformer> INSTANCE_CACHE = new MCRCache<>(100,
@@ -65,27 +67,43 @@ public class MCRXSL2XMLTransformer extends MCRXSLTransformer {
         super(stylesheets);
     }
 
+    /**
+     * @deprecated use a configured factory ID through {@link #obtainInstanceByFactory(String, String...)}
+     */
+    @Deprecated(forRemoval = true)
     public MCRXSL2XMLTransformer(Class<? extends TransformerFactory> factoryClass) {
         super(factoryClass);
     }
 
+    /**
+     * @deprecated use a configured factory ID through {@link #obtainInstanceByFactory(String, String...)}
+     */
+    @Deprecated(forRemoval = true)
     public MCRXSL2XMLTransformer(Class<? extends TransformerFactory> factoryClass, String... stylesheets) {
         super(factoryClass, stylesheets);
     }
 
-    public static MCRXSL2XMLTransformer obtainInstance(String... stylesheets) {
-        return obtainInstance(DEFAULT_FACTORY_CLASS, stylesheets);
+    private MCRXSL2XMLTransformer(String factoryId, String[] stylesheets) {
+        super(stylesheets, factoryId);
     }
 
+    public static MCRXSL2XMLTransformer obtainInstance(String... stylesheets) {
+        return obtainInstanceByFactory(MCRTransformerFactorySelector.getDefaultFactoryId(), stylesheets);
+    }
+
+    public static MCRXSL2XMLTransformer obtainInstanceByFactory(String factoryId, String... stylesheets) {
+        return obtainCachedInstance(INSTANCE_CACHE, factoryId, stylesheets,
+            () -> new MCRXSL2XMLTransformer(factoryId, stylesheets));
+    }
+
+    /**
+     * @deprecated use {@link #obtainInstanceByFactory(String, String...)}
+     */
+    @Deprecated(forRemoval = true)
     public static MCRXSL2XMLTransformer obtainInstance(Class<? extends TransformerFactory> factoryClass,
         String... stylesheets) {
-        String key = stylesheets.length == 1 ? stylesheets[0] : Arrays.toString(stylesheets);
-        MCRXSL2XMLTransformer instance = INSTANCE_CACHE.get(key);
-        if (instance == null) {
-            instance = new MCRXSL2XMLTransformer(factoryClass, stylesheets);
-            INSTANCE_CACHE.put(key, instance);
-        }
-        return instance;
+        return obtainCachedInstance(INSTANCE_CACHE, factoryClass.getName(), stylesheets,
+            () -> new MCRXSL2XMLTransformer(factoryClass, stylesheets));
     }
 
     @Override

--- a/mycore-base/src/main/java/org/mycore/common/content/transformer/MCRXSLTransformer.java
+++ b/mycore-base/src/main/java/org/mycore/common/content/transformer/MCRXSLTransformer.java
@@ -22,11 +22,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Deque;
-import java.util.Optional;
 import java.util.Properties;
+import java.util.function.Supplier;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Result;
@@ -34,10 +33,8 @@ import javax.xml.transform.Templates;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.sax.SAXSource;
-import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
 import javax.xml.transform.stream.StreamResult;
 
@@ -49,7 +46,6 @@ import org.mycore.common.MCRClassTools;
 import org.mycore.common.MCRException;
 import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.config.MCRConfigurationBase;
-import org.mycore.common.config.MCRConfigurationException;
 import org.mycore.common.content.MCRByteContent;
 import org.mycore.common.content.MCRContent;
 import org.mycore.common.content.MCRWrappedContent;
@@ -60,17 +56,17 @@ import org.mycore.common.xml.MCRXMLParserFactory;
 import org.mycore.common.xml.MCRXSLTransformerUtils;
 import org.mycore.common.xsl.MCRErrorListener;
 import org.mycore.common.xsl.MCRParameterCollector;
+import org.mycore.common.xsl.MCRSAXTransformerFactoryManager;
 import org.mycore.common.xsl.MCRTemplatesSource;
-import org.mycore.common.xsl.uriresolver.MCRURIResolver;
+import org.mycore.common.xsl.MCRTransformerFactorySelector;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 
 /**
  * Transforms XML content using a static XSL stylesheet. The stylesheet is configured via
  * <code>MCR.ContentTransformer.{ID}.Stylesheet</code>. You may choose your own instance of
- * {@link SAXTransformerFactory} via <code>MCR.ContentTransformer.{ID}.TransformerFactoryClass</code>.
- * The default transformer factory implementation {@link org.apache.xalan.processor.TransformerFactoryImpl}
- * is configured with <code>MCR.LayoutService.TransformerFactoryClass</code>.
+ * transformer factory via <code>MCR.ContentTransformer.{ID}.TransformerFactory</code>.
+ * The default transformer factory ID is configured with <code>MCR.LayoutService.TransformerFactory</code>.
  *
  * @author Frank Lützenkirchen
  */
@@ -78,8 +74,6 @@ import org.xml.sax.XMLReader;
 public class MCRXSLTransformer extends MCRParameterizedTransformer {
 
     private static final int INITIAL_BUFFER_SIZE = 32 * 1024;
-
-    private static final MCRURIResolver URI_RESOLVER = MCRURIResolver.obtainInstance();
 
     private static final MCREntityResolver ENTITY_RESOLVER = MCREntityResolver.getInstance();
 
@@ -91,9 +85,12 @@ public class MCRXSLTransformer extends MCRParameterizedTransformer {
     private static final long CHECK_PERIOD = MCRConfiguration2.getLong("MCR.LayoutService.LastModifiedCheckPeriod")
         .orElse(60_000L);
 
-    public static final Class<? extends TransformerFactory> DEFAULT_FACTORY_CLASS = MCRConfiguration2
-        .<TransformerFactory>getClass("MCR.LayoutService.TransformerFactoryClass")
-        .orElseGet(TransformerFactory.newInstance()::getClass);
+    /**
+     * @deprecated use {@link MCRTransformerFactorySelector#getDefaultFactoryId()} and a configured factory ID
+     */
+    @Deprecated(forRemoval = true)
+    public static final Class<? extends TransformerFactory> DEFAULT_FACTORY_CLASS = MCRSAXTransformerFactoryManager
+        .obtainInstance().getFactoryClass();
 
     /** The compiled XSL stylesheet */
     protected MCRTemplatesSource[] templateSources;
@@ -104,67 +101,102 @@ public class MCRXSLTransformer extends MCRParameterizedTransformer {
 
     protected long modifiedChecked;
 
-    protected SAXTransformerFactory tFactory;
+    private MCRSAXTransformerFactoryManager factoryManager;
 
     public MCRXSLTransformer() {
-        this(DEFAULT_FACTORY_CLASS, new String[0]);
+        this(new String[0], MCRTransformerFactorySelector.getDefaultFactoryId());
     }
 
     public MCRXSLTransformer(String... stylesheets) {
-        this(DEFAULT_FACTORY_CLASS, stylesheets);
+        this(stylesheets, MCRTransformerFactorySelector.getDefaultFactoryId());
     }
 
+    /**
+     * @deprecated use a configured factory ID through {@link #obtainInstanceByFactory(String, String...)}
+     */
+    @Deprecated(forRemoval = true)
     public MCRXSLTransformer(Class<? extends TransformerFactory> factoryClass) {
         this(factoryClass, new String[0]);
     }
 
+    /**
+     * @deprecated use a configured factory ID through {@link #obtainInstanceByFactory(String, String...)}
+     */
+    @Deprecated(forRemoval = true)
     public MCRXSLTransformer(Class<? extends TransformerFactory> factoryClass, String... stylesheets) {
-        setTransformerFactory(factoryClass.getName());
+        setTransformerFactory(factoryClass);
+        setStylesheets(stylesheets);
+    }
+
+    protected MCRXSLTransformer(String[] stylesheets, String factoryId) {
+        setTransformerFactory(factoryId);
         setStylesheets(stylesheets);
     }
 
     /**
-     * Sets the class name for {@link TransformerFactory} used by this transformer.
+     * Sets the shared {@link TransformerFactory} implementation used by this transformer.
      * <p>
      * Must be called for thread safety before this instance is shared to other threads.
      */
-    private void setTransformerFactory(String factoryClass) throws TransformerFactoryConfigurationError {
-        TransformerFactory transformerFactory = Optional.ofNullable(factoryClass)
-            .map(c -> TransformerFactory.newInstance(c, MCRClassTools.getClassLoader()))
-            .orElseGet(TransformerFactory::newInstance);
-        LOGGER.debug("Transformerfactory: {}", () -> transformerFactory.getClass().getName());
-        transformerFactory.setURIResolver(URI_RESOLVER);
-        transformerFactory.setErrorListener(new MCRErrorListener());
-        if (transformerFactory.getFeature(SAXSource.FEATURE) && transformerFactory.getFeature(SAXResult.FEATURE)) {
-            this.tFactory = (SAXTransformerFactory) transformerFactory;
-        } else {
-            throw new MCRConfigurationException("Transformer Factory " + transformerFactory.getClass().getName()
-                + " does not implement SAXTransformerFactory");
-        }
+    @SuppressWarnings("removal")
+    private void setTransformerFactory(Class<? extends TransformerFactory> factoryClass) {
+        this.factoryManager = MCRSAXTransformerFactoryManager.obtainInstance(factoryClass);
     }
 
-   public static MCRXSLTransformer obtainInstance(String... stylesheets) {
-        return obtainInstance(DEFAULT_FACTORY_CLASS, stylesheets);
+    private void setTransformerFactory(String factoryId) {
+        this.factoryManager = MCRSAXTransformerFactoryManager.obtainInstance(factoryId);
     }
 
+    public static MCRXSLTransformer obtainInstance(String... stylesheets) {
+        return obtainInstanceByFactory(MCRTransformerFactorySelector.getDefaultFactoryId(), stylesheets);
+    }
+
+    public static MCRXSLTransformer obtainInstanceByFactory(String factoryId, String... stylesheets) {
+        return obtainCachedInstance(INSTANCE_CACHE, factoryId, stylesheets,
+            () -> new MCRXSLTransformer(stylesheets, factoryId));
+    }
+
+    /**
+     * @deprecated use {@link #obtainInstanceByFactory(String, String...)}
+     */
+    @Deprecated(forRemoval = true)
     public static MCRXSLTransformer obtainInstance(Class<? extends TransformerFactory> factoryClass,
         String... stylesheets) {
-        String key = factoryClass.getName() + "_"
-            + (stylesheets.length == 1 ? stylesheets[0] : Arrays.toString(stylesheets));
-        MCRXSLTransformer instance = INSTANCE_CACHE.get(key);
-        if (instance == null) {
-            instance = new MCRXSLTransformer(factoryClass, stylesheets);
-            INSTANCE_CACHE.put(key, instance);
+        return obtainCachedInstance(INSTANCE_CACHE, factoryClass.getName(), stylesheets,
+            () -> new MCRXSLTransformer(factoryClass, stylesheets));
+    }
+
+    protected static <T> T obtainCachedInstance(MCRCache<String, T> cache, String factoryKey, String[] stylesheets,
+        Supplier<T> instanceSupplier) {
+        // NUL cannot occur in factory IDs or stylesheet paths, so every segment boundary remains unambiguous.
+        StringBuilder key = new StringBuilder(factoryKey).append('\0');
+        for (String stylesheet : stylesheets) {
+            key.append(stylesheet).append('\0');
+        }
+        String cacheKey = key.toString();
+        T instance = cache.get(cacheKey);
+        if (instance != null) {
+            return instance;
+        }
+        synchronized (cache) {
+            instance = cache.get(cacheKey);
+            if (instance == null) {
+                instance = instanceSupplier.get();
+                cache.put(cacheKey, instance);
+            }
         }
         return instance;
     }
 
     /**
      * Creates a new {@link TransformerFactory} instance of the configured default implementation
-     * (see <code>MCR.LayoutService.TransformerFactoryClass</code>).
+     * (see <code>MCR.LayoutService.TransformerFactory</code>).
+     *
+     * @deprecated use {@link MCRSAXTransformerFactoryManager#obtainInstance(String)} to reuse the configured provider
      *
      * @return a new transformer factory
      */
+    @Deprecated(forRemoval = true)
     public static TransformerFactory createDefaultTransformerFactory() {
         return TransformerFactory.newInstance(DEFAULT_FACTORY_CLASS.getName(), MCRClassTools.getClassLoader());
     }
@@ -175,8 +207,11 @@ public class MCRXSLTransformer extends MCRParameterizedTransformer {
         String property = "MCR.ContentTransformer." + id + ".Stylesheet";
         String[] stylesheets = MCRConfiguration2.getStringOrThrow(property).split(",");
         setStylesheets(stylesheets);
-        MCRConfiguration2.getString("MCR.ContentTransformer." + id + ".TransformerFactoryClass")
-            .ifPresent(this::setTransformerFactory);
+        String factoryProperty = "MCR.ContentTransformer." + id + ".TransformerFactory";
+        String legacyFactoryProperty = factoryProperty + "Class";
+        String factoryId = MCRTransformerFactorySelector.getFactoryId(factoryProperty, legacyFactoryProperty,
+            factoryManager.getId());
+        setTransformerFactory(factoryId);
     }
 
     public void setStylesheets(String... stylesheets) {
@@ -203,7 +238,7 @@ public class MCRXSLTransformer extends MCRParameterizedTransformer {
                         throw new TransformerConfigurationException(
                             "XSLT Stylesheet could not be found: " + templateSources[i].getKey());
                     }
-                    templates[i] = tFactory.newTemplates(source);
+                    templates[i] = factoryManager.newTemplates(source);
                     if (templates[i] == null) {
                         throw new TransformerConfigurationException(
                             "XSLT Stylesheet could not be compiled: " + templateSources[i].getURL());
@@ -334,7 +369,7 @@ public class MCRXSLTransformer extends MCRParameterizedTransformer {
         Deque<TransformerHandler> xslSteps = new ArrayDeque<>();
         //every transformhandler shares the same ErrorListener instance
         for (Templates template : templates) {
-            TransformerHandler handler = tFactory.newTransformerHandler(template);
+            TransformerHandler handler = factoryManager.newTransformerHandler(template);
             parameterCollector.setParametersTo(handler.getTransformer());
             handler.getTransformer().setErrorListener(new MCRErrorListener());
             if (!xslSteps.isEmpty()) {

--- a/mycore-base/src/main/java/org/mycore/common/xml/MCRLayoutService.java
+++ b/mycore-base/src/main/java/org/mycore/common/xml/MCRLayoutService.java
@@ -39,8 +39,8 @@ import org.mycore.common.config.annotation.MCRFactory;
 import org.mycore.common.content.MCRContent;
 import org.mycore.common.content.transformer.MCRContentTransformer;
 import org.mycore.common.content.transformer.MCRParameterizedTransformer;
-import org.mycore.common.content.transformer.MCRXSLTransformer;
 import org.mycore.common.xsl.MCRParameterCollector;
+import org.mycore.common.xsl.MCRSAXTransformerFactoryManager;
 import org.xml.sax.SAXException;
 
 import jakarta.servlet.ServletOutputStream;
@@ -79,7 +79,9 @@ public class MCRLayoutService {
     public void sendXML(HttpServletRequest req, HttpServletResponse res, MCRContent xml) throws IOException {
         res.setContentType("text/xml; charset=UTF-8");
         try {
-            Transformer transformer = MCRXSLTransformer.createDefaultTransformerFactory().newTransformer();
+            Transformer transformer = MCRSAXTransformerFactoryManager
+                .obtainInstance()
+                .newTransformer();
             transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
             transformer.setOutputProperty(OutputKeys.INDENT, "no");
             StreamResult result = new StreamResult(res.getOutputStream());

--- a/mycore-base/src/main/java/org/mycore/common/xml/MCRLayoutTransformerFactory.java
+++ b/mycore-base/src/main/java/org/mycore/common/xml/MCRLayoutTransformerFactory.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,6 +41,7 @@ import org.mycore.common.content.transformer.MCRContentTransformerFactory;
 import org.mycore.common.content.transformer.MCRIdentityTransformer;
 import org.mycore.common.content.transformer.MCRTransformerPipe;
 import org.mycore.common.content.transformer.MCRXSLTransformer;
+import org.mycore.common.xsl.MCRTransformerFactorySelector;
 import org.mycore.common.xsl.MCRXSLResourceHelper;
 import org.xml.sax.SAXException;
 
@@ -103,10 +103,7 @@ public class MCRLayoutTransformerFactory {
         if (!MCRConfiguration2.getBoolean("MCR.LayoutTransformerFactory.SuggestProperties").get()) {
             return;
         }
-        Class<? extends TransformerFactory> transformerClass = MCRConfiguration2
-            .<TransformerFactory>getClass("MCR.LayoutService.TransformerFactoryClass")
-            .orElseGet(TransformerFactory.newInstance()::getClass);
-        String classAlias = getTransformerClassValue(transformerClass);
+        String transformerFactory = MCRTransformerFactorySelector.getDefaultFactoryId();
         StringBuilder properties = new StringBuilder();
         properties.append("# Configuration for transformer ").append(idStripped).append('\n');
         String cfgPrefix = "MCR.ContentTransformer.";
@@ -118,8 +115,8 @@ public class MCRLayoutTransformerFactory {
                 .append('\n');
             properties.append(cfgPrefix)
                     .append(idStripped)
-                    .append(".TransformerFactoryClass=")
-                    .append(classAlias)
+                    .append(".TransformerFactory=")
+                    .append(transformerFactory)
                     .append('\n');
             properties.append(cfgPrefix)
                 .append(idStripped)
@@ -134,8 +131,8 @@ public class MCRLayoutTransformerFactory {
                 .append('\n');
             properties.append(cfgPrefix)
                 .append(idStripped)
-                .append(".TransformerFactoryClass=")
-                .append(classAlias)
+                .append(".TransformerFactory=")
+                .append(transformerFactory)
                 .append('\n');
             properties.append(cfgPrefix)
                 .append(idStripped)
@@ -157,8 +154,8 @@ public class MCRLayoutTransformerFactory {
                     .append('\n');
                 properties.append(cfgPrefix)
                     .append(thisTransformerId)
-                    .append(".TransformerFactoryClass=")
-                    .append(classAlias)
+                    .append(".TransformerFactory=")
+                    .append(transformerFactory)
                     .append('\n');
                 properties.append(cfgPrefix)
                     .append(thisTransformerId)
@@ -176,16 +173,6 @@ public class MCRLayoutTransformerFactory {
     private String getTransformerId(String stylesheet) {
         String withoutExtension = stylesheet.replaceAll("\\.xsl$", "");
         return "tmp_" + withoutExtension.replaceAll("[^a-zA-Z0-9]", "_");
-    }
-
-    private String getTransformerClassValue(Class<? extends TransformerFactory> transformerClass) {
-        if (Objects.equals(transformerClass.getName(), MCRConfiguration2.getStringOrThrow("SAXON"))) {
-            return "%SAXON%";
-        } else if (Objects.equals(transformerClass.getName(), MCRConfiguration2.getStringOrThrow("XALAN"))) {
-            return "%XALAN%";
-        } else {
-            return transformerClass.getName();
-        }
     }
 
     protected String[] getStylesheets(String id, String stylesheet)

--- a/mycore-base/src/main/java/org/mycore/common/xsl/MCRLegacyTransformerFactorySupport.java
+++ b/mycore-base/src/main/java/org/mycore/common/xsl/MCRLegacyTransformerFactorySupport.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.xsl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import javax.xml.transform.TransformerFactory;
+
+import org.mycore.common.MCRClassTools;
+import org.mycore.common.config.MCRConfiguration2;
+
+/**
+ * Compatibility support for class-based transformer factory selection.
+ * <p>
+ * Resolves legacy classes to a unique configured ID, preferring exact matches over subclasses.
+ * Classes without a unique match receive an internal {@code legacy:} ID. Their factories are created
+ * lazily, shared within the owning registry and always accessed serially.
+ * The class-to-ID registration is independent of registry initialization so legacy properties can be
+ * resolved while the registry is being constructed.
+ */
+final class MCRLegacyTransformerFactorySupport {
+
+    private static final String CLASS_PROPERTY_SUFFIX = ".Class";
+
+    private static final String LEGACY_FACTORY_ID_PREFIX = "legacy:";
+
+    private static final ConcurrentMap<String, Class<? extends TransformerFactory>> LEGACY_FACTORY_CLASSES =
+        new ConcurrentHashMap<>();
+
+    private final ConcurrentMap<String, MCRSAXTransformerFactoryManager> factories = new ConcurrentHashMap<>();
+
+    /**
+     * Returns the shared legacy factory, or {@code null} if the ID has not been registered for a class.
+     */
+    MCRSAXTransformerFactoryManager get(String id) {
+        Class<? extends TransformerFactory> factoryClass = LEGACY_FACTORY_CLASSES.get(id);
+        return factoryClass == null ? null : factories.computeIfAbsent(id, _ -> createLegacyFactory(id, factoryClass));
+    }
+
+    static String getFactoryId(Class<? extends TransformerFactory> factoryClass,
+        Map<String, MCRSAXTransformerFactoryManager> configuredFactories) {
+        Map<String, Class<? extends TransformerFactory>> factoryClasses = new HashMap<>();
+        configuredFactories.forEach((id, factory) -> factoryClasses.put(id, factory.getFactoryClass()));
+        return resolveFactoryId(factoryClasses, factoryClass);
+    }
+
+    /**
+     * Resolves an ID directly from properties without initializing the shared registry.
+     * This keeps legacy-property migration out of the registry's construction path.
+     */
+    static String getFactoryId(Class<? extends TransformerFactory> factoryClass) {
+        String propertyPrefix = MCRTransformerFactoryRegistry.CONFIGURATION_PREFIX + ".";
+        Map<String, Class<? extends TransformerFactory>> factoryClasses = new HashMap<>();
+        MCRConfiguration2.getSubpropertiesMap(propertyPrefix).keySet().stream()
+            .filter(key -> key.endsWith(CLASS_PROPERTY_SUFFIX))
+            .filter(key -> key.indexOf('.') == key.lastIndexOf('.'))
+            .map(key -> key.substring(0, key.length() - CLASS_PROPERTY_SUFFIX.length()))
+            .forEach(id -> MCRConfiguration2.<TransformerFactory>
+                getClass(propertyPrefix + id + CLASS_PROPERTY_SUFFIX)
+                .ifPresent(configuredClass -> factoryClasses.put(id, configuredClass)));
+        return resolveFactoryId(factoryClasses, factoryClass);
+    }
+
+    private static String resolveFactoryId(Map<String, Class<? extends TransformerFactory>> factoryClasses,
+        Class<? extends TransformerFactory> factoryClass) {
+        List<String> exactMatches = factoryClasses.entrySet().stream()
+            .filter(entry -> entry.getValue().equals(factoryClass))
+            .map(Map.Entry::getKey)
+            .toList();
+        if (!exactMatches.isEmpty()) {
+            return getConfiguredOrLegacyId(exactMatches, factoryClass);
+        }
+        List<String> assignableMatches = factoryClasses.entrySet().stream()
+            .filter(entry -> factoryClass.isAssignableFrom(entry.getValue()))
+            .map(Map.Entry::getKey)
+            .toList();
+        return getConfiguredOrLegacyId(assignableMatches, factoryClass);
+    }
+
+    private static String getConfiguredOrLegacyId(List<String> matches,
+        Class<? extends TransformerFactory> factoryClass) {
+        if (matches.size() == 1) {
+            return matches.getFirst();
+        }
+        String legacyFactoryId = LEGACY_FACTORY_ID_PREFIX + factoryClass.getName();
+        LEGACY_FACTORY_CLASSES.putIfAbsent(legacyFactoryId, factoryClass);
+        return legacyFactoryId;
+    }
+
+    static boolean isLegacyFactoryId(String factoryId) {
+        return factoryId.startsWith(LEGACY_FACTORY_ID_PREFIX);
+    }
+
+    private MCRSAXTransformerFactoryManager createLegacyFactory(String id,
+        Class<? extends TransformerFactory> factoryClass) {
+        TransformerFactory factory = TransformerFactory.newInstance(factoryClass.getName(),
+            MCRClassTools.getClassLoader());
+        return new MCRSAXTransformerFactoryManager(id, factory, true);
+    }
+
+}

--- a/mycore-base/src/main/java/org/mycore/common/xsl/MCRLegacyXSLCheck.java
+++ b/mycore-base/src/main/java/org/mycore/common/xsl/MCRLegacyXSLCheck.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.xsl;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.common.config.MCRConfigurationException;
+import org.mycore.common.events.MCRStartupHandler.AutoExecutable;
+
+import jakarta.servlet.ServletContext;
+
+/**
+ * Rejects legacy XSL factory properties that would be ignored in favor of a factory ID property.
+ * <p>
+ * This startup check is temporary compatibility support. Remove this class and its
+ * {@code MCR.Startup.Class} registration when the deprecated class-based transformer APIs
+ * and properties are removed.
+ */
+public class MCRLegacyXSLCheck implements AutoExecutable {
+
+    private static final String LEGACY_SUFFIX = ".TransformerFactoryClass";
+
+    @Override
+    public String getName() {
+        return "Legacy XSL configuration check";
+    }
+
+    @Override
+    public int getPriority() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public void startUp(ServletContext servletContext) {
+        Map<String, String> properties = MCRConfiguration2.getAllPropertiesMap();
+        String conflicts = properties.keySet().stream()
+            .filter(key -> key.endsWith(LEGACY_SUFFIX))
+            .filter(key -> properties.containsKey(currentProperty(key)))
+            .sorted()
+            .map(key -> migrationMessage(key, properties))
+            .collect(Collectors.joining("\n\n"));
+        if (!conflicts.isEmpty()) {
+            throw new MCRConfigurationException("Conflicting legacy XSL transformer factory properties. "
+                + "Migrate the following settings before starting the application:\n\n" + conflicts
+                + "\n\nFactory IDs are configured below '" + MCRTransformerFactoryRegistry.CONFIGURATION_PREFIX
+                + ".<ID>.Class'. Choose the ID matching the intended implementation; "
+                + "do not simply rename a class-valued property.");
+        }
+    }
+
+    private static String currentProperty(String legacyProperty) {
+        return legacyProperty.substring(0, legacyProperty.length() - "Class".length());
+    }
+
+    private static String migrationMessage(String legacyProperty, Map<String, String> properties) {
+        String property = currentProperty(legacyProperty);
+        return legacyProperty + "=" + properties.get(legacyProperty) + "\n"
+            + property + "=" + properties.get(property) + "\n"
+            + "Set '" + property + "' to the intended factory ID and remove '" + legacyProperty + "'.";
+    }
+
+}

--- a/mycore-base/src/main/java/org/mycore/common/xsl/MCRSAXTransformerFactoryManager.java
+++ b/mycore-base/src/main/java/org/mycore/common/xsl/MCRSAXTransformerFactoryManager.java
@@ -1,0 +1,234 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.xsl;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import javax.xml.transform.ErrorListener;
+import javax.xml.transform.Source;
+import javax.xml.transform.Templates;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.URIResolver;
+import javax.xml.transform.sax.SAXTransformerFactory;
+import javax.xml.transform.sax.TransformerHandler;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.common.config.MCRConfigurationException;
+import org.mycore.common.xsl.uriresolver.MCRURIResolver;
+
+/**
+ * Manages access to one application-scoped {@link SAXTransformerFactory}.
+ * <p>
+ * JAXP does not guarantee that a factory supports concurrent operations. Access can therefore be serialized for
+ * providers that require it, while the returned {@link Templates}, {@link Transformer}, and
+ * {@link TransformerHandler} instances can follow their individual JAXP lifecycle rules.
+ */
+public final class MCRSAXTransformerFactoryManager {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private final String id;
+
+    private final SAXTransformerFactory factory;
+
+    private final boolean serializeAccess;
+
+    private final Supplier<URIResolver> uriResolverSupplier;
+
+    private final Object factoryMonitor = new Object();
+
+    private final Object initializationMonitor = new Object();
+
+    private volatile boolean initialized;
+
+    private boolean initializing;
+
+    MCRSAXTransformerFactoryManager(String id, TransformerFactory factory, boolean serializeAccess) {
+        this(id, factory, serializeAccess, MCRURIResolver::obtainInstance);
+    }
+
+    MCRSAXTransformerFactoryManager(String id, TransformerFactory factory, boolean serializeAccess,
+        Supplier<URIResolver> uriResolverSupplier) {
+        this.id = Objects.requireNonNull(id);
+        Objects.requireNonNull(factory);
+        if (factory instanceof SAXTransformerFactory saxTransformerFactory) {
+            this.factory = saxTransformerFactory;
+        } else {
+            throw new MCRConfigurationException("Transformer Factory " + factory.getClass().getName()
+                + " does not implement SAXTransformerFactory");
+        }
+        this.serializeAccess = serializeAccess;
+        this.uriResolverSupplier = Objects.requireNonNull(uriResolverSupplier);
+    }
+
+    /**
+     * Returns the shared factory manager for the default selected at call time.
+     *
+     * @return shared manager selected by {@link MCRTransformerFactorySelector#getDefaultFactoryId()}
+     */
+    public static MCRSAXTransformerFactoryManager obtainInstance() {
+        return obtainInstance(MCRTransformerFactorySelector.getDefaultFactoryId());
+    }
+
+    /**
+     * Returns the shared, fully configured factory manager with the supplied ID.
+     *
+     * @param id configured factory ID
+     * @return shared manager for this ID
+     */
+    public static MCRSAXTransformerFactoryManager obtainInstance(String id) {
+        return LazyInstanceHolder.REGISTRY.get(id);
+    }
+
+    /**
+     * Returns the uniquely configured factory with the supplied implementation class.
+     *
+     * @deprecated use {@link #obtainInstance(String)} with a configured factory ID
+     */
+    @Deprecated(forRemoval = true)
+    public static MCRSAXTransformerFactoryManager obtainInstance(
+        Class<? extends TransformerFactory> factoryClass) {
+        return LazyInstanceHolder.REGISTRY.get(factoryClass);
+    }
+
+    /**
+     * Returns the configured ID of this manager.
+     *
+     * @return configured factory ID
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Compiles a stylesheet using the configured factory access policy.
+     */
+    public Templates newTemplates(Source source) throws TransformerConfigurationException {
+        return withFactoryAccess(() -> factory.newTemplates(source));
+    }
+
+    /**
+     * Creates a request-local transformer handler using the configured factory access policy.
+     */
+    public TransformerHandler newTransformerHandler(Templates templates) throws TransformerConfigurationException {
+        return withFactoryAccess(() -> factory.newTransformerHandler(templates));
+    }
+
+    /**
+     * Compiles a stylesheet and creates a request-local transformer using the configured factory access policy.
+     */
+    public Transformer newTransformer(Source source) throws TransformerConfigurationException {
+        return withFactoryAccess(() -> factory.newTransformer(source));
+    }
+
+    /**
+     * Creates a request-local identity transformer using the configured factory access policy.
+     */
+    public Transformer newTransformer() throws TransformerConfigurationException {
+        return withFactoryAccess(factory::newTransformer);
+    }
+
+    boolean isAccessSerialized() {
+        return serializeAccess;
+    }
+
+    private <T> T withFactoryAccess(FactoryOperation<T> operation) throws TransformerConfigurationException {
+        initialize();
+        if (!serializeAccess) {
+            return operation.execute();
+        }
+        synchronized (factoryMonitor) {
+            return operation.execute();
+        }
+    }
+
+    public Class<? extends TransformerFactory> getFactoryClass() {
+        return factory.getClass();
+    }
+
+    @SuppressWarnings("PMD.UnusedAssignment") // read by a same-thread recursive call through the resolver supplier
+    private void initialize() {
+        if (initialized) {
+            return;
+        }
+        synchronized (initializationMonitor) {
+            if (initialized) {
+                return;
+            }
+            if (initializing) {
+                throw new MCRConfigurationException("Recursive initialization of transformer factory manager '"
+                    + id + "'");
+            }
+            initializing = true;
+            try {
+                factory.setURIResolver(uriResolverSupplier.get());
+                factory.setErrorListener(new FactoryErrorListener());
+                initialized = true;
+            } finally {
+                initializing = false;
+            }
+        }
+    }
+
+    @FunctionalInterface
+    private interface FactoryOperation<T> {
+
+        T execute() throws TransformerConfigurationException;
+
+    }
+
+    private static final class LazyInstanceHolder {
+
+        private static final MCRTransformerFactoryRegistry REGISTRY = MCRConfiguration2
+            .getSingleInstanceOfOrThrow(MCRTransformerFactoryRegistry.class,
+                MCRTransformerFactoryRegistry.CONFIGURATION_PREFIX);
+
+    }
+
+    private static final class FactoryErrorListener implements ErrorListener {
+
+        @Override
+        public void warning(TransformerException exception) {
+            TransformerException unwrappedException = MCRErrorListener.unwrapException(exception);
+            LOGGER.warn("Warning while compiling XSL stylesheet:{}", unwrappedException::getMessageAndLocation);
+        }
+
+        @Override
+        public void error(TransformerException exception) throws TransformerException {
+            TransformerException unwrappedException = MCRErrorListener.unwrapException(exception);
+            LOGGER.error("Error while compiling XSL stylesheet:{}", unwrappedException::getMessageAndLocation);
+            throw unwrappedException;
+        }
+
+        @Override
+        public void fatalError(TransformerException exception) throws TransformerException {
+            TransformerException unwrappedException = MCRErrorListener.unwrapException(exception);
+            LOGGER.fatal("Fatal error while compiling XSL stylesheet.", unwrappedException);
+            throw unwrappedException;
+        }
+
+    }
+
+}

--- a/mycore-base/src/main/java/org/mycore/common/xsl/MCRSaxonTransformerFactoryConfiguration.java
+++ b/mycore-base/src/main/java/org/mycore/common/xsl/MCRSaxonTransformerFactoryConfiguration.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.xsl;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+import javax.xml.transform.TransformerFactory;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.mycore.common.MCRUtils;
+import org.mycore.common.config.MCRConfigurationDir;
+import org.mycore.common.config.MCRConfigurationException;
+import org.mycore.common.config.annotation.MCRProperty;
+
+/**
+ * Applies a provider-specific configuration file through the JAXP {@link TransformerFactory} interface.
+ * <p>
+ * This class has no compile-time dependency on the provider. A relative file is resolved against the MyCoRe
+ * configuration directory. If that directory is disabled, it is resolved against the current working directory.
+ */
+public final class MCRSaxonTransformerFactoryConfiguration implements Consumer<TransformerFactory> {
+
+    static final String CONFIGURATION_FILE_ATTRIBUTE = "http://saxon.sf.net/feature/configuration-file";
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private String file;
+
+    /**
+     * Sets the optional provider configuration file.
+     *
+     * @param file absolute path or path relative to the MyCoRe configuration directory
+     */
+    @MCRProperty(name = "File", required = false)
+    public void setFile(String file) {
+        this.file = file;
+    }
+
+    @Override
+    public void accept(TransformerFactory factory) {
+        if (file == null) {
+            return;
+        }
+        Path configurationFile = resolveConfigurationFile();
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("Configuring Saxon TransformerFactory {} with {}", factory.getClass().getName(),
+                configurationFile);
+        }
+        try {
+            factory.setAttribute(CONFIGURATION_FILE_ATTRIBUTE, configurationFile.toString());
+        } catch (IllegalArgumentException e) {
+            throw new MCRConfigurationException("Could not apply Saxon configuration file " + configurationFile
+                + " to TransformerFactory " + factory.getClass().getName(), e);
+        }
+    }
+
+    private Path resolveConfigurationFile() {
+        final Path configuredPath;
+        try {
+            configuredPath = Path.of(file);
+        } catch (InvalidPathException e) {
+            throw configurationException("is not a valid path", e);
+        }
+
+        Path resolvedPath = configuredPath;
+        if (!configuredPath.isAbsolute()) {
+            File configurationDirectory = MCRConfigurationDir.getConfigurationDirectory();
+            Path basePath = configurationDirectory == null ? Path.of("") : configurationDirectory.toPath();
+            resolvedPath = MCRUtils.safeResolve(basePath, configuredPath);
+        }
+        resolvedPath = resolvedPath.toAbsolutePath().normalize();
+
+        if (!Files.isRegularFile(resolvedPath) || !Files.isReadable(resolvedPath)) {
+            throw configurationException("does not point to a readable regular file: " + resolvedPath, null);
+        }
+        return resolvedPath;
+    }
+
+    private MCRConfigurationException configurationException(String message, Exception cause) {
+        String fullMessage = "Saxon configuration file " + message;
+        return cause == null
+            ? new MCRConfigurationException(fullMessage)
+            : new MCRConfigurationException(fullMessage, cause);
+    }
+
+}

--- a/mycore-base/src/main/java/org/mycore/common/xsl/MCRTemplatesCompiler.java
+++ b/mycore-base/src/main/java/org/mycore/common/xsl/MCRTemplatesCompiler.java
@@ -18,22 +18,17 @@
 
 package org.mycore.common.xsl;
 
-import javax.xml.transform.ErrorListener;
 import javax.xml.transform.Source;
 import javax.xml.transform.SourceLocator;
 import javax.xml.transform.Templates;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.sax.SAXTransformerFactory;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.xml.utils.WrappedRuntimeException;
 import org.mycore.common.MCRExceptionCauseFinder;
 import org.mycore.common.config.MCRConfigurationException;
-import org.mycore.common.xsl.uriresolver.MCRURIResolver;
 
 /**
  * Compiles XSL sources, reports compile errors and returns transformer
@@ -45,44 +40,15 @@ public class MCRTemplatesCompiler {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    /** The XSL transformer factory to use */
-    private static SAXTransformerFactory factory;
-
-    static {
-        System.setProperty("javax.xml.transform.TransformerFactory",
-            "org.apache.xalan.processor.TransformerFactoryImpl");
-        TransformerFactory tf = TransformerFactory.newInstance();
-        LOGGER.info("Transformerfactory: {}", () -> tf.getClass().getName());
-
-        if (!tf.getFeature(SAXTransformerFactory.FEATURE)) {
-            throw new MCRConfigurationException("Could not load a SAXTransformerFactory for use with XSLT");
-        }
-
-        factory = (SAXTransformerFactory) tf;
-        factory.setURIResolver(MCRURIResolver.obtainInstance());
-        factory.setErrorListener(new ErrorListener() {
-            @Override
-            public void error(TransformerException ex) {
-                throw new WrappedRuntimeException(MCRExceptionCauseFinder.getCause(ex));
-            }
-
-            @Override
-            public void fatalError(TransformerException ex) {
-                throw new WrappedRuntimeException(MCRExceptionCauseFinder.getCause(ex));
-            }
-
-            @Override
-            public void warning(TransformerException ex) {
-                LOGGER.warn(ex::getMessageAndLocation);
-            }
-        });
-    }
+    /** The shared transformer factory used to compile templates. */
+    private static final MCRSAXTransformerFactoryManager FACTORY =
+        MCRSAXTransformerFactoryManager.obtainInstance("Xalan");
 
     /** Compiles the given XSL source code */
     public static Templates compileTemplates(MCRTemplatesSource ts) {
         try {
             Source source = ts.getSource();
-            return factory.newTemplates(source);
+            return FACTORY.newTemplates(source);
         } catch (Exception exc) {
             LOGGER.error("Error while compiling template", exc);
             Exception cause = MCRExceptionCauseFinder.getCause(exc);
@@ -94,7 +60,7 @@ public class MCRTemplatesCompiler {
     /** Returns a new transformer for the compiled XSL templates
      */
     public static Transformer getTransformer(Templates templates) throws TransformerConfigurationException {
-        return factory.newTransformerHandler(templates).getTransformer();
+        return FACTORY.newTransformerHandler(templates).getTransformer();
     }
 
     private static String buildErrorMessage(String resource, Exception cause) {

--- a/mycore-base/src/main/java/org/mycore/common/xsl/MCRTransformerFactoryRegistry.java
+++ b/mycore-base/src/main/java/org/mycore/common/xsl/MCRTransformerFactoryRegistry.java
@@ -1,0 +1,122 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.xsl;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import javax.xml.transform.TransformerFactory;
+
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.common.config.MCRConfigurationException;
+import org.mycore.common.config.annotation.MCRInstanceMap;
+import org.mycore.common.config.annotation.MCRPostConstruction;
+
+/**
+ * Registry of named, application-scoped JAXP transformer factories.
+ * <p>
+ * Entries are injected from {@code MCR.TransformerFactory.{id}.Class}. An optional consumer configured below
+ * {@code MCR.TransformerFactory.{id}.Configuration.Class} is applied before the common MyCoRe configuration.
+ * Access to a factory is serialized by default and can be disabled with
+ * {@code MCR.TransformerFactory.{id}.SerializeAccess=false} for thread-safe providers.
+ * A factory ID is one property-name segment and therefore must not contain a dot.
+ */
+public final class MCRTransformerFactoryRegistry {
+
+    public static final String CONFIGURATION_PREFIX = "MCR.TransformerFactory";
+
+    private static final String SERIALIZE_ACCESS_PROPERTY = "SerializeAccess";
+
+    private Map<String, TransformerFactory> configuredFactories = Map.of();
+
+    private Map<String, MCRSAXTransformerFactoryManager> factories = Map.of();
+
+    private final MCRLegacyTransformerFactorySupport legacyFactories = new MCRLegacyTransformerFactorySupport();
+
+    /**
+     * Receives the transformer factories configured directly below {@link #CONFIGURATION_PREFIX}.
+     *
+     * @param configuredFactories transformer factories by configured ID
+     */
+    @MCRInstanceMap(valueClass = TransformerFactory.class)
+    public void setConfiguredFactories(Map<String, TransformerFactory> configuredFactories) {
+        this.configuredFactories = new HashMap<>(configuredFactories);
+    }
+
+    /**
+     * Applies the optional per-factory configuration and creates the shared holders.
+     *
+     * @param configurationPrefix canonical property prefix supplied by the MyCoRe instantiator
+     */
+    @MCRPostConstruction
+    public void initialize(String configurationPrefix) {
+        Map<String, MCRSAXTransformerFactoryManager> initializedFactories = new HashMap<>();
+        configuredFactories.forEach((id, factory) -> {
+            applyConfiguration(configurationPrefix, id, factory);
+            boolean serializeAccess = MCRConfiguration2
+                .getBoolean(configurationPrefix + "." + id + "." + SERIALIZE_ACCESS_PROPERTY)
+                .orElse(true);
+            initializedFactories.put(id, new MCRSAXTransformerFactoryManager(id, factory, serializeAccess));
+        });
+        factories = Map.copyOf(initializedFactories);
+        configuredFactories = Map.of();
+    }
+
+    /**
+     * Returns the shared factory with the supplied ID.
+     *
+     * @param id configured factory ID
+     * @return shared factory
+     */
+    public MCRSAXTransformerFactoryManager get(String id) {
+        MCRSAXTransformerFactoryManager factory = factories.get(id);
+        if (factory == null) {
+            factory = legacyFactories.get(id);
+        }
+        if (factory == null) {
+            throw new MCRConfigurationException("Unknown transformer factory ID '" + id
+                + "'. Configured IDs: " + factories.keySet());
+        }
+        return factory;
+    }
+
+    /**
+     * Resolves a legacy class to a configured or internal legacy factory.
+     */
+    MCRSAXTransformerFactoryManager get(Class<? extends TransformerFactory> factoryClass) {
+        return get(MCRLegacyTransformerFactorySupport.getFactoryId(factoryClass, factories));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void applyConfiguration(String configurationPrefix, String id, TransformerFactory factory) {
+        String property = configurationPrefix + "." + id + ".Configuration";
+        MCRConfiguration2.getInstanceOf(Consumer.class, property).ifPresent(configuration -> {
+            try {
+                ((Consumer<TransformerFactory>) configuration).accept(factory);
+            } catch (MCRConfigurationException e) {
+                throw e;
+            } catch (RuntimeException e) {
+                throw new MCRConfigurationException("Could not configure transformer factory "
+                    + factory.getClass().getName() + " using " + property + ".Class", e);
+            }
+        });
+    }
+
+}

--- a/mycore-base/src/main/java/org/mycore/common/xsl/MCRTransformerFactorySelector.java
+++ b/mycore-base/src/main/java/org/mycore/common/xsl/MCRTransformerFactorySelector.java
@@ -1,0 +1,118 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.xsl;
+
+import java.util.Optional;
+
+import javax.xml.transform.TransformerFactory;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.mycore.common.MCRClassTools;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.common.config.MCRConfigurationException;
+
+/**
+ * Selects a configured transformer factory ID and migrates legacy class-valued properties.
+ */
+public final class MCRTransformerFactorySelector {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private static final String DEFAULT_FACTORY_PROPERTY = "MCR.LayoutService.TransformerFactory";
+
+    private static final String LEGACY_DEFAULT_FACTORY_PROPERTY = DEFAULT_FACTORY_PROPERTY + "Class";
+
+    private MCRTransformerFactorySelector() {
+    }
+
+    /**
+     * Resolves the current default from {@code MCR.LayoutService.TransformerFactory} or the
+     * legacy {@code MCR.LayoutService.TransformerFactoryClass} property.
+     *
+     * @return current default factory ID
+     * @throws MCRConfigurationException if neither property is configured
+     */
+    public static String getDefaultFactoryId() {
+        return getConfiguredFactoryId(DEFAULT_FACTORY_PROPERTY, LEGACY_DEFAULT_FACTORY_PROPERTY)
+            .orElseThrow(() -> new MCRConfigurationException("Missing required configuration property '"
+                + DEFAULT_FACTORY_PROPERTY + "'. Configure a transformer factory ID."));
+    }
+
+    /**
+     * Returns the ID from the current property, or maps the legacy factory class to its configured ID.
+     *
+     * @param property current ID-valued property
+     * @param legacyProperty legacy class-valued property
+     * @param defaultId ID used when neither property is configured
+     * @return selected configured factory ID
+     */
+    public static String getFactoryId(String property, String legacyProperty, String defaultId) {
+        return getConfiguredFactoryId(property, legacyProperty).orElse(defaultId);
+    }
+
+    private static Optional<String> getConfiguredFactoryId(String property, String legacyProperty) {
+        return MCRConfiguration2.getString(property).map(MCRTransformerFactorySelector::getFactoryId)
+            .or(() -> MCRConfiguration2
+                .<TransformerFactory>getClass(legacyProperty)
+                .map(factoryClass -> migrateLegacyProperty(property, legacyProperty, factoryClass)));
+    }
+
+    public static String getFactoryId(String factoryIdOrClassName) {
+        if (factoryIdOrClassName.indexOf('.') == -1) {
+            return factoryIdOrClassName;
+        }
+        try {
+            Class<?> factoryClass = MCRClassTools.forName(factoryIdOrClassName);
+            if (TransformerFactory.class.isAssignableFrom(factoryClass)) {
+                LOGGER.warn("Transformer factory class value '{}' is deprecated. Configure and reference a factory "
+                    + "ID instead.", factoryIdOrClassName);
+                return MCRLegacyTransformerFactorySupport
+                    .getFactoryId(factoryClass.asSubclass(TransformerFactory.class));
+            }
+        } catch (ClassNotFoundException e) {
+            // Not a class name, so handle it as a factory ID.
+        }
+        return factoryIdOrClassName;
+    }
+
+    /**
+     * @deprecated configure and reference a factory ID instead of an implementation class
+     */
+    @Deprecated(forRemoval = true)
+    public static String getFactoryId(Class<? extends TransformerFactory> factoryClass) {
+        return MCRLegacyTransformerFactorySupport.getFactoryId(factoryClass);
+    }
+
+    private static String migrateLegacyProperty(String property, String legacyProperty,
+        Class<? extends TransformerFactory> factoryClass) {
+        String factoryId = MCRLegacyTransformerFactorySupport.getFactoryId(factoryClass);
+        if (MCRLegacyTransformerFactorySupport.isLegacyFactoryId(factoryId)) {
+            String factoryClassName = factoryClass.getName();
+            LOGGER.warn("Configuration property '{}' is deprecated. Register {} below '{}' and replace the property "
+                + "with a factory ID.", legacyProperty, factoryClassName,
+                MCRTransformerFactoryRegistry.CONFIGURATION_PREFIX);
+        } else {
+            LOGGER.warn("Configuration property '{}' is deprecated. Replace it with '{}={}'.", legacyProperty,
+                property, factoryId);
+        }
+        return factoryId;
+    }
+
+}

--- a/mycore-base/src/main/java/org/mycore/common/xsl/uriresolver/MCRXSLStyleURIResolver.java
+++ b/mycore-base/src/main/java/org/mycore/common/xsl/uriresolver/MCRXSLStyleURIResolver.java
@@ -35,10 +35,13 @@ import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.config.annotation.MCRConfigurationProxy;
 import org.mycore.common.config.annotation.MCRInstance;
 import org.mycore.common.config.annotation.MCRInstanceMap;
+import org.mycore.common.config.annotation.MCRPostConstruction;
 import org.mycore.common.config.annotation.MCRProperty;
 import org.mycore.common.content.MCRSourceContent;
 import org.mycore.common.content.transformer.MCRXSLTransformer;
 import org.mycore.common.xsl.MCRParameterCollector;
+import org.mycore.common.xsl.MCRSAXTransformerFactoryManager;
+import org.mycore.common.xsl.MCRTransformerFactorySelector;
 import org.mycore.common.xsl.MCRXSLResourceHelper;
 
 /**
@@ -163,7 +166,7 @@ public class MCRXSLStyleURIResolver implements URIResolver {
             String[] stylesheets = augmentStylesheetsPaths(stylesheetPaths.split(","),
                 flavor.xslFolder);
             MCRXSLTransformer transformer =
-                MCRXSLTransformer.obtainInstance(flavor.getTransformerFactory(), stylesheets);
+                MCRXSLTransformer.obtainInstanceByFactory(flavor.getTransformerFactoryId(), stylesheets);
 
             //prepare parameter collector
             MCRParameterCollector parameterCollector = MCRParameterCollector.ofCurrentSession();
@@ -185,11 +188,11 @@ public class MCRXSLStyleURIResolver implements URIResolver {
     }
 
     /**
-     * Represents a named combination of a {@link TransformerFactory} class and an XSL folder.
+     * Represents a named combination of a transformer factory ID and an XSL folder.
      */
     public static class Flavor {
 
-        private Class<? extends TransformerFactory> transformerFactory;
+        private String transformerFactoryId;
 
         private String xslFolder;
 
@@ -197,22 +200,67 @@ public class MCRXSLStyleURIResolver implements URIResolver {
 
         }
 
-        public Flavor(Class<? extends TransformerFactory> transformerFactory, String xslFolder) {
-            this.transformerFactory = transformerFactory;
+        public Flavor(String transformerFactoryId, String xslFolder) {
+            this.transformerFactoryId = transformerFactoryId;
             this.xslFolder = xslFolder;
         }
 
+        /**
+         * @deprecated use {@link #Flavor(String, String)} with a configured factory ID
+         */
+        @Deprecated(forRemoval = true)
+        public Flavor(Class<? extends TransformerFactory> transformerFactory, String xslFolder) {
+            setTransformerFactory(transformerFactory);
+            this.xslFolder = xslFolder;
+        }
+
+        public String getTransformerFactoryId() {
+            return transformerFactoryId;
+        }
+
+        @MCRProperty(name = "TransformerFactory", required = false, order = 1)
+        public void setTransformerFactoryId(String transformerFactoryId) {
+            this.transformerFactoryId = MCRTransformerFactorySelector.getFactoryId(transformerFactoryId);
+        }
+
+        /**
+         * @deprecated use {@link #getTransformerFactoryId()}
+         */
+        @Deprecated(forRemoval = true)
         public Class<? extends TransformerFactory> getTransformerFactory() {
-            return transformerFactory;
+            return MCRSAXTransformerFactoryManager.obtainInstance(transformerFactoryId).getFactoryClass();
         }
 
+        /**
+         * @deprecated use {@link #setTransformerFactoryId(String)}
+         */
+        @Deprecated(forRemoval = true)
+        @SuppressWarnings("removal")
         public void setTransformerFactory(Class<? extends TransformerFactory> transformerFactory) {
-            this.transformerFactory = transformerFactory;
+            this.transformerFactoryId = MCRTransformerFactorySelector.getFactoryId(transformerFactory);
         }
 
-        @MCRInstance(name = "TransformerFactory", valueClass = TransformerFactory.class)
+        /**
+         * @deprecated configure {@code TransformerFactory=<id>} instead of {@code TransformerFactory.Class=<class>}
+         */
+        @Deprecated(forRemoval = true)
         public void setTransformerFactoryInstance(TransformerFactory transformerFactory) {
-            this.transformerFactory = transformerFactory.getClass();
+            LOGGER.warn("Class-based transformer factory configuration is deprecated. Configure and reference a "
+                + "factory ID instead.");
+            setTransformerFactory(transformerFactory.getClass());
+        }
+
+        @MCRPostConstruction
+        public void initialize(String configurationPrefix) {
+            if (transformerFactoryId != null) {
+                return;
+            }
+            String legacyProperty = configurationPrefix + ".TransformerFactory.Class";
+            MCRConfiguration2.<TransformerFactory>getClass(legacyProperty).ifPresent(factoryClass -> {
+                LOGGER.warn("Configuration property '{}' is deprecated. Configure and reference a factory ID "
+                    + "instead.", legacyProperty);
+                setTransformerFactory(factoryClass);
+            });
         }
 
         public String getXslFolder() {
@@ -226,7 +274,7 @@ public class MCRXSLStyleURIResolver implements URIResolver {
 
         @Override
         public String toString() {
-            return "Flavor[transformerFactory=" + transformerFactory + ", xslFolder=" + xslFolder + "]";
+            return "Flavor[transformerFactoryId=" + transformerFactoryId + ", xslFolder=" + xslFolder + "]";
         }
 
     }
@@ -238,7 +286,7 @@ public class MCRXSLStyleURIResolver implements URIResolver {
 
         /**
          * Optional explicit default flavor. If {@code null}, the default flavor is derived
-         * from {@code MCR.LayoutService.TransformerFactoryClass} and
+         * from {@code MCR.LayoutService.TransformerFactory} and
          * {@link MCRXSLResourceHelper#getXSLFolder()}.
          */
         @MCRInstance(name = "DefaultFlavor", valueClass = Flavor.class, required = false)
@@ -257,10 +305,7 @@ public class MCRXSLStyleURIResolver implements URIResolver {
         }
 
         private Flavor getDefaultFlavor() {
-            Class<? extends TransformerFactory> factory =
-                MCRConfiguration2.<TransformerFactory>getClass("MCR.LayoutService.TransformerFactoryClass")
-                    .orElseGet(TransformerFactory.newInstance()::getClass);
-            return new Flavor(factory, MCRXSLResourceHelper.getXSLFolder());
+            return new Flavor(MCRTransformerFactorySelector.getDefaultFactoryId(), MCRXSLResourceHelper.getXSLFolder());
         }
 
     }

--- a/mycore-base/src/main/java/org/mycore/datamodel/common/MCRDataURL.java
+++ b/mycore-base/src/main/java/org/mycore/datamodel/common/MCRDataURL.java
@@ -42,12 +42,11 @@ import java.util.stream.Collectors;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 import org.mycore.common.MCRException;
-import org.mycore.common.content.transformer.MCRXSLTransformer;
+import org.mycore.common.xsl.MCRSAXTransformerFactoryManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -222,8 +221,9 @@ public class MCRDataURL implements Serializable {
             .orElseGet(() -> Optional.of(nodeList).filter(nl -> nl.getLength() == 1).map(nl -> nl.item(0))
                 .orElseThrow(() -> new IllegalArgumentException("Nodelist must have an single root element.")));
 
-        final TransformerFactory transformerFactory = MCRXSLTransformer.createDefaultTransformerFactory();
-        final Transformer transformer = transformerFactory.newTransformer();
+        final Transformer transformer = MCRSAXTransformerFactoryManager
+            .obtainInstance()
+            .newTransformer();
 
         MCRDataURLEncoding enc = encoding != null ? MCRDataURLEncoding.fromValue(encoding) : null;
         String method = "xml";

--- a/mycore-base/src/main/java/org/mycore/frontend/MCRLayoutUtilities.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/MCRLayoutUtilities.java
@@ -40,7 +40,6 @@ import java.util.concurrent.TimeUnit;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
@@ -69,8 +68,8 @@ import org.mycore.common.MCRException;
 import org.mycore.common.MCRSessionMgr;
 import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.content.MCRURLContent;
-import org.mycore.common.content.transformer.MCRXSLTransformer;
 import org.mycore.common.xml.MCRXMLFunctions;
+import org.mycore.common.xsl.MCRSAXTransformerFactoryManager;
 import org.mycore.resource.MCRResourceHelper;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Node;
@@ -143,7 +142,7 @@ public class MCRLayoutUtilities {
     /**
      * Verifies a given $webpage-ID (//item/@href) from navigation.xml on read
      * permission, based on ACL-System. To be used by XSL with
-     * Xalan-Java-Extension-Call. $blockerWebpageID can be used as already
+     * a Java extension call. $blockerWebpageID can be used as already
      * verified item with read access. So, only items of the ancestor axis till
      * and exclusive $blockerWebpageID are verified. Use this, if you want to
      * speed up the check
@@ -169,7 +168,7 @@ public class MCRLayoutUtilities {
     /**
      * Verifies a given $webpage-ID (//item/@href) from navigation.xml on read
      * permission, based on ACL-System. To be used by XSL with
-     * Xalan-Java-Extension-Call.
+     * a Java extension call.
      *
      * @param webpageID
      *            any item/@href from navigation.xml
@@ -400,8 +399,9 @@ public class MCRLayoutUtilities {
         if (LOGGER.isDebugEnabled()) {
             try {
                 String encoding = "UTF-8";
-                TransformerFactory tf = MCRXSLTransformer.createDefaultTransformerFactory();
-                Transformer transformer = tf.newTransformer();
+                Transformer transformer = MCRSAXTransformerFactoryManager
+                    .obtainInstance()
+                    .newTransformer();
                 transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
                 transformer.setOutputProperty(OutputKeys.METHOD, "xml");
                 transformer.setOutputProperty(OutputKeys.INDENT, "yes");

--- a/mycore-base/src/main/java/org/mycore/frontend/cli/MCRCommandUtils.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/cli/MCRCommandUtils.java
@@ -28,7 +28,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -39,7 +38,7 @@ import org.jdom2.xpath.XPathExpression;
 import org.jdom2.xpath.XPathFactory;
 import org.mycore.common.MCRConstants;
 import org.mycore.common.MCRUsageException;
-import org.mycore.common.content.transformer.MCRXSLTransformer;
+import org.mycore.common.xsl.MCRSAXTransformerFactoryManager;
 import org.mycore.common.xsl.MCRXSLResourceHelper;
 import org.mycore.common.xsl.uriresolver.MCRURIResolver;
 import org.mycore.datamodel.common.MCRXMLMetadataManager;
@@ -199,9 +198,9 @@ public class MCRCommandUtils {
 
         try {
             if (element != null) {
-                TransformerFactory transformerFactory = MCRXSLTransformer.createDefaultTransformerFactory();
-                transformerFactory.setURIResolver(MCRURIResolver.obtainInstance());
-                transformer = transformerFactory.newTransformer(new JDOMSource(element));
+                transformer = MCRSAXTransformerFactoryManager
+                    .obtainInstance()
+                    .newTransformer(new JDOMSource(element));
                 cache.put(style, transformer);
                 LOGGER.info("Loaded transformer from resource {} for style {}.", xslFilePath, style);
                 return transformer;

--- a/mycore-base/src/main/java/org/mycore/frontend/cli/MCRObjectCommands.java
+++ b/mycore-base/src/main/java/org/mycore/frontend/cli/MCRObjectCommands.java
@@ -45,7 +45,6 @@ import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
@@ -69,13 +68,13 @@ import org.mycore.common.content.MCRJDOMContent;
 import org.mycore.common.content.MCRSourceContent;
 import org.mycore.common.content.transformer.MCRContentTransformer;
 import org.mycore.common.content.transformer.MCRContentTransformerFactory;
-import org.mycore.common.content.transformer.MCRXSLTransformer;
 import org.mycore.common.xml.MCREntityResolver;
 import org.mycore.common.xml.MCRLayoutTransformerFactory;
 import org.mycore.common.xml.MCRXMLHelper;
 import org.mycore.common.xml.MCRXMLParserFactory;
 import org.mycore.common.xml.MCRXSLTransformerUtils;
 import org.mycore.common.xsl.MCRErrorListener;
+import org.mycore.common.xsl.MCRSAXTransformerFactoryManager;
 import org.mycore.common.xsl.uriresolver.MCRURIResolver;
 import org.mycore.datamodel.common.MCRAbstractMetadataVersion;
 import org.mycore.datamodel.common.MCRActiveLinkException;
@@ -970,13 +969,13 @@ public class MCRObjectCommands extends MCRAbstractCommands {
         MCRObjectID mcrId = MCRObjectID.getInstance(objectId);
         Document document = MCRXMLMetadataManager.obtainInstance().retrieveXML(mcrId);
         // do XSL transform
-        TransformerFactory transformerFactory = MCRXSLTransformer.createDefaultTransformerFactory();
-        transformerFactory.setErrorListener(new MCRErrorListener());
-        transformerFactory.setURIResolver(MCRURIResolver.obtainInstance());
         XMLReader xmlReader = MCRXMLParserFactory.getNonValidatingParser().getXMLReader();
         xmlReader.setEntityResolver(MCREntityResolver.getInstance());
         SAXSource styleSource = new SAXSource(xmlReader, style.getInputSource());
-        Transformer transformer = transformerFactory.newTransformer(styleSource);
+        Transformer transformer = MCRSAXTransformerFactoryManager
+            .obtainInstance()
+            .newTransformer(styleSource);
+        transformer.setErrorListener(new MCRErrorListener());
         for (Entry<String, String> property : MCRConfigurationBase.getAllPropertiesMap().entrySet()) {
             transformer.setParameter(property.getKey(), property.getValue());
         }

--- a/mycore-base/src/main/resources/config/deprecated.properties
+++ b/mycore-base/src/main/resources/config/deprecated.properties
@@ -43,7 +43,7 @@ MCR.URIResolver.Classification.Format.Description=MCR.URIResolver.ModuleResolver
 MCR.URIResolver.Classification.Format.TextCounter=MCR.URIResolver.ModuleResolver.classification.Format.TextCounter
 MCR.URIResolver.Classification.Format.IDText=MCR.URIResolver.ModuleResolver.classification.Format.IDText
 
-MCR.URIResolver.XSLStyle.Flavor.xsl.TransformerFactoryClass=(MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xsl=org.mycore.common.xsl.uriresolver.MCRXSLStyleURIResolver$Flavor and MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xsl.TransformerFactory)
+MCR.URIResolver.XSLStyle.Flavor.xsl.TransformerFactoryClass=(MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xsl.Class=org.mycore.common.xsl.uriresolver.MCRXSLStyleURIResolver$Flavor and MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xsl.TransformerFactory)
 MCR.URIResolver.XSLStyle.Flavor.xsl.XSLFolder=MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xsl.XSLFolder
-MCR.URIResolver.XSLStyle.Flavor.xslt.TransformerFactoryClass=(MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xsl=org.mycore.common.xslt.uriresolver.MCRXSLStyleURIResolver$Flavor and MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xslt.TransformerFactory)
+MCR.URIResolver.XSLStyle.Flavor.xslt.TransformerFactoryClass=(MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xslt.Class=org.mycore.common.xsl.uriresolver.MCRXSLStyleURIResolver$Flavor and MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xslt.TransformerFactory)
 MCR.URIResolver.XSLStyle.Flavor.xslt.XSLFolder=MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xslt.XSLFolder

--- a/mycore-base/src/main/resources/config/mycore.properties
+++ b/mycore-base/src/main/resources/config/mycore.properties
@@ -703,7 +703,8 @@ MCR.Jersey.Resource.ApplicationPaths=rsc
 # Autostart classes
 ##############################################################################
 
-MCR.Startup.Class=org.mycore.backend.jpa.MCRJPAConfigurationCheck,org.mycore.backend.jpa.MCRJPABootstrapper,org.mycore.datamodel.niofs.MCRFileSystemPromoter,org.mycore.frontend.support.MCRAutoDeploy,org.mycore.frontend.fileupload.MCRUploadServletDeployer,org.mycore.frontend.jersey.MCRJWTUtil
+# Remove MCRLegacyXSLCheck together with the deprecated class-based transformer APIs.
+MCR.Startup.Class=org.mycore.common.xsl.MCRLegacyXSLCheck,org.mycore.backend.jpa.MCRJPAConfigurationCheck,org.mycore.backend.jpa.MCRJPABootstrapper,org.mycore.datamodel.niofs.MCRFileSystemPromoter,org.mycore.frontend.support.MCRAutoDeploy,org.mycore.frontend.fileupload.MCRUploadServletDeployer,org.mycore.frontend.jersey.MCRJWTUtil
 MCR.Startup.CheckClassProperties=true
 MCR.Startup.CheckClassRegEx=(?:^|,\\s*)org\\.mycore(\\.[a-z0-9]+)*\\.[A-Z]
 ##############################################################################

--- a/mycore-base/src/main/resources/config/mycore.properties
+++ b/mycore-base/src/main/resources/config/mycore.properties
@@ -52,6 +52,16 @@ SLOWXALAN=org.apache.xalan.processor.TransformerFactoryImpl
 XALAN=org.mycore.common.xsl.MCRXalanTransformerFactory
 SAXON=net.sf.saxon.TransformerFactoryImpl
 
+MCR.TransformerFactory.Xalan.Class=%XALAN%
+MCR.TransformerFactory.Xalan.SerializeAccess=true
+MCR.TransformerFactory.SlowXalan.Class=%SLOWXALAN%
+MCR.TransformerFactory.SlowXalan.SerializeAccess=true
+MCR.TransformerFactory.Saxon.Class=%SAXON%
+MCR.TransformerFactory.Saxon.SerializeAccess=false
+MCR.TransformerFactory.Saxon.Configuration.Class=org.mycore.common.xsl.MCRSaxonTransformerFactoryConfiguration
+# Optional: path relative to MCR.ConfigDir (or an absolute path)
+#MCR.TransformerFactory.Saxon.Configuration.File=saxon-config.xml
+
 # External extensions of MCRURIResolver
 # MCR.URIResolver.ExternalResolver.Class=
 
@@ -107,10 +117,10 @@ MCR.URIResolver.ModuleResolver.xslImport.Class=org.mycore.common.xsl.uriresolver
 MCR.URIResolver.ModuleResolver.xslInclude.Class=org.mycore.common.xsl.uriresolver.MCRXSLIncludeURIResolver
 MCR.URIResolver.ModuleResolver.xslStyle.Class=org.mycore.common.xsl.uriresolver.MCRXSLStyleURIResolver
 MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xsl.Class=org.mycore.common.xsl.uriresolver.MCRXSLStyleURIResolver$Flavor
-MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xsl.TransformerFactory.Class=%XALAN%
+MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xsl.TransformerFactory=Xalan
 MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xsl.XSLFolder=xsl
 MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xslt.Class=org.mycore.common.xsl.uriresolver.MCRXSLStyleURIResolver$Flavor
-MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xslt.TransformerFactory.Class=%SAXON%
+MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xslt.TransformerFactory=Saxon
 MCR.URIResolver.ModuleResolver.xslStyle.Flavor.xslt.XSLFolder=xslt
 MCR.URIResolver.ModuleResolver.xslTransform.Class=org.mycore.common.xml.MCRLayoutTransformerURIResolver
 
@@ -508,20 +518,19 @@ MCR.ContentTransformer.Default.Class=org.mycore.common.content.transformer.MCRXS
 
 MCR.ContentTransformer.debug.Class=org.mycore.common.content.transformer.MCRDebuggingTransformer
 MCR.ContentTransformer.stylesheets-yed.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.stylesheets-yed.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.stylesheets-yed.TransformerFactory=Saxon
 MCR.ContentTransformer.stylesheets-yed.Stylesheet=xslt/stylesheets-graphml.xsl,xslt/graphml-yed.xsl
 MCR.ContentTransformer.mycoreobject-compress.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.mycoreobject-compress.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.mycoreobject-compress.TransformerFactory=Saxon
 MCR.ContentTransformer.mycoreobject-compress.Stylesheet=xslt/save-object.xsl
 MCR.ContentTransformer.mcr_directory-json.Class=org.mycore.common.content.transformer.MCRToJSONTransformer
-#MCR.LayoutService.TransformerFactoryClass=%XALAN%
-#MCR.LayoutService.TransformerFactoryClass=%SAXON%
-MCR.LayoutService.TransformerFactoryClass=
+# Required default TransformerFactory ID used by the layout service
+MCR.LayoutService.TransformerFactory=Saxon
 MCR.LayoutTransformerFactory.Default.Ignore=mycoreobject-xml,mycorederivate-xml,mycoreobject-versions,mycorederivate-versions
 MCR.LayoutTransformerFactory.SuggestProperties=false
 
 MCR.ContentTransformer.normalize-namespace.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.normalize-namespace.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.normalize-namespace.TransformerFactory=Saxon
 MCR.ContentTransformer.normalize-namespace.Stylesheet=xslt/normalize-namespaces.xsl
 
 #configure JSON content transformer for each of your mycore object types like mods, document, ...

--- a/mycore-base/src/test/java/org/mycore/common/content/transformer/MCRXSLTransformerTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/content/transformer/MCRXSLTransformerTest.java
@@ -1,0 +1,236 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.content.transformer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.xalan.processor.TransformerFactoryImpl;
+import org.jdom2.Element;
+import org.junit.jupiter.api.Test;
+import org.mycore.common.MCRTestConfiguration;
+import org.mycore.common.MCRTestProperty;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.common.config.MCRConfigurationException;
+import org.mycore.common.content.MCRJDOMContent;
+import org.mycore.common.xsl.MCRSAXTransformerFactoryManager;
+import org.mycore.common.xsl.MCRXalanTransformerFactory;
+import org.mycore.common.xsl.MCRTransformerFactorySelector;
+import org.mycore.common.xsl.uriresolver.MCRXSLStyleURIResolver.Flavor;
+import org.mycore.test.MyCoReTest;
+
+@MyCoReTest
+public class MCRXSLTransformerTest {
+
+    private static final String TRANSFORMER_PREFIX = "MCR.ContentTransformer.Legacy";
+
+    private static final String LAYOUT_FACTORY_PROPERTY = "MCR.LayoutService.TransformerFactory";
+
+    private static final String FO_FACTORY_PROPERTY = "MCR.LayoutService.FoFormatter.TransformerFactory";
+
+    private static final String LEGACY_FO_FACTORY_PROPERTY = "MCR.LayoutService.FoFormatter.transformerFactoryImpl";
+
+    private static final String FLAVOR_PREFIX = "MCR.Test.LegacyFlavor";
+
+    @Test
+    @MCRTestConfiguration(properties = {
+        @MCRTestProperty(key = TRANSFORMER_PREFIX + ".Stylesheet", string = "unused.xsl"),
+        @MCRTestProperty(
+            key = TRANSFORMER_PREFIX + ".TransformerFactoryClass",
+            classNameOf = TransformerFactoryImpl.class)
+    })
+    public void warnsAboutLegacyTransformerFactoryClassProperty() {
+        List<String> warnings = collectWarnings(() -> new MCRXSLTransformer().init("Legacy"));
+
+        assertEquals(List.of("Configuration property '" + TRANSFORMER_PREFIX
+            + ".TransformerFactoryClass' is deprecated. Replace it with '" + TRANSFORMER_PREFIX
+            + ".TransformerFactory=SlowXalan'."), warnings);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = {
+        @MCRTestProperty(key = LAYOUT_FACTORY_PROPERTY, empty = true),
+        @MCRTestProperty(key = LAYOUT_FACTORY_PROPERTY + "Class", classNameOf = TransformerFactoryImpl.class),
+        @MCRTestProperty(key = LEGACY_FO_FACTORY_PROPERTY, classNameOf = TransformerFactoryImpl.class)
+    })
+    public void supportsLegacyLayoutAndFoFactoryProperties() {
+        List<String> warnings = collectWarnings(() -> {
+            String defaultFactoryId = MCRTransformerFactorySelector.getDefaultFactoryId();
+            assertEquals("SlowXalan", defaultFactoryId);
+            assertEquals("SlowXalan", MCRTransformerFactorySelector.getFactoryId(FO_FACTORY_PROPERTY,
+                LEGACY_FO_FACTORY_PROPERTY, defaultFactoryId));
+        });
+
+        assertEquals(List.of(
+            "Configuration property 'MCR.LayoutService.TransformerFactoryClass' is deprecated. Replace it with "
+                + "'MCR.LayoutService.TransformerFactory=SlowXalan'.",
+            "Configuration property 'MCR.LayoutService.FoFormatter.transformerFactoryImpl' is deprecated. Replace "
+                + "it with 'MCR.LayoutService.FoFormatter.TransformerFactory=SlowXalan'."),
+            warnings);
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = {
+        @MCRTestProperty(key = LAYOUT_FACTORY_PROPERTY, string = "Xalan")
+    })
+    public void resolvesDefaultFactoryIdAtCallTime() {
+        assertEquals("Xalan", MCRTransformerFactorySelector.getDefaultFactoryId());
+        assertSame(MCRSAXTransformerFactoryManager.obtainInstance("Xalan"),
+            MCRSAXTransformerFactoryManager.obtainInstance());
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = {
+        @MCRTestProperty(key = LAYOUT_FACTORY_PROPERTY, empty = true),
+        @MCRTestProperty(key = LAYOUT_FACTORY_PROPERTY + "Class", empty = true)
+    })
+    public void rejectsMissingDefaultFactoryConfiguration() {
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class,
+            MCRSAXTransformerFactoryManager::obtainInstance);
+
+        assertTrue(exception.getMessage().contains(LAYOUT_FACTORY_PROPERTY));
+    }
+
+    private List<String> collectWarnings(Runnable action) {
+        org.apache.logging.log4j.core.Logger logger =
+            (org.apache.logging.log4j.core.Logger) LogManager.getLogger(MCRTransformerFactorySelector.class);
+        CollectingAppender appender = new CollectingAppender();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            action.run();
+        } finally {
+            logger.removeAppender(appender);
+            appender.stop();
+        }
+        return appender.getWarnMessages();
+    }
+
+    @Test
+    public void cachesXSL2XMLTransformersPerFactoryId() throws Exception {
+        String stylesheet = "xsl/reflection.xsl";
+        MCRJDOMContent source = new MCRJDOMContent(new Element("root"));
+
+        MCRXSL2XMLTransformer saxon = MCRXSL2XMLTransformer.obtainInstanceByFactory("Saxon", stylesheet);
+        MCRXSL2XMLTransformer xalan = MCRXSL2XMLTransformer.obtainInstanceByFactory("Xalan", stylesheet);
+
+        assertEquals("Saxonica", saxon.transform(source).asXML().getRootElement().getAttributeValue("vendor"));
+        assertEquals("Apache Software Foundation",
+            xalan.transform(source).asXML().getRootElement().getAttributeValue("vendor"));
+    }
+
+    @Test
+    public void cacheKeySeparatesFactoryAndStylesheetSegments() {
+        MCRXSLTransformer.obtainInstanceByFactory("Saxon", "collision_A_B");
+
+        assertThrows(MCRConfigurationException.class,
+            () -> MCRXSLTransformer.obtainInstanceByFactory("Saxon_collision_A", "B"));
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = {
+        @MCRTestProperty(key = TRANSFORMER_PREFIX + ".Stylesheet", string = "xsl/reflection.xsl"),
+        @MCRTestProperty(
+            key = TRANSFORMER_PREFIX + ".TransformerFactoryClass",
+            classNameOf = UnregisteredTransformerFactory.class)
+    })
+    public void supportsUnregisteredLegacyTransformerFactoryClass() throws Exception {
+        MCRXSLTransformer transformer = new MCRXSLTransformer();
+        List<String> warnings = collectWarnings(() -> transformer.init("Legacy"));
+
+        assertTrue(warnings.stream().anyMatch(message -> message.contains("Register "
+            + UnregisteredTransformerFactory.class.getName())));
+        assertEquals("Apache Software Foundation", transformer.transform(
+            new MCRJDOMContent(new Element("root"))).asXML().getRootElement().getAttributeValue("vendor"));
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    public void retainsLegacyFlavorMethods() {
+        Flavor flavor = new Flavor(UnregisteredTransformerFactory.class, "xsl");
+
+        assertEquals(UnregisteredTransformerFactory.class, flavor.getTransformerFactory());
+        flavor.setTransformerFactory(TransformerFactoryImpl.class);
+        assertEquals(TransformerFactoryImpl.class, flavor.getTransformerFactory());
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    @MCRTestConfiguration(properties = {
+        @MCRTestProperty(key = FLAVOR_PREFIX + ".Class", classNameOf = Flavor.class),
+        @MCRTestProperty(
+            key = FLAVOR_PREFIX + ".TransformerFactory.Class",
+            classNameOf = UnregisteredTransformerFactory.class),
+        @MCRTestProperty(key = FLAVOR_PREFIX + ".XSLFolder", string = "xsl")
+    })
+    public void loadsLegacyFlavorFactoryClassProperty() {
+        Flavor flavor = MCRConfiguration2.getInstanceOfOrThrow(Flavor.class, FLAVOR_PREFIX);
+
+        assertEquals(UnregisteredTransformerFactory.class, flavor.getTransformerFactory());
+        assertEquals("xsl", flavor.getXslFolder());
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    public void migratesLegacyFlavorClassValue() {
+        Flavor flavor = new Flavor();
+
+        List<String> warnings = collectWarnings(
+            () -> flavor.setTransformerFactoryId(UnregisteredTransformerFactory.class.getName()));
+
+        assertEquals(UnregisteredTransformerFactory.class, flavor.getTransformerFactory());
+        assertTrue(warnings.stream().anyMatch(message -> message.contains("class value")));
+    }
+
+    private static final class CollectingAppender extends AbstractAppender {
+
+        private final List<LogEvent> events = new ArrayList<>();
+
+        private CollectingAppender() {
+            super(CollectingAppender.class.getSimpleName(), null, null, false, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            events.add(event.toImmutable());
+        }
+
+        private List<String> getWarnMessages() {
+            return events.stream()
+                .filter(event -> event.getLevel() == Level.WARN)
+                .map(event -> event.getMessage().getFormattedMessage())
+                .toList();
+        }
+
+    }
+
+    public static final class UnregisteredTransformerFactory extends MCRXalanTransformerFactory {
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/common/xsl/MCRLegacyXSLCheckTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/xsl/MCRLegacyXSLCheckTest.java
@@ -55,7 +55,8 @@ public class MCRLegacyXSLCheckTest {
             () -> new MCRLegacyXSLCheck().startUp(null));
 
         assertTrue(exception.getMessage().contains(LAYOUT_PROPERTY + "=Saxon"));
-        assertTrue(exception.getMessage().contains(LAYOUT_PROPERTY + "Class=" + MCRXalanTransformerFactory.class.getName()));
+        assertTrue(
+            exception.getMessage().contains(LAYOUT_PROPERTY + "Class=" + MCRXalanTransformerFactory.class.getName()));
         assertTrue(exception.getMessage().contains("Set '" + LAYOUT_PROPERTY + "' to the intended factory ID"));
         assertTrue(exception.getMessage().contains("remove '" + LAYOUT_PROPERTY + "Class'"));
     }
@@ -71,7 +72,8 @@ public class MCRLegacyXSLCheckTest {
             () -> new MCRLegacyXSLCheck().startUp(null));
 
         assertTrue(exception.getMessage().contains(CONTENT_PROPERTY + "=Saxon"));
-        assertTrue(exception.getMessage().contains(CONTENT_PROPERTY + "Class=" + MCRXalanTransformerFactory.class.getName()));
+        assertTrue(
+            exception.getMessage().contains(CONTENT_PROPERTY + "Class=" + MCRXalanTransformerFactory.class.getName()));
         assertTrue(exception.getMessage().contains(CUSTOM_PROPERTY + "=Custom"));
         assertTrue(exception.getMessage().contains(CUSTOM_PROPERTY + "Class=application.CustomFactory"));
     }

--- a/mycore-base/src/test/java/org/mycore/common/xsl/MCRLegacyXSLCheckTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/xsl/MCRLegacyXSLCheckTest.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.xsl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.mycore.common.MCRTestConfiguration;
+import org.mycore.common.MCRTestProperty;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.common.config.MCRConfigurationException;
+import org.mycore.test.MyCoReTest;
+
+@MyCoReTest
+public class MCRLegacyXSLCheckTest {
+
+    private static final String LAYOUT_PROPERTY = "MCR.LayoutService.TransformerFactory";
+
+    private static final String CONTENT_PROPERTY = "MCR.ContentTransformer.stylesheets-yed.TransformerFactory";
+
+    private static final String CUSTOM_PROPERTY = "MCR.Test.Custom.TransformerFactory";
+
+    @Test
+    public void acceptsDefaultsAndIsRegisteredFirst() {
+        assertEquals(MCRLegacyXSLCheck.class.getName(),
+            MCRConfiguration2.getStringOrThrow("MCR.Startup.Class").split(",")[0]);
+        assertDoesNotThrow(() -> new MCRLegacyXSLCheck().startUp(null));
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = {
+        @MCRTestProperty(key = LAYOUT_PROPERTY + "Class", string = "%XALAN%")
+    })
+    public void rejectsLegacyLayoutOverrideWithInheritedDefault() {
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class,
+            () -> new MCRLegacyXSLCheck().startUp(null));
+
+        assertTrue(exception.getMessage().contains(LAYOUT_PROPERTY + "=Saxon"));
+        assertTrue(exception.getMessage().contains(LAYOUT_PROPERTY + "Class=" + MCRXalanTransformerFactory.class.getName()));
+        assertTrue(exception.getMessage().contains("Set '" + LAYOUT_PROPERTY + "' to the intended factory ID"));
+        assertTrue(exception.getMessage().contains("remove '" + LAYOUT_PROPERTY + "Class'"));
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = {
+        @MCRTestProperty(key = CONTENT_PROPERTY + "Class", string = "%XALAN%"),
+        @MCRTestProperty(key = CUSTOM_PROPERTY + "Class", string = "application.CustomFactory"),
+        @MCRTestProperty(key = CUSTOM_PROPERTY, string = "Custom")
+    })
+    public void reportsAllConflictsIncludingModuleDefaultsAndCustomPrefixes() {
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class,
+            () -> new MCRLegacyXSLCheck().startUp(null));
+
+        assertTrue(exception.getMessage().contains(CONTENT_PROPERTY + "=Saxon"));
+        assertTrue(exception.getMessage().contains(CONTENT_PROPERTY + "Class=" + MCRXalanTransformerFactory.class.getName()));
+        assertTrue(exception.getMessage().contains(CUSTOM_PROPERTY + "=Custom"));
+        assertTrue(exception.getMessage().contains(CUSTOM_PROPERTY + "Class=application.CustomFactory"));
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = {
+        @MCRTestProperty(key = LAYOUT_PROPERTY, empty = true),
+        @MCRTestProperty(key = LAYOUT_PROPERTY + "Class", string = "%XALAN%"),
+        @MCRTestProperty(key = CUSTOM_PROPERTY + "Class", string = "%SLOWXALAN%")
+    })
+    public void acceptsLegacyOnlyPropertiesAndPreservesFactorySelection() {
+        assertDoesNotThrow(() -> new MCRLegacyXSLCheck().startUp(null));
+        assertEquals("Xalan", MCRTransformerFactorySelector.getDefaultFactoryId());
+        assertEquals("SlowXalan", MCRTransformerFactorySelector.getFactoryId(CUSTOM_PROPERTY,
+            CUSTOM_PROPERTY + "Class", "Saxon"));
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = {
+        @MCRTestProperty(key = LAYOUT_PROPERTY + "Class", string = "  "),
+        @MCRTestProperty(key = CUSTOM_PROPERTY + "Class", string = "%XALAN%"),
+        @MCRTestProperty(key = CUSTOM_PROPERTY, string = "  ")
+    })
+    public void treatsBlankValuesAsAbsent() {
+        assertDoesNotThrow(() -> new MCRLegacyXSLCheck().startUp(null));
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = {
+        @MCRTestProperty(key = LAYOUT_PROPERTY + "Class", string = "%SAXON%")
+    })
+    public void requiresMigrationEvenWhenBothPropertiesSelectTheSameFactory() {
+        assertThrows(MCRConfigurationException.class, () -> new MCRLegacyXSLCheck().startUp(null));
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/common/xsl/MCRSAXTransformerFactoryManagerTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/xsl/MCRSAXTransformerFactoryManagerTest.java
@@ -1,0 +1,309 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.xsl;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.Templates;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.sax.TransformerHandler;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+
+import org.junit.jupiter.api.Test;
+import org.mycore.common.config.MCRConfigurationException;
+import org.mycore.test.MyCoReTest;
+import org.xml.sax.helpers.AttributesImpl;
+
+@MyCoReTest
+public class MCRSAXTransformerFactoryManagerTest {
+
+    private static final String STYLESHEET = """
+        <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+          <xsl:template match="/root"><result>ok</result></xsl:template>
+        </xsl:stylesheet>
+        """;
+
+    private static final String NAMESPACE_PARAMETER_STYLESHEET = """
+        <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+            xmlns:test="urn:test">
+          <xsl:param name="test:value"/>
+          <xsl:template match="/"><result><xsl:value-of select="$test:value"/></result></xsl:template>
+        </xsl:stylesheet>
+        """;
+
+    @Test
+    public void sameProviderUsesSameHolder() {
+        MCRSAXTransformerFactoryManager saxon =
+            MCRSAXTransformerFactoryManager.obtainInstance("Saxon");
+        MCRSAXTransformerFactoryManager sameSaxon =
+            MCRSAXTransformerFactoryManager.obtainInstance("Saxon");
+        MCRSAXTransformerFactoryManager xalan =
+            MCRSAXTransformerFactoryManager.obtainInstance("Xalan");
+
+        assertSame(saxon, sameSaxon);
+        assertNotSame(saxon, xalan);
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    public void prefersExactFactoryClassForLegacyLookup() {
+        MCRSAXTransformerFactoryManager slowXalan = MCRSAXTransformerFactoryManager.obtainInstance("SlowXalan");
+
+        assertSame(slowXalan, MCRSAXTransformerFactoryManager
+            .obtainInstance(org.apache.xalan.processor.TransformerFactoryImpl.class));
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    public void sharesUnregisteredLegacyFactoryClass() {
+        MCRSAXTransformerFactoryManager first =
+            MCRSAXTransformerFactoryManager.obtainInstance(UnregisteredTransformerFactory.class);
+        MCRSAXTransformerFactoryManager second =
+            MCRSAXTransformerFactoryManager.obtainInstance(UnregisteredTransformerFactory.class);
+
+        assertSame(first, second);
+        assertEquals(UnregisteredTransformerFactory.class, first.getFactoryClass());
+        assertTrue(first.isAccessSerialized());
+    }
+
+    @Test
+    public void keepsNamespaceParameterSupportInSlowXalan() throws TransformerConfigurationException {
+        Templates slowXalan = compile("SlowXalan", NAMESPACE_PARAMETER_STYLESHEET);
+        Templates optimizedXalan = compile("Xalan", NAMESPACE_PARAMETER_STYLESHEET);
+        String parameterName = "{urn:test}value";
+
+        assertDoesNotThrow(() -> slowXalan.newTransformer().setParameter(parameterName, "supported"));
+        assertThrows(IllegalArgumentException.class,
+            () -> optimizedXalan.newTransformer().setParameter(parameterName, "unsupported"));
+    }
+
+    @Test
+    public void serializesAllOperationsOnFactory() throws Exception {
+        Source source = new StreamSource();
+        Templates templates = new DummyTemplates();
+        CountDownLatch compileEntered = new CountDownLatch(1);
+        CountDownLatch releaseCompile = new CountDownLatch(1);
+        CountDownLatch handlerTaskStarted = new CountDownLatch(1);
+        CountDownLatch handlerCallEntered = new CountDownLatch(1);
+        AtomicReference<Thread> handlerThread = new AtomicReference<>();
+        BlockingTransformerFactory factory = new BlockingTransformerFactory(templates, compileEntered,
+            releaseCompile, handlerCallEntered);
+
+        MCRSAXTransformerFactoryManager sharedFactory =
+            new MCRSAXTransformerFactoryManager("Blocking", factory, true, () -> null);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Templates> compile = executor.submit(() -> sharedFactory.newTemplates(source));
+            assertTrue(compileEntered.await(5, SECONDS));
+
+            Future<TransformerHandler> createHandler = executor.submit(() -> {
+                handlerThread.set(Thread.currentThread());
+                handlerTaskStarted.countDown();
+                return sharedFactory.newTransformerHandler(templates);
+            });
+            assertTrue(handlerTaskStarted.await(5, SECONDS));
+            assertThreadBlocked(handlerThread.get());
+            assertEquals(1, handlerCallEntered.getCount());
+
+            releaseCompile.countDown();
+            assertSame(templates, compile.get(5, SECONDS));
+            assertNull(createHandler.get(5, SECONDS));
+            assertTrue(handlerCallEntered.await(5, SECONDS));
+        } finally {
+            releaseCompile.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void permitsConcurrentOperationsWhenSerializationIsDisabled() throws Exception {
+        Source source = new StreamSource();
+        Templates templates = new DummyTemplates();
+        CountDownLatch compileEntered = new CountDownLatch(1);
+        CountDownLatch releaseCompile = new CountDownLatch(1);
+        CountDownLatch handlerCallEntered = new CountDownLatch(1);
+        BlockingTransformerFactory factory = new BlockingTransformerFactory(templates, compileEntered,
+            releaseCompile, handlerCallEntered);
+
+        MCRSAXTransformerFactoryManager sharedFactory =
+            new MCRSAXTransformerFactoryManager("Concurrent", factory, false, () -> null);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Templates> compile = executor.submit(() -> sharedFactory.newTemplates(source));
+            assertTrue(compileEntered.await(5, SECONDS));
+
+            Future<TransformerHandler> createHandler =
+                executor.submit(() -> sharedFactory.newTransformerHandler(templates));
+            assertTrue(handlerCallEntered.await(5, SECONDS));
+
+            releaseCompile.countDown();
+            assertSame(templates, compile.get(5, SECONDS));
+            assertNull(createHandler.get(5, SECONDS));
+        } finally {
+            releaseCompile.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void transformsConcurrentlyWithSaxonAndXalan() throws Exception {
+        assertConcurrentTransformations("Saxon");
+        assertConcurrentTransformations("Xalan");
+    }
+
+    @Test
+    public void reportsRecursiveInitialization() {
+        AtomicReference<MCRSAXTransformerFactoryManager> manager = new AtomicReference<>();
+        manager.set(new MCRSAXTransformerFactoryManager("Recursive", new MCRXalanTransformerFactory(), false,
+            () -> {
+                try {
+                    manager.get().newTransformer();
+                } catch (TransformerConfigurationException e) {
+                    throw new AssertionError(e);
+                }
+                return null;
+            }));
+
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class,
+            () -> manager.get().newTransformer());
+
+        assertTrue(exception.getMessage().contains("Recursive initialization"));
+        assertTrue(exception.getMessage().contains("Recursive"));
+    }
+
+    private static void assertThreadBlocked(Thread thread) {
+        long deadline = System.nanoTime() + SECONDS.toNanos(5);
+        while (thread.getState() != Thread.State.BLOCKED && System.nanoTime() < deadline) {
+            Thread.onSpinWait();
+        }
+        assertEquals(Thread.State.BLOCKED, thread.getState());
+    }
+
+    private void assertConcurrentTransformations(String factoryId) throws Exception {
+        MCRSAXTransformerFactoryManager sharedFactory = MCRSAXTransformerFactoryManager.obtainInstance(factoryId);
+        Templates templates = sharedFactory.newTemplates(new StreamSource(new StringReader(STYLESHEET)));
+        ExecutorService executor = Executors.newFixedThreadPool(8);
+        try {
+            List<Future<String>> results = new ArrayList<>();
+            for (int i = 0; i < 32; i++) {
+                results.add(executor.submit(() -> transform(sharedFactory, templates)));
+            }
+            for (Future<String> result : results) {
+                assertTrue(result.get(5, SECONDS).contains("<result>ok</result>"));
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private Templates compile(String factoryId, String stylesheet) throws TransformerConfigurationException {
+        return MCRSAXTransformerFactoryManager.obtainInstance(factoryId)
+            .newTemplates(new StreamSource(new StringReader(stylesheet)));
+    }
+
+    private String transform(MCRSAXTransformerFactoryManager sharedFactory, Templates templates) throws Exception {
+        TransformerHandler handler = sharedFactory.newTransformerHandler(templates);
+        StringWriter result = new StringWriter();
+        handler.setResult(new StreamResult(result));
+        handler.startDocument();
+        handler.startElement("", "root", "root", new AttributesImpl());
+        handler.endElement("", "root", "root");
+        handler.endDocument();
+        return result.toString();
+    }
+
+    private static final class BlockingTransformerFactory extends MCRXalanTransformerFactory {
+
+        private final Templates templates;
+
+        private final CountDownLatch compileEntered;
+
+        private final CountDownLatch releaseCompile;
+
+        private final CountDownLatch handlerCallEntered;
+
+        private BlockingTransformerFactory(Templates templates, CountDownLatch compileEntered,
+            CountDownLatch releaseCompile, CountDownLatch handlerCallEntered) {
+            this.templates = templates;
+            this.compileEntered = compileEntered;
+            this.releaseCompile = releaseCompile;
+            this.handlerCallEntered = handlerCallEntered;
+        }
+
+        @Override
+        public Templates newTemplates(Source source) throws TransformerConfigurationException {
+            compileEntered.countDown();
+            try {
+                if (!releaseCompile.await(5, SECONDS)) {
+                    throw new TransformerConfigurationException("Timed out waiting to release compilation");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new TransformerConfigurationException(e);
+            }
+            return templates;
+        }
+
+        @Override
+        public TransformerHandler newTransformerHandler(Templates templates) {
+            handlerCallEntered.countDown();
+            return null;
+        }
+
+    }
+
+    private static final class DummyTemplates implements Templates {
+
+        @Override
+        public Transformer newTransformer() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Properties getOutputProperties() {
+            return new Properties();
+        }
+
+    }
+
+    public static final class UnregisteredTransformerFactory extends MCRXalanTransformerFactory {
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/common/xsl/MCRSaxonTransformerFactoryConfigurationTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/xsl/MCRSaxonTransformerFactoryConfigurationTest.java
@@ -1,0 +1,93 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.xsl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+import javax.xml.transform.TransformerFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mycore.common.config.MCRConfigurationDir;
+import org.mycore.common.config.MCRConfigurationException;
+import org.mycore.test.MyCoReTest;
+
+@MyCoReTest
+public class MCRSaxonTransformerFactoryConfigurationTest {
+
+    private static final String ALLOW_EXTERNAL_FUNCTIONS_ATTRIBUTE =
+        "http://saxon.sf.net/feature/allow-external-functions";
+
+    @Test
+    public void appliesConfigurationFileRelativeToConfigurationDirectory() throws IOException {
+        Path relativeConfigurationFile = Path.of("test", getClass().getSimpleName(), "saxon-config.xml");
+        Path configurationFile = Objects.requireNonNull(MCRConfigurationDir.getConfigurationDirectory()).toPath()
+            .resolve(relativeConfigurationFile);
+        Files.createDirectories(configurationFile.getParent());
+        writeSaxonConfiguration(configurationFile);
+        MCRSaxonTransformerFactoryConfiguration configuration = new MCRSaxonTransformerFactoryConfiguration();
+        configuration.setFile(relativeConfigurationFile.toString());
+        TransformerFactory saxonFactory = new net.sf.saxon.TransformerFactoryImpl();
+
+        configuration.accept(saxonFactory);
+
+        assertEquals(Boolean.FALSE, saxonFactory.getAttribute(ALLOW_EXTERNAL_FUNCTIONS_ATTRIBUTE));
+    }
+
+    @Test
+    public void rejectsMissingConfigurationFile(@TempDir Path temporaryDirectory) {
+        MCRSaxonTransformerFactoryConfiguration configuration = new MCRSaxonTransformerFactoryConfiguration();
+        configuration.setFile(temporaryDirectory.resolve("missing.xml").toString());
+        TransformerFactory saxonFactory = new net.sf.saxon.TransformerFactoryImpl();
+
+        assertThrows(MCRConfigurationException.class, () -> configuration.accept(saxonFactory));
+    }
+
+    @Test
+    public void reportsUnsupportedFactoryWithoutClaimingThatTheFileCouldNotBeLoaded(@TempDir Path temporaryDirectory)
+        throws IOException {
+        Path configurationFile = writeSaxonConfiguration(temporaryDirectory.resolve("saxon-config.xml"));
+        MCRSaxonTransformerFactoryConfiguration configuration = new MCRSaxonTransformerFactoryConfiguration();
+        configuration.setFile(configurationFile.toString());
+        TransformerFactory xalanFactory = new MCRXalanTransformerFactory();
+
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class,
+            () -> configuration.accept(xalanFactory));
+
+        assertTrue(exception.getMessage().contains("Could not apply Saxon configuration file"));
+        assertTrue(exception.getMessage().contains(xalanFactory.getClass().getName()));
+    }
+
+    private Path writeSaxonConfiguration(Path configurationFile) throws IOException {
+        return Files.writeString(configurationFile, """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <configuration xmlns="http://saxon.sf.net/ns/configuration" edition="HE">
+              <global allowExternalFunctions="false"/>
+            </configuration>
+            """);
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/common/xsl/MCRTransformerFactoryRegistryTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/xsl/MCRTransformerFactoryRegistryTest.java
@@ -1,0 +1,151 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.common.xsl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerFactory;
+
+import org.junit.jupiter.api.Test;
+import org.mycore.common.MCRTestConfiguration;
+import org.mycore.common.MCRTestProperty;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.common.config.MCRConfigurationException;
+import org.mycore.common.config.annotation.MCRProperty;
+import org.mycore.test.MyCoReTest;
+
+@MyCoReTest
+public class MCRTransformerFactoryRegistryTest {
+
+    private static final String TEST_PREFIX = "MCR.Test.TransformerFactory";
+
+    @Test
+    @MCRTestConfiguration(properties = {
+        @MCRTestProperty(key = TEST_PREFIX + ".Configured.Class", classNameOf = ConfigurableFactory.class),
+        @MCRTestProperty(
+            key = TEST_PREFIX + ".Configured.Configuration.Class",
+            classNameOf = TestConfiguration.class),
+        @MCRTestProperty(key = TEST_PREFIX + ".Configured.Configuration.Enabled", string = "true"),
+        @MCRTestProperty(key = TEST_PREFIX + ".Concurrent.Class", classNameOf = MCRXalanTransformerFactory.class),
+        @MCRTestProperty(key = TEST_PREFIX + ".Concurrent.SerializeAccess", string = "false")
+    })
+    public void createsAndConfiguresFactoryMapFromProperties() throws TransformerConfigurationException {
+        MCRTransformerFactoryRegistry registry = MCRConfiguration2.getInstanceOfOrThrow(
+            MCRTransformerFactoryRegistry.class, TEST_PREFIX);
+
+        assertNotNull(registry.get("Configured").newTransformer());
+        assertTrue(registry.get("Configured").isAccessSerialized());
+        assertFalse(registry.get("Concurrent").isAccessSerialized());
+        assertThrows(MCRConfigurationException.class, () -> registry.get("Missing"));
+    }
+
+    @Test
+    @MCRTestConfiguration(properties = {
+        @MCRTestProperty(key = TEST_PREFIX + ".Failing.Class", classNameOf = MCRXalanTransformerFactory.class),
+        @MCRTestProperty(
+            key = TEST_PREFIX + ".Failing.Configuration.Class",
+            classNameOf = FailingConfiguration.class)
+    })
+    public void preservesFailuresFromFactoryConfigurationConsumer() {
+        MCRTransformerFactoryRegistry registry = new MCRTransformerFactoryRegistry();
+        registry.setConfiguredFactories(Map.of("Failing", new MCRXalanTransformerFactory()));
+        MCRConfigurationException exception = assertThrows(MCRConfigurationException.class,
+            () -> registry.initialize(TEST_PREFIX));
+
+        assertTrue(exception.getMessage().contains("Could not configure transformer factory"));
+        assertInstanceOf(ClassCastException.class, exception.getCause());
+    }
+
+    @Test
+    public void resolvesLegacyClassToUniqueConfiguredSubclass() {
+        MCRTransformerFactoryRegistry registry = new MCRTransformerFactoryRegistry();
+        registry.setConfiguredFactories(Map.of("Custom", new ConfigurableFactory()));
+        registry.initialize(TEST_PREFIX);
+
+        assertSame(registry.get("Custom"), registry.get(MCRXalanTransformerFactory.class));
+    }
+
+    @Test
+    public void sharesLegacyFallbackForAmbiguousConfiguredClass() {
+        MCRTransformerFactoryRegistry registry = new MCRTransformerFactoryRegistry();
+        registry.setConfiguredFactories(Map.of(
+            "First", new MCRXalanTransformerFactory(),
+            "Second", new MCRXalanTransformerFactory()));
+        registry.initialize(TEST_PREFIX);
+
+        MCRSAXTransformerFactoryManager legacy = registry.get(MCRXalanTransformerFactory.class);
+
+        assertNotSame(registry.get("First"), legacy);
+        assertNotSame(registry.get("Second"), legacy);
+        assertSame(legacy, registry.get(MCRXalanTransformerFactory.class));
+        assertSame(legacy, registry.get(legacy.getId()));
+        assertTrue(legacy.isAccessSerialized());
+    }
+
+    public static final class ConfigurableFactory extends MCRXalanTransformerFactory {
+
+        private boolean configured;
+
+        @Override
+        public Transformer newTransformer() throws TransformerConfigurationException {
+            if (!configured) {
+                throw new TransformerConfigurationException("Factory was not configured");
+            }
+            return super.newTransformer();
+        }
+
+    }
+
+    public static final class TestConfiguration implements Consumer<TransformerFactory> {
+
+        private boolean enabled;
+
+        @MCRProperty(name = "Enabled")
+        public void setEnabled(String enabled) {
+            this.enabled = Boolean.parseBoolean(enabled);
+        }
+
+        @Override
+        public void accept(TransformerFactory factory) {
+            ((ConfigurableFactory) factory).configured = enabled;
+        }
+
+    }
+
+    public static final class FailingConfiguration implements Consumer<TransformerFactory> {
+
+        @Override
+        public void accept(TransformerFactory factory) {
+            throw new ClassCastException("Failure inside the configuration consumer");
+        }
+
+    }
+
+}

--- a/mycore-base/src/test/java/org/mycore/common/xsl/uriresolver/MCRURIResolverSaxonTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/xsl/uriresolver/MCRURIResolverSaxonTest.java
@@ -31,7 +31,7 @@ import org.mycore.test.MyCoReTest;
 @MyCoReTest
 @MCRTestConfiguration(properties = {
     @MCRTestProperty(key = "MCR.Layout.Transformer.Factory.XSLFolder", string = "xslt-test"),
-    @MCRTestProperty(key = "MCR.LayoutService.TransformerFactoryClass", string = "%SAXON%")
+    @MCRTestProperty(key = "MCR.LayoutService.TransformerFactory", string = "Saxon")
 })
 public class MCRURIResolverSaxonTest {
 

--- a/mycore-base/src/test/java/org/mycore/common/xsl/uriresolver/MCRURIResolverXalanTest.java
+++ b/mycore-base/src/test/java/org/mycore/common/xsl/uriresolver/MCRURIResolverXalanTest.java
@@ -31,7 +31,7 @@ import org.mycore.test.MyCoReTest;
 @MyCoReTest
 @MCRTestConfiguration(properties = {
     @MCRTestProperty(key = "MCR.Layout.Transformer.Factory.XSLFolder", string = "xsl-test"),
-    @MCRTestProperty(key = "MCR.LayoutService.TransformerFactoryClass", string = "%XALAN%")
+    @MCRTestProperty(key = "MCR.LayoutService.TransformerFactory", string = "Xalan")
 })
 public class MCRURIResolverXalanTest {
 

--- a/mycore-fo/src/main/java/org/mycore/component/fo/common/fo/MCRFoFormatterFOP.java
+++ b/mycore-fo/src/main/java/org/mycore/component/fo/common/fo/MCRFoFormatterFOP.java
@@ -35,8 +35,6 @@ import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.sax.SAXResult;
 
 import org.apache.fop.apps.EnvironmentalProfileFactory;
@@ -54,13 +52,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.xmlgraphics.io.Resource;
 import org.apache.xmlgraphics.io.ResourceResolver;
-import org.mycore.common.MCRClassTools;
 import org.mycore.common.MCRCoreVersion;
 import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.content.MCRContent;
 import org.mycore.common.content.MCRSourceContent;
-import org.mycore.common.xsl.MCRErrorListener;
-import org.mycore.common.xsl.uriresolver.MCRURIResolver;
+import org.mycore.common.xsl.MCRSAXTransformerFactoryManager;
+import org.mycore.common.xsl.MCRTransformerFactorySelector;
 import org.mycore.resource.MCRResourceHelper;
 
 /**
@@ -73,7 +70,13 @@ public class MCRFoFormatterFOP implements MCRFoFormatterInterface {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
+    private static final String FACTORY_PROPERTY = "MCR.LayoutService.FoFormatter.TransformerFactory";
+
+    private static final String LEGACY_FACTORY_PROPERTY = "MCR.LayoutService.FoFormatter.transformerFactoryImpl";
+
     private FopFactory fopFactory;
+
+    private MCRSAXTransformerFactoryManager factoryManager;
 
     final ResourceResolver resolver = new ResourceResolver() {
         @Override
@@ -141,17 +144,13 @@ public class MCRFoFormatterFOP implements MCRFoFormatterInterface {
             }
         }
         fopFactory = fopFactoryBuilder.build();
-        getTransformerFactory();
+        factoryManager = getTransformerFactoryManager();
     }
 
-    private static TransformerFactory getTransformerFactory() throws TransformerFactoryConfigurationError {
-        TransformerFactory transformerFactory = MCRConfiguration2
-            .getString("MCR.LayoutService.FoFormatter.transformerFactoryImpl")
-            .map(impl -> TransformerFactory.newInstance(impl, MCRClassTools.getClassLoader()))
-            .orElseGet(TransformerFactory::newInstance);
-        transformerFactory.setURIResolver(MCRURIResolver.obtainInstance());
-        transformerFactory.setErrorListener(new MCRErrorListener());
-        return transformerFactory;
+    private static MCRSAXTransformerFactoryManager getTransformerFactoryManager() {
+        String factoryId = MCRTransformerFactorySelector.getFactoryId(FACTORY_PROPERTY, LEGACY_FACTORY_PROPERTY,
+            MCRTransformerFactorySelector.getDefaultFactoryId());
+        return MCRSAXTransformerFactoryManager.obtainInstance(factoryId);
     }
 
     @Override
@@ -164,7 +163,7 @@ public class MCRFoFormatterFOP implements MCRFoFormatterInterface {
             final Fop fop = fopFactory.newFop(MimeConstants.MIME_PDF, userAgent, out);
             final Source src = input.getSource();
             final Result res = new SAXResult(fop.getDefaultHandler());
-            Transformer transformer = getTransformerFactory().newTransformer();
+            Transformer transformer = factoryManager.newTransformer();
             transformer.transform(src, res);
         } catch (FOPException e) {
             throw new TransformerException(e);

--- a/mycore-fo/src/main/resources/components/fo/config/mycore.properties
+++ b/mycore-fo/src/main/resources/components/fo/config/mycore.properties
@@ -7,6 +7,7 @@ MCR.Layout.Transformer.Factory.Class=org.mycore.component.fo.common.content.xml.
 
 # Class that implements MCRFoFormatterInterface
 MCR.LayoutService.FoFormatter.Class=org.mycore.component.fo.common.fo.MCRFoFormatterFOP
+# Shared TransformerFactory used for the identity transform (defaults to MCR.LayoutService.TransformerFactory)
+#MCR.LayoutService.FoFormatter.TransformerFactory=Saxon
 # Configuration file for FOP in classpath
 MCR.LayoutService.FoFormatter.FOP.config=
-

--- a/mycore-mods/src/main/resources/components/mods/config/mycore.properties
+++ b/mycore-mods/src/main/resources/components/mods/config/mycore.properties
@@ -6,10 +6,10 @@ MCR.MODS.Types=mods
 
 # Export bibliography entries as MODS, using mycoreobject-mods.xsl
 MCR.ContentTransformer.mods.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.mods.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.mods.TransformerFactory=Saxon
 MCR.ContentTransformer.mods.Stylesheet=xslt/exportCollection-resolveBasketEntry.xsl,xslt/exportCollection-mods.xsl
 MCR.ContentTransformer.bibmods.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.bibmods.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.bibmods.TransformerFactory=Saxon
 MCR.ContentTransformer.bibmods.Stylesheet=%MCR.ContentTransformer.mods.Stylesheet%,xslt/mods2bibmods.xsl
 MCR.ContentTransformer.bibmods.MIMEType=text/xml
 
@@ -65,12 +65,12 @@ MCR.ContentTransformer.wordbib.Steps=bibmods, normalize-namespace, mods2wordbib
 
 # Export MODS to DC, using LOC stylesheet
 MCR.ContentTransformer.mods2dc.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.mods2dc.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.mods2dc.TransformerFactory=Saxon
 MCR.ContentTransformer.mods2dc.Stylesheet=%MCR.ContentTransformer.mods.Stylesheet%,xslt/mods2dc.xsl
 
 # Export MODS to datacite using mycoreobject-datacite.xsl and generate DOI
 MCR.ContentTransformer.datacite.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.datacite.TransformerFactoryClass=%XALAN%
+MCR.ContentTransformer.datacite.TransformerFactory=Xalan
 MCR.ContentTransformer.datacite.Stylesheet=xsl/mycoreobject-datacite.xsl
 MCR.DOI.Prefix=10.5072
 MCR.DOI.HostingInstitution=MyCoRe Community
@@ -181,12 +181,12 @@ MCR.MODS.Utils.ccTextLink=none
 # Configure Transformer for schema.org
 MCR.ContentTransformer.schemaOrg.Class=org.mycore.common.content.transformer.MCRXSLTransformer
 MCR.ContentTransformer.schemaOrg.Stylesheet=xslt/mods2schemaorg.xsl
-MCR.ContentTransformer.schemaOrg.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.schemaOrg.TransformerFactory=Saxon
 
 # Configure Transformer for crossref.org
 MCR.ContentTransformer.crossref.Class=org.mycore.common.content.transformer.MCRXSLTransformer
 MCR.ContentTransformer.crossref.Stylesheet=xslt/crossref/mods.xsl
-MCR.ContentTransformer.crossref.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.crossref.TransformerFactory=Saxon
 
 # Batch Editor to modify mods:mods
 MCR.BatchEditor.BaseLevel.publication=/mycoreobject/metadata/def.modsContainer/modsContainer/mods:mods
@@ -221,7 +221,7 @@ MCR.ContentTransformer.modsCsl-xhtml-pdf.FontResources=/com/cathive/fonts/roboto
 
 MCR.ContentTransformer.cslhtml-extend.Class=org.mycore.common.content.transformer.MCRXSLTransformer
 MCR.ContentTransformer.cslhtml-extend.Stylesheet=xslt/cslHtml-extend.xsl
-MCR.ContentTransformer.cslhtml-extend.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.cslhtml-extend.TransformerFactory=Saxon
 MCR.ContentTransformer.cslhtml-extend.ContentDisposition=attachment
 
 MCR.ContentTransformer.html2xhtml.Class=org.mycore.common.content.transformer.MCRHTML2XHTMLContentTransformer
@@ -229,7 +229,7 @@ MCR.ContentTransformer.html2xhtml.Class=org.mycore.common.content.transformer.MC
 # basket
 MCR.ContentTransformer.basket-objectList.Class=org.mycore.common.content.transformer.MCRXSLTransformer
 MCR.ContentTransformer.basket-objectList.Stylesheet=xslt/basket2objectList.xsl
-MCR.ContentTransformer.basket-objectList.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.basket-objectList.TransformerFactory=Saxon
 
 MCR.ContentTransformer.basket-csl-html.Class=org.mycore.common.content.transformer.MCRTransformerPipe
 MCR.ContentTransformer.basket-csl-html.Steps=basket-objectList,modsList2csl,html2xhtml,cslhtml-extend
@@ -240,7 +240,7 @@ MCR.ContentTransformer.basket-csl-pdf.Steps=basket-objectList,modsList2csl,html2
 # searchlist
 MCR.ContentTransformer.response-objectList.Class=org.mycore.common.content.transformer.MCRXSLTransformer
 MCR.ContentTransformer.response-objectList.Stylesheet=xslt/response2objectList.xsl
-MCR.ContentTransformer.response-objectList.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.response-objectList.TransformerFactory=Saxon
 
 
 MCR.ContentTransformer.response-csl-html.Class=org.mycore.common.content.transformer.MCRTransformerPipe
@@ -264,7 +264,7 @@ MCR.Access.Facts.Condition.embargo.Class=org.mycore.mods.access.facts.condition.
 # Migration from mods:extension @label to @type
 MCR.MODS.Migration.CovertLabelList=
 MCR.ContentTransformer.migrate-extension-display.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.migrate-extension-display.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.migrate-extension-display.TransformerFactory=Saxon
 MCR.ContentTransformer.migrate-extension-display.Stylesheet=xslt/migrate-extension-display.xsl
 
 #Import commands

--- a/mycore-orcid/src/main/resources/components/orcid/config/mycore.properties
+++ b/mycore-orcid/src/main/resources/components/orcid/config/mycore.properties
@@ -28,12 +28,12 @@ MCR.ORCID.Works.BulkFetchSize=20
 
 # Transformer used to transform HTTP GET response with ORCID works xml to MODS
 MCR.ContentTransformer.Work2MyCoRe.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.Work2MyCoRe.TransformerFactoryClass=%XALAN%
+MCR.ContentTransformer.Work2MyCoRe.TransformerFactory=Xalan
 MCR.ContentTransformer.Work2MyCoRe.Stylesheet=xsl/orcid/work2mcr.xsl
 
 # Transformer used to transform MyCoRe object with MODS to ORCID works XML schema
 MCR.ContentTransformer.MyCoRe2Work.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.MyCoRe2Work.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.MyCoRe2Work.TransformerFactory=Saxon
 MCR.ContentTransformer.MyCoRe2Work.Stylesheet=xslt/orcid/mcr2work.xsl
 
 # Transformer used to transform BibTeX to MODS

--- a/mycore-orcid2/src/main/resources/components/orcid2/config/mycore.properties
+++ b/mycore-orcid2/src/main/resources/components/orcid2/config/mycore.properties
@@ -34,30 +34,30 @@ MCR.CLI.Classes.Internal=%MCR.CLI.Classes.Internal%,org.mycore.orcid2.cli.MCRORC
 
 # Transformer used to transform ORCID OAuth response
 MCR.ContentTransformer.ORCIDOAuthAccessTokenResponse.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.ORCIDOAuthAccessTokenResponse.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.ORCIDOAuthAccessTokenResponse.TransformerFactory=Saxon
 MCR.ContentTransformer.ORCIDOAuthAccessTokenResponse.Stylesheet=xslt/orcid2/auth/orcidoauth2html.xsl
 MCR.ContentTransformer.ORCIDOAuthErrorResponse.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.ORCIDOAuthErrorResponse.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.ORCIDOAuthErrorResponse.TransformerFactory=Saxon
 MCR.ContentTransformer.ORCIDOAuthErrorResponse.Stylesheet=xslt/orcid2/auth/orcidoauth2html.xsl
 
 # Transformer used to transform mods to ORCID v3 Work
 MCR.ContentTransformer.MODS2ORCIDv3Work.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.MODS2ORCIDv3Work.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.MODS2ORCIDv3Work.TransformerFactory=Saxon
 MCR.ContentTransformer.MODS2ORCIDv3Work.Stylesheet=xslt/orcid2/v3/mcr2work.xsl
 
 # Transformer used to transform ORCID v3 Work to mods
 MCR.ContentTransformer.BaseORCIDv3Work2MODS.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.BaseORCIDv3Work2MODS.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.BaseORCIDv3Work2MODS.TransformerFactory=Saxon
 MCR.ContentTransformer.BaseORCIDv3Work2MODS.Stylesheet=xslt/orcid2/v3/work2mcr.xsl
 
 # Transformer used to transform ORCID v3 Work to mods
 MCR.ContentTransformer.BaseORCIDv3WorkSummary2MODS.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.BaseORCIDv3WorkSummary2MODS.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.BaseORCIDv3WorkSummary2MODS.TransformerFactory=Saxon
 MCR.ContentTransformer.BaseORCIDv3WorkSummary2MODS.Stylesheet=xslt/orcid2/v3/work2mcr.xsl
 
 # Transformer used to filter object before publishing to orcid
 MCR.ContentTransformer.ORCIDMODSFilter.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.ORCIDMODSFilter.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.ORCIDMODSFilter.TransformerFactory=Saxon
 MCR.ContentTransformer.ORCIDMODSFilter.Stylesheet=xslt/orcid2/orcid-object-filter.xsl
 
 # Transformer used to transform BibTeX to MODS

--- a/mycore-solr/src/main/resources/components/solr/config/mycore.properties
+++ b/mycore-solr/src/main/resources/components/solr/config/mycore.properties
@@ -120,18 +120,18 @@ MCR.URIResolver.xslIncludes.solr-export=
 # we do not provide a xslt 3.0 for the solr-layout-utils.xsl in components-3
 
 MCR.ContentTransformer.response.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.response.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.response.TransformerFactory=Saxon
 MCR.ContentTransformer.response.Stylesheet=%MCR.ContentTransformer.response-prepared.Stylesheet%,xslt/solr/response/response.xsl
 
 MCR.ContentTransformer.response-browse.Stylesheet=xslt/solr/response/response-browse.xsl
 
 MCR.ContentTransformer.mycoreobject-solrdocument.Class=org.mycore.common.content.transformer.MCRXSL2JAXBTransformer
-MCR.ContentTransformer.mycoreobject-solrdocument.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.mycoreobject-solrdocument.TransformerFactory=Saxon
 MCR.ContentTransformer.mycoreobject-solrdocument.Stylesheet=xslt/solr/indexing/mycoreobject-solrdocument.xsl
 MCR.ContentTransformer.mycoreobject-solrdocument.Context=org.mycore.solr.index.document.jaxb
 
 MCR.ContentTransformer.response-prepared.Class=org.mycore.common.content.transformer.MCRXSLTransformer
-MCR.ContentTransformer.response-prepared.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.response-prepared.TransformerFactory=Saxon
 MCR.ContentTransformer.response-prepared.Stylesheet=xslt/solr/response/response-join-results.xsl,xslt/solr/response/response-addDocId.xsl,xslt/solr/response/response-addDerivates.xsl
 
 MCR.Solr.FileIndexStrategy.Class=org.mycore.solr.index.strategy.MCRSolrMimeTypeStrategy

--- a/mycore-webtools/src/main/resources/components/webtools/config/mycore.properties
+++ b/mycore-webtools/src/main/resources/components/webtools/config/mycore.properties
@@ -19,7 +19,7 @@ MCR.Vue.Properties=MCR.NameOfProject
 # Properties Helper                                                          #
 ##############################################################################
 MCR.Servlet.MCRPropertyHelperContentServlet.Disabled=true
-MCR.ContentTransformer.properties-analyze-xsl.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.properties-analyze-xsl.TransformerFactory=Saxon
 MCR.ContentTransformer.properties-analyze-xsl.Stylesheet=xslt/properties-analyze.xsl
 MCR.ContentTransformer.properties-analyze.Class=org.mycore.common.content.transformer.MCRTransformerPipe
 MCR.ContentTransformer.properties-analyze.Steps=properties-analyze-xsl,DefaultStep

--- a/mycore-xeditor/src/main/java/org/mycore/frontend/xeditor/MCRPostProcessorXSL.java
+++ b/mycore-xeditor/src/main/java/org/mycore/frontend/xeditor/MCRPostProcessorXSL.java
@@ -20,16 +20,12 @@ package org.mycore.frontend.xeditor;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Optional;
-
-import javax.xml.transform.TransformerFactory;
 
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.Text;
 import org.jdom2.filter.Filters;
-import org.mycore.common.config.MCRConfiguration2;
 import org.mycore.common.content.MCRContent;
 import org.mycore.common.content.MCRJDOMContent;
 import org.mycore.common.content.transformer.MCRContentTransformer;
@@ -42,12 +38,12 @@ import org.mycore.common.xsl.MCRXSLResourceHelper;
  * that allows execution of XSLT stylesheets after an editor is closed
  * <p>
  * &lt;xed:post-processor class="org.mycore.frontend.xeditor.MCRPostProcessorXSL"
- *      xsl="editor/ir_xeditor2mods.xsl" transformer="saxon" /&gt;
+ *      xsl="editor/ir_xeditor2mods.xsl" /&gt;
  * <p>
  * You can specify with param xsl the stylesheet, which should be processed and
- * you can specify with parm transformer the XSLStylesheetProcessor ('xalan' or 'saxon').
+ * you can select a supported processor with the optional transformer parameter.
  * If no transformer is specified the default transformer will be used
- * (property: MCR.LayoutService.TransformerFactoryClass).
+ * (property: MCR.LayoutService.TransformerFactory).
  */
 public class MCRPostProcessorXSL implements MCRXEditorPostProcessor {
 
@@ -61,20 +57,17 @@ public class MCRPostProcessorXSL implements MCRXEditorPostProcessor {
             return xml.clone();
         }
 
-        Optional<Class<? extends TransformerFactory>> oFactoryClass =
-            switch (transformer) {
-                case "xalan" -> MCRConfiguration2.<TransformerFactory>getClass("SLOWXALAN");
-                case "saxon" -> MCRConfiguration2.<TransformerFactory>getClass("SAXON");
-                case null, default -> Optional.empty();
-            };
-
-        Class<? extends TransformerFactory> factoryClass = oFactoryClass.orElse(null);
+        String factoryId = switch (transformer) {
+            case "xalan" -> "SlowXalan";
+            case "saxon" -> "Saxon";
+            case null, default -> null;
+        };
 
         final String xslFolder = MCRXSLResourceHelper.getXSLFolder();
         MCRContent source = new MCRJDOMContent(xml);
         MCRXSL2XMLTransformer transformer =
-            factoryClass == null ? MCRXSL2XMLTransformer.obtainInstance(xslFolder + "/" + stylesheet)
-                : MCRXSL2XMLTransformer.obtainInstance(factoryClass, xslFolder + "/" + stylesheet);
+            factoryId == null ? MCRXSL2XMLTransformer.obtainInstance(xslFolder + "/" + stylesheet)
+                : MCRXSL2XMLTransformer.obtainInstanceByFactory(factoryId, xslFolder + "/" + stylesheet);
         MCRContent transformed = transformer.transform(source);
         MCRContent normalized = new MCRNormalizeUnicodeTransformer().transform(transformed);
         return normalized.asXML();

--- a/mycore-xeditor/src/main/resources/components/xeditor/config/mycore.properties
+++ b/mycore-xeditor/src/main/resources/components/xeditor/config/mycore.properties
@@ -41,7 +41,7 @@ MCR.URIResolver.xslIncludes.xeditor=resource:/xslt/xeditor-custom.xsl
 
 # Transformer to use for transformation from XEditor definition to HTML
 MCR.ContentTransformer.xeditor.Class=org.mycore.common.content.transformer.MCRXSL2XMLTransformer
-MCR.ContentTransformer.xeditor.TransformerFactoryClass=%SAXON%
+MCR.ContentTransformer.xeditor.TransformerFactory=Saxon
 MCR.ContentTransformer.xeditor.Stylesheet=xslt/xeditor-templates.xsl,xslt/xeditor.xsl
 
 # Transformer helper resolver to link between Java and XSL transformation of *.xed

--- a/mycore-xeditor/src/test/java/org/mycore/frontend/xeditor/MCRPostProcessorXSLTest.java
+++ b/mycore-xeditor/src/test/java/org/mycore/frontend/xeditor/MCRPostProcessorXSLTest.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mycore.frontend.xeditor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.junit.jupiter.api.Test;
+import org.mycore.test.MyCoReTest;
+
+@MyCoReTest
+public class MCRPostProcessorXSLTest {
+
+    @Test
+    public void usesPlainXalanFactoryId() throws Exception {
+        MCRPostProcessorXSL postProcessor = new MCRPostProcessorXSL();
+        postProcessor.setAttributes(Map.of("xsl", "post-processor-test.xsl", "transformer", "xalan"));
+
+        Document result = postProcessor.process(new Document(new Element("input")));
+
+        assertEquals("Apache Software Foundation", result.getRootElement().getAttributeValue("vendor"));
+    }
+
+}

--- a/mycore-xeditor/src/test/resources/xslt/post-processor-test.xsl
+++ b/mycore-xeditor/src/test/resources/xslt/post-processor-test.xsl
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <result vendor="{system-property('xsl:vendor')}"/>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
* Saxon becomes the explicit default, replacing automatic JAXP provider discovery. Default selection is now resolved at call time.
* Configuration uses named factory IDs (Saxon, Xalan, SlowXalan) instead of class names. Existing module configurations are migrated; class-based APIs and properties remain supported but deprecated.
* Factories can have individual configuration, including an optional Saxon XML configuration file.
* Concurrency handling is explicit: factory operations are serialized for Xalan by default, while Saxon permits concurrent access.
* Transformer caching is corrected: XML transformer cache keys now include the factory, stylesheet combinations cannot collide, and concurrent cache misses avoid duplicate creation.
* Template compilation stops changing the JVM-wide JAXP property and uses the configured Xalan factory.
* Regression tests cover concurrency, configuration, legacy compatibility, caching, and XEditor processor selection.

[Link to jira](https://mycore.atlassian.net/browse/MCR-3830).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [x] New features or migrations are documented.
- [x] Does this change affect existing applications, data, or configurations?
  - [x] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [ ] Affected version is listed in the ticket.
- [ ] Minimal code changes were made (no refactoring).
- [ ] This PR truly fixes **only** the reported bug.
- [ ] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [x] If the **public API** has changed:
  - [x] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [x] Java license headers are added where necessary.
- [x] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [x] All configuration options are documented in Javadoc and `mycore.properties`.
- [x] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
