### PR TITLE
MCR-3833 run PDF/A validation asynchronously

### DIFF
--- a/mycore-validation/pom.xml
+++ b/mycore-validation/pom.xml
@@ -35,8 +35,16 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mycore</groupId>
       <artifactId>mycore-base</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mycore</groupId>
+      <artifactId>mycore-jobqueue</artifactId>
     </dependency>
     <dependency>
       <groupId>org.verapdf</groupId>
@@ -45,6 +53,12 @@
     <dependency>
       <groupId>org.verapdf</groupId>
       <artifactId>validation-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mycore</groupId>
+      <artifactId>mycore-base</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAFunctions.java
+++ b/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAFunctions.java
@@ -76,15 +76,9 @@ public class MCRPDFAFunctions {
         List<PDFAValidationResult> results = new ArrayList<>();
         Files.walkFileTree(dir, new SimpleFileVisitor<>() {
             @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                 if (file.getFileName().toString().endsWith(".pdf")) {
-                    try {
-                        results.add(new PDFAValidationResult(dir.relativize(file).toString(),
-                            PDF_A_VALIDATOR.validate(file), null));
-                    } catch (MCRPDFAValidationException e) {
-                        results.add(new PDFAValidationResult(dir.relativize(file).toString(),
-                            null, e));
-                    }
+                    results.add(validate(file, dir.relativize(file).toString()));
                 }
                 return FileVisitResult.CONTINUE;
             }
@@ -95,6 +89,30 @@ public class MCRPDFAFunctions {
             }
         });
         return createXML(objectId, results);
+    }
+
+    /**
+     * Validates a single PDF file and returns its validation report. The returned document has the same
+     * {@code <file>} element as a root that {@link #getResults(Path, String)} returns as a child of
+     * {@code <derivate>}, so both can be presented by the same stylesheets.
+     *
+     * @param file the PDF file to validate
+     * @param name the name of the file as it should appear in the report, usually relative to the derivate root
+     * @return a document with a {@code <file>} root element
+     * @throws ParserConfigurationException If a DocumentBuilder cannot be created.
+     */
+    public static Document getResult(Path file, String name) throws ParserConfigurationException {
+        Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        document.appendChild(createFileElement(document, validate(file, name)));
+        return document;
+    }
+
+    private static PDFAValidationResult validate(Path file, String name) {
+        try {
+            return new PDFAValidationResult(name, PDF_A_VALIDATOR.validate(file), null);
+        } catch (MCRPDFAValidationException | IOException e) {
+            return new PDFAValidationResult(name, null, e);
+        }
     }
 
     /**
@@ -114,35 +132,32 @@ public class MCRPDFAFunctions {
         document.appendChild(derivateElement);
         if (results != null) {
             for (PDFAValidationResult result : results) {
-                createXMLTag(derivateElement, document, result);
+                derivateElement.appendChild(createFileElement(document, result));
             }
         }
         return document;
     }
 
     /**
-     * Creates an XML tag for a PDF file with its validation results.
+     * Creates the {@code <file>} element for a PDF file with its validation results.
      *
-     * @param derivateElement The parent element to which the file element is added.
-     * @param document        The XML document being constructed.
-     * @param resultEntry     A map entry containing the file name and its validation result.
+     * @param document    The XML document being constructed.
+     * @param resultEntry The file name and its validation result.
+     * @return The "file" XML element.
      */
-    private static void createXMLTag(Element derivateElement, Document document,
-        PDFAValidationResult resultEntry) {
+    private static Element createFileElement(Document document, PDFAValidationResult resultEntry) {
         String fileName = resultEntry.name();
         ValidationResult result = resultEntry.result();
         if (result != null) {
-            Element fileElement = createFileElement(document, fileName, result);
-            derivateElement.appendChild(fileElement);
-        } else {
-            Element fileElement = document.createElement("file");
-            fileElement.setAttribute("name", fileName);
-            derivateElement.appendChild(fileElement);
-            fileElement.setAttribute("flavour", "Validation Error");
-            Element exceptionElements = document.createElement("exceptions");
-            exceptionElements.appendChild(createExceptionElement(document, resultEntry.exception()));
-            fileElement.appendChild(exceptionElements);
+            return createFileElement(document, fileName, result);
         }
+        Element fileElement = document.createElement("file");
+        fileElement.setAttribute("name", fileName);
+        fileElement.setAttribute("flavour", "Validation Error");
+        Element exceptionElements = document.createElement("exceptions");
+        exceptionElements.appendChild(createExceptionElement(document, resultEntry.exception()));
+        fileElement.appendChild(exceptionElements);
+        return fileElement;
     }
 
     /**

--- a/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAFunctions.java
+++ b/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAFunctions.java
@@ -76,7 +76,7 @@ public class MCRPDFAFunctions {
         List<PDFAValidationResult> results = new ArrayList<>();
         Files.walkFileTree(dir, new SimpleFileVisitor<>() {
             @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                 if (file.getFileName().toString().endsWith(".pdf")) {
                     results.add(validate(file, dir.relativize(file).toString()));
                 }
@@ -96,21 +96,25 @@ public class MCRPDFAFunctions {
      * {@code <file>} element as a root that {@link #getResults(Path, String)} returns as a child of
      * {@code <derivate>}, so both can be presented by the same stylesheets.
      *
+     * A PDF file that cannot be validated is reported as a validation error, because that does not change until
+     * the file itself does. Failures of reading the file are not, so that the caller can try again later.
+     *
      * @param file the PDF file to validate
      * @param name the name of the file as it should appear in the report, usually relative to the derivate root
      * @return a document with a {@code <file>} root element
      * @throws ParserConfigurationException If a DocumentBuilder cannot be created.
+     * @throws IOException                  If the PDF file cannot be read.
      */
-    public static Document getResult(Path file, String name) throws ParserConfigurationException {
+    public static Document getResult(Path file, String name) throws ParserConfigurationException, IOException {
         Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
         document.appendChild(createFileElement(document, validate(file, name)));
         return document;
     }
 
-    private static PDFAValidationResult validate(Path file, String name) {
+    private static PDFAValidationResult validate(Path file, String name) throws IOException {
         try {
             return new PDFAValidationResult(name, PDF_A_VALIDATOR.validate(file), null);
-        } catch (MCRPDFAValidationException | IOException e) {
+        } catch (MCRPDFAValidationException e) {
             return new PDFAValidationResult(name, null, e);
         }
     }

--- a/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAReportManager.java
+++ b/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAReportManager.java
@@ -1,0 +1,372 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mycore.validation.pdfa;
+
+import static org.mycore.validation.pdfa.MCRPDFAReportStore.CONFIG_PREFIX;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.mycore.common.MCRException;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.common.content.MCRDOMContent;
+import org.mycore.datamodel.classifications2.MCRCategLinkReference;
+import org.mycore.datamodel.classifications2.MCRCategLinkService;
+import org.mycore.datamodel.classifications2.MCRCategLinkServiceFactory;
+import org.mycore.datamodel.classifications2.MCRCategoryID;
+import org.mycore.datamodel.common.MCRLinkTableManager;
+import org.mycore.datamodel.metadata.MCRObject;
+import org.mycore.datamodel.metadata.MCRObjectID;
+import org.mycore.datamodel.niofs.MCRPath;
+import org.mycore.services.queuedjob.MCRJob;
+import org.mycore.services.queuedjob.MCRJobQueueManager;
+import org.mycore.services.queuedjob.MCRJobStatus;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+/**
+ * Keeps the persisted PDF/A validation reports of a derivate in sync with its PDF files.
+ * <p>
+ * Validation itself is expensive and therefore never performed while a page is rendered. Instead reports are
+ * produced by {@link MCRPDFAValidationJobAction} and read back by {@link MCRPDFAReportResolver}. A report is
+ * considered up to date as long as it records both the last modified time of the PDF file it describes and the
+ * version of the veraPDF library that is currently in use.
+ * <p>
+ * Reports are only kept for derivates whose parent objects are in an eligible state. Whether an object is eligible
+ * is decided by its classification links alone, so that objects created directly in an excluded state are treated
+ * like objects that were moved into one.
+ */
+public final class MCRPDFAReportManager {
+
+    static final String PDF_SUFFIX = ".pdf";
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private static final String STATE_CLASSIFICATION_PROPERTY = "MCR.Metadata.Service.State.Classification.ID";
+
+    private static final String DEFAULT_STATE_CLASSIFICATION = "state";
+
+    private static final String ATTR_LAST_MODIFIED = "lastModified";
+
+    private static final String ATTR_VALIDATOR = "validator";
+
+    /** Guards report writes against concurrent cleanup, so that a late job cannot resurrect removed reports. */
+    private static final Object REPORT_LOCK = new Object();
+
+    private MCRPDFAReportManager() {
+    }
+
+    /**
+     * Returns whether reports may be kept for the given derivate, that is whether none of its parent objects is in
+     * an excluded state. Only classification links are inspected, no metadata is read.
+     * <p>
+     * The excluded states are configured as plain category IDs of the state classification, whose root ID is taken
+     * from {@code MCR.Metadata.Service.State.Classification.ID}, just like the state of an object itself.
+     *
+     * @param derivateId the ID of the derivate
+     * @return {@code true} if reports may be kept
+     */
+    public static boolean isEligible(MCRObjectID derivateId) {
+        Collection<String> parents = MCRLinkTableManager.getInstance()
+            .getSourceOf(derivateId, MCRLinkTableManager.ENTRY_TYPE_DERIVATE);
+        MCRCategLinkService linkService = MCRCategLinkServiceFactory.obtainInstance();
+        List<MCRCategoryID> excludedStates = getExcludedStates();
+        return !parents.isEmpty() && parents.stream()
+            .map(MCRObjectID::getInstance)
+            .map(MCRCategLinkReference::new)
+            .noneMatch(reference -> excludedStates.stream()
+                .anyMatch(state -> linkService.isInCategory(reference, state)));
+    }
+
+    /**
+     * Returns whether the given object is in an excluded state, based on the state it carries itself. Use this for
+     * an object that is currently being created or updated, as its classification links are not yet up to date.
+     *
+     * @param object the object
+     * @return {@code true} if the object is in an excluded state
+     */
+    public static boolean isExcluded(MCRObject object) {
+        MCRCategoryID state = object.getService().getState();
+        return state != null && getExcludedStates().contains(state);
+    }
+
+    /**
+     * Returns whether reports are removed when an object enters an excluded state.
+     *
+     * @return {@code true} if reports are removed
+     */
+    public static boolean isDeleteOnExcludedState() {
+        return MCRConfiguration2.getBoolean(CONFIG_PREFIX + "DeleteOnExcludedState").orElse(true);
+    }
+
+    private static List<MCRCategoryID> getExcludedStates() {
+        String classificationId = MCRConfiguration2.getString(STATE_CLASSIFICATION_PROPERTY)
+            .orElse(DEFAULT_STATE_CLASSIFICATION);
+        return MCRConfiguration2.getString(CONFIG_PREFIX + "ExcludedStates").stream()
+            .flatMap(MCRConfiguration2::splitValue)
+            .map(state -> new MCRCategoryID(classificationId, state))
+            .toList();
+    }
+
+    /**
+     * Returns the paths of all PDF files of the given derivate, relative to its root directory.
+     *
+     * @param derivateId the ID of the derivate
+     * @return the derivate relative paths of all PDF files
+     */
+    public static List<String> listPDFFiles(MCRObjectID derivateId) {
+        MCRPath root = MCRPath.getRootPath(derivateId.toString());
+        try (Stream<Path> files = Files.walk(root)) {
+            return files.filter(Files::isRegularFile)
+                .map(root::relativize)
+                .map(Path::toString)
+                .filter(path -> path.toLowerCase(Locale.ROOT).endsWith(PDF_SUFFIX))
+                .sorted()
+                .toList();
+        } catch (NoSuchFileException e) {
+            return List.of();
+        } catch (IOException e) {
+            throw new MCRException("Could not list PDF files of " + derivateId, e);
+        }
+    }
+
+    /**
+     * Returns a summary of the validation state of all PDF files of the given derivate and schedules validation of
+     * every file that has no up to date report. No PDF file is parsed, so this is cheap enough to be called while a
+     * page is rendered.
+     *
+     * @param derivateId the ID of the derivate
+     * @return a document with a {@code <derivate>} root element, holding one {@code <file>} element per PDF file
+     * @throws ParserConfigurationException If a DocumentBuilder cannot be created.
+     */
+    public static Document getReportSummary(MCRObjectID derivateId) throws ParserConfigurationException {
+        Document summary = newDocumentBuilderFactory().newDocumentBuilder().newDocument();
+        Element root = summary.createElement("derivate");
+        root.setAttribute("id", derivateId.toString());
+        summary.appendChild(root);
+        if (!isEligible(derivateId)) {
+            return summary;
+        }
+        for (String file : listPDFFiles(derivateId)) {
+            Optional<Element> report = findCurrentReport(derivateId, file);
+            if (report.isPresent()) {
+                root.appendChild(summary.importNode(report.get(), true));
+            } else {
+                Element pending = summary.createElement("file");
+                pending.setAttribute("name", file);
+                pending.setAttribute("status", "pending");
+                root.appendChild(pending);
+                scheduleValidation(derivateId, file);
+            }
+        }
+        return summary;
+    }
+
+    /**
+     * Adds a validation job for the given PDF file, unless an unprocessed job for it already exists.
+     *
+     * @param derivateId the ID of the derivate
+     * @param file       the path of the PDF file, relative to the derivate root
+     */
+    public static void scheduleValidation(MCRObjectID derivateId, String file) {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(MCRPDFAValidationJobAction.DERIVATE_ID_PARAMETER, derivateId.toString());
+        parameters.put(MCRPDFAValidationJobAction.PATH_PARAMETER, file);
+        MCRJobQueueManager queueManager = MCRJobQueueManager.getInstance();
+        if (queueManager.getJobDAO().getJobCount(MCRPDFAValidationJobAction.class, parameters,
+            List.of(MCRJobStatus.NEW, MCRJobStatus.ERROR)) > 0) {
+            LOGGER.debug("PDF/A validation of {}/{} is already scheduled.", derivateId, file);
+            return;
+        }
+        MCRJob job = new MCRJob(MCRPDFAValidationJobAction.class);
+        job.setParameters(parameters);
+        if (queueManager.getJobQueue(MCRPDFAValidationJobAction.class).offer(job)) {
+            LOGGER.info("Scheduled PDF/A validation of {}/{}.", derivateId, file);
+        } else {
+            LOGGER.warn("Could not schedule PDF/A validation of {}/{}, the job queue is not running.",
+                derivateId, file);
+        }
+    }
+
+    /**
+     * Adds validation jobs for all PDF files of the given derivate that have no up to date report.
+     *
+     * @param derivateId the ID of the derivate
+     */
+    public static void scheduleMissingValidations(MCRObjectID derivateId) {
+        if (!isEligible(derivateId)) {
+            return;
+        }
+        listPDFFiles(derivateId).stream()
+            .filter(file -> findCurrentReport(derivateId, file).isEmpty())
+            .forEach(file -> scheduleValidation(derivateId, file));
+    }
+
+    /**
+     * Validates a single PDF file and stores its report. Eligibility is checked before validation and again before
+     * the report is written, so that a report is never stored for an object that meanwhile entered an excluded
+     * state. If the PDF file changed while it was validated, the outdated result is discarded.
+     *
+     * @param derivateId the ID of the derivate
+     * @param file       the path of the PDF file, relative to the derivate root
+     * @throws IOException if the PDF file cannot be read or the report cannot be written
+     */
+    public static void validate(MCRObjectID derivateId, String file) throws IOException {
+        if (!isEligible(derivateId)) {
+            LOGGER.info("Skipping PDF/A validation of {}/{}, object is in an excluded state.", derivateId, file);
+            return;
+        }
+        MCRPath pdf = MCRPath.getPath(derivateId.toString(), file);
+        if (!Files.isRegularFile(pdf)) {
+            deleteReport(derivateId, file);
+            return;
+        }
+        String lastModified = getLastModified(pdf);
+        Document report;
+        try {
+            report = MCRPDFAFunctions.getResult(pdf, file);
+        } catch (ParserConfigurationException e) {
+            throw new IOException(e);
+        }
+        if (!lastModified.equals(getLastModified(pdf))) {
+            LOGGER.info("Discarding PDF/A validation of {}/{}, the file changed while it was validated.",
+                derivateId, file);
+            return;
+        }
+        Element root = report.getDocumentElement();
+        root.setAttribute(ATTR_LAST_MODIFIED, lastModified);
+        root.setAttribute(ATTR_VALIDATOR, MCRPDFAValidator.getVersion());
+        synchronized (REPORT_LOCK) {
+            if (!isEligible(derivateId)) {
+                LOGGER.info("Dropping PDF/A report of {}/{}, object entered an excluded state.", derivateId, file);
+                return;
+            }
+            MCRPDFAReportStore.obtainInstance(derivateId)
+                .writeReport(derivateId, file, new MCRDOMContent(report));
+        }
+        LOGGER.info("Stored PDF/A report of {}/{}.", derivateId, file);
+    }
+
+    /**
+     * Returns the stored report of the given PDF file, if it is up to date.
+     *
+     * @param derivateId the ID of the derivate
+     * @param file       the path of the PDF file, relative to the derivate root
+     * @return the {@code <file>} element of the report or {@link Optional#empty()} if there is no current report
+     */
+    public static Optional<Element> findCurrentReport(MCRObjectID derivateId, String file) {
+        Path report = MCRPDFAReportStore.obtainInstance(derivateId).getReportFile(derivateId, file);
+        if (!Files.isRegularFile(report)) {
+            LOGGER.debug("No PDF/A report of {}/{} stored at {}.", () -> derivateId, () -> file, () -> report);
+            return Optional.empty();
+        }
+        try {
+            Element root = parse(report).getDocumentElement();
+            String storedValidator = root.getAttribute(ATTR_VALIDATOR);
+            String validator = MCRPDFAValidator.getVersion();
+            if (!Objects.equals(storedValidator, validator)) {
+                LOGGER.info("PDF/A report of {}/{} was produced by veraPDF {}, but {} is in use.",
+                    derivateId, file, storedValidator, validator);
+                return Optional.empty();
+            }
+            String storedLastModified = root.getAttribute(ATTR_LAST_MODIFIED);
+            String lastModified = getLastModified(MCRPath.getPath(derivateId.toString(), file));
+            if (!Objects.equals(storedLastModified, lastModified)) {
+                LOGGER.info("PDF/A report of {}/{} describes the file as of {}, but it was last modified at {}.",
+                    derivateId, file, storedLastModified, lastModified);
+                return Optional.empty();
+            }
+            LOGGER.debug("Using PDF/A report of {}/{}.", derivateId, file);
+            return Optional.of(root);
+        } catch (IOException e) {
+            LOGGER.warn(() -> "Ignoring unreadable PDF/A report " + report, e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Deletes the report of a single PDF file.
+     *
+     * @param derivateId the ID of the derivate
+     * @param file       the path of the PDF file, relative to the derivate root
+     */
+    public static void deleteReport(MCRObjectID derivateId, String file) {
+        Path report = MCRPDFAReportStore.obtainInstance(derivateId).getReportFile(derivateId, file);
+        synchronized (REPORT_LOCK) {
+            try {
+                Files.deleteIfExists(report);
+            } catch (IOException e) {
+                LOGGER.error(() -> "Could not delete PDF/A report " + report, e);
+            }
+        }
+    }
+
+    /**
+     * Deletes all reports of the given derivate.
+     *
+     * @param derivateId the ID of the derivate
+     */
+    public static void deleteReports(MCRObjectID derivateId) {
+        MCRPDFAReportStore store = MCRPDFAReportStore.obtainInstance(derivateId);
+        synchronized (REPORT_LOCK) {
+            try {
+                store.deleteReports(derivateId);
+            } catch (IOException e) {
+                LOGGER.error(() -> "Could not delete PDF/A reports of " + derivateId, e);
+            }
+        }
+    }
+
+    private static String getLastModified(Path path) throws IOException {
+        return Files.getLastModifiedTime(path).toInstant().toString();
+    }
+
+    private static Document parse(Path path) throws IOException {
+        try (InputStream input = Files.newInputStream(path)) {
+            return newDocumentBuilderFactory().newDocumentBuilder().parse(input);
+        } catch (ParserConfigurationException | SAXException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private static DocumentBuilderFactory newDocumentBuilderFactory() throws ParserConfigurationException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        return factory;
+    }
+}

--- a/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAReportResolver.java
+++ b/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAReportResolver.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mycore.validation.pdfa;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.URIResolver;
+import javax.xml.transform.dom.DOMSource;
+
+import org.mycore.datamodel.metadata.MCRObjectID;
+
+/**
+ * Resolves {@code pdfAReport:{derivateId}} to the persisted PDF/A validation reports of a derivate.
+ * <p>
+ * Unlike {@link MCRPDFAValidatorResolver} this resolver never validates a PDF file itself. Files without an up to
+ * date report are reported as {@code <file name="..." status="pending"/>} and their validation is scheduled, so
+ * that a later request can present the result.
+ *
+ * @see MCRPDFAReportManager#getReportSummary(MCRObjectID)
+ */
+public class MCRPDFAReportResolver implements URIResolver {
+
+    @Override
+    public Source resolve(String href, String base) throws TransformerException {
+        MCRObjectID derivateId = MCRObjectID.getInstance(href.substring(href.indexOf(':') + 1));
+        try {
+            return new DOMSource(MCRPDFAReportManager.getReportSummary(derivateId));
+        } catch (ParserConfigurationException e) {
+            throw new TransformerException(e);
+        }
+    }
+}

--- a/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAReportStore.java
+++ b/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAReportStore.java
@@ -34,12 +34,15 @@ import org.mycore.datamodel.metadata.MCRObjectID;
 /**
  * Stores one PDF/A validation report per PDF file below the slot directory of its derivate.
  * <p>
- * Reports are named after the PDF file they describe, with the file extension replaced by {@code .xml}. The path
- * relative to the derivate root is preserved, so identically named PDF files in different directories do not
- * collide. Stores are separated by {@link MCRObjectID#getBase()} like the IFS2 content stores are, so that numeric
- * derivate IDs of different projects cannot collide either:
+ * Reports are named after the PDF file they describe, with {@code .xml} appended. The path relative to the derivate
+ * root is preserved, so identically named PDF files in different directories do not collide, and appending rather
+ * than replacing the extension keeps the mapping injective: {@code chapter.pdf} and {@code chapter.PDF}, which can
+ * coexist on a case sensitive store, would both claim {@code chapter.xml}.
  * <p>
- * {@code <BaseDir>/<project>/derivate/<slots>/<derivate ID>/<relative path>.xml}
+ * Stores are separated by {@link MCRObjectID#getBase()} like the IFS2 content stores are, so that numeric derivate
+ * IDs of different projects cannot collide either:
+ * <p>
+ * {@code <BaseDir>/<project>/derivate/<slots>/<derivate ID>/<PDF path>.xml}
  * <p>
  * Instances are created reflectively by {@link MCRStoreManager}, use {@link #obtainInstance(MCRObjectID)}.
  */
@@ -110,10 +113,7 @@ public final class MCRPDFAReportStore extends MCRStore {
     }
 
     private static String toReportPath(String path) {
-        String relativePath = path.startsWith("/") ? path.substring(1) : path;
-        int extension = relativePath.lastIndexOf('.');
-        int directory = relativePath.lastIndexOf('/');
-        return (extension > directory ? relativePath.substring(0, extension) : relativePath) + XML_SUFFIX;
+        return (path.startsWith("/") ? path.substring(1) : path) + XML_SUFFIX;
     }
 
     /**

--- a/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAReportStore.java
+++ b/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAReportStore.java
@@ -1,0 +1,181 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mycore.validation.pdfa;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.common.config.MCRConfigurationException;
+import org.mycore.common.content.MCRContent;
+import org.mycore.datamodel.ifs2.MCRStore;
+import org.mycore.datamodel.ifs2.MCRStoreManager;
+import org.mycore.datamodel.metadata.MCRObjectID;
+
+/**
+ * Stores one PDF/A validation report per PDF file below the slot directory of its derivate.
+ * <p>
+ * Reports are named after the PDF file they describe, with the file extension replaced by {@code .xml}. The path
+ * relative to the derivate root is preserved, so identically named PDF files in different directories do not
+ * collide. Stores are separated by {@link MCRObjectID#getBase()} like the IFS2 content stores are, so that numeric
+ * derivate IDs of different projects cannot collide either:
+ * <p>
+ * {@code <BaseDir>/<project>/derivate/<slots>/<derivate ID>/<relative path>.xml}
+ * <p>
+ * Instances are created reflectively by {@link MCRStoreManager}, use {@link #obtainInstance(MCRObjectID)}.
+ */
+public final class MCRPDFAReportStore extends MCRStore {
+
+    static final String CONFIG_PREFIX = "MCR.PDFA.Report.";
+
+    private static final String STORE_ID_PREFIX = "PDFA_";
+
+    private static final String XML_SUFFIX = ".xml";
+
+    /**
+     * Returns the report store responsible for the given derivate.
+     *
+     * @param derivateId the ID of the derivate
+     * @return the report store
+     */
+    public static MCRPDFAReportStore obtainInstance(MCRObjectID derivateId) {
+        String base = derivateId.getBase();
+        String storeId = STORE_ID_PREFIX + base;
+        return MCRStoreManager.computeStoreIfAbsent(storeId, () -> buildStore(storeId, base));
+    }
+
+    private static MCRPDFAReportStore buildStore(String storeId, String base) {
+        String baseDir = MCRConfiguration2.getStringOrThrow(CONFIG_PREFIX + "BaseDir")
+            + File.separatorChar + base.replace("_", File.separator);
+        MCRStoreConfig config = new Config(storeId, baseDir, base + "_", getSlotLayout());
+        try {
+            return MCRStoreManager.buildStore(config, MCRPDFAReportStore.class);
+        } catch (ReflectiveOperationException e) {
+            throw new MCRConfigurationException("Could not create PDF/A report store with ID " + storeId, e);
+        }
+    }
+
+    private static String getSlotLayout() {
+        return MCRConfiguration2.getString(CONFIG_PREFIX + "SlotLayout").orElseGet(() -> {
+            String baseId = "a_a";
+            int patternLength = MCRObjectID.formatID(baseId, 1).length() - baseId.length() - "_".length();
+            return patternLength - 4 + "-2-2";
+        });
+    }
+
+    /**
+     * Returns the directory holding all reports of the given derivate. The directory need not exist.
+     *
+     * @param derivateId the ID of the derivate
+     * @return the report directory
+     */
+    public Path getReportDirectory(MCRObjectID derivateId) {
+        return getSlot(derivateId.getNumberAsInteger());
+    }
+
+    /**
+     * Returns the report file describing a single PDF file. The file need not exist.
+     *
+     * @param derivateId the ID of the derivate
+     * @param path       the path of the PDF file, relative to the derivate root
+     * @return the report file
+     * @throws IllegalArgumentException if the given path does not point into the derivate
+     */
+    public Path getReportFile(MCRObjectID derivateId, String path) {
+        Path directory = getReportDirectory(derivateId);
+        Path report = directory.resolve(toReportPath(path)).normalize();
+        if (!report.startsWith(directory)) {
+            throw new IllegalArgumentException("Not a derivate relative path: " + path);
+        }
+        return report;
+    }
+
+    private static String toReportPath(String path) {
+        String relativePath = path.startsWith("/") ? path.substring(1) : path;
+        int extension = relativePath.lastIndexOf('.');
+        int directory = relativePath.lastIndexOf('/');
+        return (extension > directory ? relativePath.substring(0, extension) : relativePath) + XML_SUFFIX;
+    }
+
+    /**
+     * Writes the report of a single PDF file, creating missing directories on the way. An already stored report is
+     * replaced atomically where the file system supports it, so that a report is never read half written.
+     *
+     * @param derivateId the ID of the derivate
+     * @param path       the path of the PDF file, relative to the derivate root
+     * @param report     the report to write
+     * @throws IOException if the report cannot be written
+     */
+    public void writeReport(MCRObjectID derivateId, String path, MCRContent report) throws IOException {
+        Path target = getReportFile(derivateId, path);
+        Path directory = target.getParent();
+        Files.createDirectories(directory);
+        Path temporary = Files.createTempFile(directory, target.getFileName().toString(), ".tmp");
+        try {
+            report.sendTo(temporary, StandardCopyOption.REPLACE_EXISTING);
+            try {
+                Files.move(temporary, target, StandardCopyOption.REPLACE_EXISTING,
+                    StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(temporary, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    /**
+     * Deletes all reports of the given derivate, if any are stored.
+     *
+     * @param derivateId the ID of the derivate
+     * @throws IOException if the reports cannot be deleted
+     */
+    public void deleteReports(MCRObjectID derivateId) throws IOException {
+        int slot = derivateId.getNumberAsInteger();
+        if (exists(slot)) {
+            delete(slot);
+        }
+    }
+
+    private record Config(String id, String baseDir, String prefix, String slotLayout) implements MCRStoreConfig {
+
+        @Override
+        public String getID() {
+            return id;
+        }
+
+        @Override
+        public String getBaseDir() {
+            return baseDir;
+        }
+
+        @Override
+        public String getPrefix() {
+            return prefix;
+        }
+
+        @Override
+        public String getSlotLayout() {
+            return slotLayout;
+        }
+    }
+}

--- a/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAValidationEventHandler.java
+++ b/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAValidationEventHandler.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mycore.validation.pdfa;
+
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.BiConsumer;
+
+import org.mycore.common.MCRSessionMgr;
+import org.mycore.common.events.MCREvent;
+import org.mycore.common.events.MCREventHandlerBase;
+import org.mycore.datamodel.metadata.MCRDerivate;
+import org.mycore.datamodel.metadata.MCRMetaLinkID;
+import org.mycore.datamodel.metadata.MCRObject;
+import org.mycore.datamodel.metadata.MCRObjectID;
+import org.mycore.datamodel.niofs.MCRPath;
+
+/**
+ * Keeps the persisted PDF/A validation reports in sync with the files and the state of the objects they belong to.
+ * <p>
+ * Uploading or replacing a PDF file schedules its validation, deleting it removes its report. Entering an excluded
+ * state removes the reports of all derivates of an object, returning to an eligible state schedules the validation
+ * of every PDF file that has no report, without requiring another upload. Deleting an object or a derivate always
+ * removes the associated reports.
+ */
+public class MCRPDFAValidationEventHandler extends MCREventHandlerBase {
+
+    @Override
+    protected void handlePathCreated(MCREvent evt, Path path, BasicFileAttributes attrs) {
+        handlePathUpdated(evt, path, attrs);
+    }
+
+    @Override
+    protected void handlePathUpdated(MCREvent evt, Path path, BasicFileAttributes attrs) {
+        forPDFFile(path, (derivateId, file) -> {
+            if (MCRPDFAReportManager.isEligible(derivateId)) {
+                MCRPDFAReportManager.scheduleValidation(derivateId, file);
+            } else {
+                MCRPDFAReportManager.deleteReport(derivateId, file);
+            }
+        });
+    }
+
+    @Override
+    protected void handlePathDeleted(MCREvent evt, Path path, BasicFileAttributes attrs) {
+        forPDFFile(path, MCRPDFAReportManager::deleteReport);
+    }
+
+    @Override
+    protected void handleObjectUpdated(MCREvent evt, MCRObject obj) {
+        boolean excluded = MCRPDFAReportManager.isExcluded(obj);
+        if (evt.get(MCREvent.OBJECT_OLD_KEY) instanceof MCRObject old
+            && MCRPDFAReportManager.isExcluded(old) == excluded) {
+            return;
+        }
+        List<MCRObjectID> derivateIds = getDerivateIds(obj);
+        // the state change is only visible to the jobs once it is committed
+        MCRSessionMgr.getCurrentSession().onCommit(() -> {
+            if (!excluded) {
+                derivateIds.forEach(MCRPDFAReportManager::scheduleMissingValidations);
+            } else if (MCRPDFAReportManager.isDeleteOnExcludedState()) {
+                derivateIds.forEach(MCRPDFAReportManager::deleteReports);
+            }
+        });
+    }
+
+    @Override
+    protected void handleObjectDeleted(MCREvent evt, MCRObject obj) {
+        getDerivateIds(obj).forEach(MCRPDFAReportManager::deleteReports);
+    }
+
+    @Override
+    protected void handleDerivateDeleted(MCREvent evt, MCRDerivate der) {
+        MCRPDFAReportManager.deleteReports(der.getId());
+    }
+
+    private static List<MCRObjectID> getDerivateIds(MCRObject obj) {
+        return obj.getStructure().getDerivates().stream().map(MCRMetaLinkID::getXLinkHrefID).toList();
+    }
+
+    private static void forPDFFile(Path path, BiConsumer<MCRObjectID, String> action) {
+        MCRPath mcrPath = MCRPath.ofPath(path);
+        String file = mcrPath.getOwnerRelativePath();
+        if (!file.toLowerCase(Locale.ROOT).endsWith(MCRPDFAReportManager.PDF_SUFFIX)) {
+            return;
+        }
+        action.accept(MCRObjectID.getInstance(mcrPath.getOwner()), file.substring(1));
+    }
+}

--- a/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAValidationJobAction.java
+++ b/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAValidationJobAction.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mycore.validation.pdfa;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import org.mycore.datamodel.metadata.MCRObjectID;
+import org.mycore.services.queuedjob.MCRJob;
+import org.mycore.services.queuedjob.MCRJobAction;
+
+/**
+ * Validates a single PDF file of a derivate and stores its report.
+ *
+ * @see MCRPDFAReportManager#validate(MCRObjectID, String)
+ */
+public class MCRPDFAValidationJobAction extends MCRJobAction {
+
+    public static final String DERIVATE_ID_PARAMETER = "derivateID";
+
+    public static final String PATH_PARAMETER = "path";
+
+    /**
+     * The constructor of the job action with specific {@link MCRJob}.
+     *
+     * @param job the job holding the parameters for the action
+     */
+    public MCRPDFAValidationJobAction(MCRJob job) {
+        super(job);
+    }
+
+    @Override
+    public boolean isActivated() {
+        return true;
+    }
+
+    @Override
+    public String name() {
+        return "PDF/A validation - " + job.getParameter(DERIVATE_ID_PARAMETER) + ":"
+            + job.getParameter(PATH_PARAMETER);
+    }
+
+    @Override
+    public void execute() throws ExecutionException {
+        MCRObjectID derivateId = MCRObjectID.getInstance(job.getParameter(DERIVATE_ID_PARAMETER));
+        try {
+            MCRPDFAReportManager.validate(derivateId, job.getParameter(PATH_PARAMETER));
+        } catch (IOException e) {
+            throw new ExecutionException(e);
+        }
+    }
+
+    @Override
+    public void rollback() {
+        // nothing to roll back, reports are written atomically
+    }
+}

--- a/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAValidator.java
+++ b/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAValidator.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.verapdf.ReleaseDetails;
 import org.verapdf.core.EncryptedPdfException;
 import org.verapdf.core.ModelParsingException;
 import org.verapdf.core.ValidationException;
@@ -42,6 +43,18 @@ public class MCRPDFAValidator {
     private static volatile Boolean initialized = false;
 
     private static final Object MUTEX = new Object();
+
+    private static final String CORE_RELEASE_ID = "core";
+
+    /**
+     * Returns the version of the underlying veraPDF library. Validation results of different versions are not
+     * comparable, so persisted results should record the version they were produced with.
+     *
+     * @return the veraPDF version
+     */
+    public static String getVersion() {
+        return ReleaseDetails.byId(CORE_RELEASE_ID).getVersion();
+    }
 
     private static void initialise() {
         if (!initialized) {

--- a/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAValidatorResolver.java
+++ b/mycore-validation/src/main/java/org/mycore/validation/pdfa/MCRPDFAValidatorResolver.java
@@ -45,7 +45,11 @@ import org.w3c.dom.Document;
  *<p><br>
  * Note: This implementation assumes that the 'href' parameter follows the 'mcrpdfa:{derivateId}' format, and the 'base'
  * parameter is not used in the resolution process.
+ *
+ * @deprecated Validating while a document is transformed can take long enough to time out the request. Use
+ *             {@link MCRPDFAReportResolver} instead, which reads reports that were produced asynchronously.
  */
+@Deprecated
 public class MCRPDFAValidatorResolver implements URIResolver {
 
     @Override

--- a/mycore-validation/src/main/resources/components/validation/config/mycore.properties
+++ b/mycore-validation/src/main/resources/components/validation/config/mycore.properties
@@ -4,5 +4,25 @@
 #                                                                    #
 ######################################################################
 
+# Reads reports that were produced asynchronously, does not validate
+MCR.URIResolver.ModuleResolver.pdfAReport=org.mycore.validation.pdfa.MCRPDFAReportResolver
+
+# Deprecated: validates while the document is transformed, which may time out the request
 MCR.URIResolver.ModuleResolver.pdfAValidator=org.mycore.validation.pdfa.MCRPDFAValidatorResolver
 
+### Storage of the PDF/A validation reports, one report per PDF file
+MCR.PDFA.Report.BaseDir=%MCR.datadir%/verapdf
+# MCR.PDFA.Report.SlotLayout=4-2-2
+
+### Reports are neither produced nor kept for objects in one of these states
+### Category IDs of the classification named by MCR.Metadata.Service.State.Classification.ID
+MCR.PDFA.Report.ExcludedStates=published,blocked,deleted
+### Remove the reports of an object that enters an excluded state
+MCR.PDFA.Report.DeleteOnExcludedState=true
+
+MCR.EventHandler.MCRPath.090.Class=org.mycore.validation.pdfa.MCRPDFAValidationEventHandler
+MCR.EventHandler.MCRObject.090.Class=org.mycore.validation.pdfa.MCRPDFAValidationEventHandler
+MCR.EventHandler.MCRDerivate.090.Class=org.mycore.validation.pdfa.MCRPDFAValidationEventHandler
+
+MCR.QueuedJob.MCRPDFAValidationJobAction.JobThreads=1
+MCR.QueuedJob.OrdinaryJobs=%MCR.QueuedJob.OrdinaryJobs%,org.mycore.validation.pdfa.MCRPDFAValidationJobAction

--- a/mycore-validation/src/test/java/org/mycore/validation/pdfa/MCRPDFAFunctionsTest.java
+++ b/mycore-validation/src/test/java/org/mycore/validation/pdfa/MCRPDFAFunctionsTest.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mycore.validation.pdfa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+public class MCRPDFAFunctionsTest {
+
+    @Test
+    public void singleFileResultUsesTheSameMarkupAsTheDirectoryResult() throws Exception {
+        Element file = validate("/pdfA-1b.pdf", "sub/pdfA-1b.pdf");
+        assertEquals("file", file.getNodeName());
+        assertEquals("sub/pdfA-1b.pdf", file.getAttribute("name"));
+        assertEquals("1b", file.getAttribute("flavour"));
+        assertEquals(0, file.getElementsByTagName("failed").getLength());
+    }
+
+    @Test
+    public void singleFileResultReportsFailedRules() throws Exception {
+        Element file = validate("/noPdfA.pdf", "noPdfA.pdf");
+        assertTrue("expected failed rules", file.getElementsByTagName("failed").getLength() > 0);
+        Element failed = (Element) file.getElementsByTagName("failed").item(0);
+        assertNotNull(failed.getAttribute("clause"));
+        assertNotNull(failed.getAttribute("testNumber"));
+    }
+
+    @Test
+    public void validatorReportsItsVersion() {
+        assertTrue("expected a veraPDF version", MCRPDFAValidator.getVersion().matches("\\d+\\.\\d+.*"));
+    }
+
+    private static Element validate(String resource, String name) throws Exception {
+        Document document = MCRPDFAFunctions.getResult(resource(resource), name);
+        return document.getDocumentElement();
+    }
+
+    private static Path resource(String resource) throws URISyntaxException {
+        return Path.of(MCRPDFAFunctionsTest.class.getResource(resource).toURI());
+    }
+}

--- a/mycore-validation/src/test/java/org/mycore/validation/pdfa/MCRPDFAFunctionsTest.java
+++ b/mycore-validation/src/test/java/org/mycore/validation/pdfa/MCRPDFAFunctionsTest.java
@@ -19,8 +19,10 @@ package org.mycore.validation.pdfa;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 
@@ -46,6 +48,13 @@ public class MCRPDFAFunctionsTest {
         Element failed = (Element) file.getElementsByTagName("failed").item(0);
         assertNotNull(failed.getAttribute("clause"));
         assertNotNull(failed.getAttribute("testNumber"));
+    }
+
+    @Test
+    public void unreadableFilesAreNotReportedAsValidationErrors() {
+        // an I/O failure may be transient, so it must reach the caller instead of being persisted as a result
+        Path missing = Path.of("does-not-exist.pdf");
+        assertThrows(IOException.class, () -> MCRPDFAFunctions.getResult(missing, "does-not-exist.pdf"));
     }
 
     @Test

--- a/mycore-validation/src/test/java/org/mycore/validation/pdfa/MCRPDFAReportStoreTest.java
+++ b/mycore-validation/src/test/java/org/mycore/validation/pdfa/MCRPDFAReportStoreTest.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See https://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.mycore.validation.pdfa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.After;
+import org.junit.Test;
+import org.mycore.common.MCRTestCase;
+import org.mycore.common.content.MCRDOMContent;
+import org.mycore.common.MCRTestConfiguration;
+import org.mycore.common.MCRTestProperty;
+import org.mycore.common.config.MCRConfiguration2;
+import org.mycore.datamodel.ifs2.MCRStoreManager;
+import org.mycore.datamodel.metadata.MCRObjectID;
+
+@MCRTestConfiguration(properties = {
+    @MCRTestProperty(key = "MCR.Metadata.Type.derivate", string = "true"),
+    @MCRTestProperty(key = "MCR.PDFA.Report.SlotLayout", string = "4-2-2")
+})
+public class MCRPDFAReportStoreTest extends MCRTestCase {
+
+    private static final String DERIVATE = "mir_derivate_00000123";
+
+    @After
+    public void removeStores() {
+        MCRStoreManager.removeStore("PDFA_mir_derivate");
+        MCRStoreManager.removeStore("PDFA_foo_derivate");
+    }
+
+    @Test
+    public void reportIsNamedAfterItsPdfFile() {
+        MCRPDFAReportStore store = obtainStore();
+        Path directory = store.getReportDirectory(derivateId());
+        assertEquals("chapter.xml", directory.relativize(store.getReportFile(derivateId(), "chapter.pdf")).toString());
+        assertEquals(Path.of("sub", "chapter.xml"),
+            directory.relativize(store.getReportFile(derivateId(), "sub/chapter.pdf")));
+        assertEquals(Path.of("other", "chapter.xml"),
+            directory.relativize(store.getReportFile(derivateId(), "/other/chapter.pdf")));
+        assertEquals("mcrdata.xml", directory.relativize(store.getReportFile(derivateId(), "mcrdata.pdf")).toString());
+        assertEquals("CHAPTER.xml", directory.relativize(store.getReportFile(derivateId(), "CHAPTER.PDF")).toString());
+        assertEquals("no-extension.xml",
+            directory.relativize(store.getReportFile(derivateId(), "no-extension")).toString());
+    }
+
+    @Test
+    public void reportDirectoryUsesTheSlotLayout() {
+        Path directory = obtainStore().getReportDirectory(derivateId());
+        assertEquals(Path.of("0000", "01", "mir_derivate_00000123"),
+            obtainStore().getBaseDirectory().relativize(directory));
+        assertEquals(Path.of("mir", "derivate"),
+            Path.of(MCRConfiguration2.getStringOrThrow("MCR.PDFA.Report.BaseDir"))
+                .relativize(obtainStore().getBaseDirectory()));
+    }
+
+    @Test
+    public void storesOfDifferentProjectsAreSeparated() {
+        MCRObjectID otherId = MCRObjectID.getInstance("foo_derivate_00000123");
+        assertNotEquals(obtainStore().getReportFile(derivateId(), "chapter.pdf"),
+            MCRPDFAReportStore.obtainInstance(otherId).getReportFile(otherId, "chapter.pdf"));
+    }
+
+    @Test
+    public void reportIsWrittenEvenIfNoReportExistsYet() throws Exception {
+        MCRPDFAReportStore store = obtainStore();
+        Path target = store.getReportFile(derivateId(), "sub/chapter.pdf");
+        store.writeReport(derivateId(), "sub/chapter.pdf", new MCRDOMContent(report()));
+        assertTrue("report was not written to " + target, Files.isRegularFile(target));
+        assertTrue(Files.readString(target).contains("flavour=\"1b\""));
+    }
+
+    @Test
+    public void reportReplacesAnOlderReportOfTheSameFile() throws Exception {
+        MCRPDFAReportStore store = obtainStore();
+        Path target = store.getReportFile(derivateId(), "chapter.pdf");
+        store.writeReport(derivateId(), "chapter.pdf", new MCRDOMContent(report()));
+        store.writeReport(derivateId(), "chapter.pdf", new MCRDOMContent(report()));
+        assertTrue(Files.isRegularFile(target));
+        try (Stream<Path> files = Files.list(target.getParent())) {
+            assertEquals("no temporary files may be left behind", List.of(target), files.toList());
+        }
+    }
+
+    private static org.w3c.dom.Document report() throws Exception {
+        Path pdf = Path.of(MCRPDFAReportStoreTest.class.getResource("/pdfA-1b.pdf").toURI());
+        return MCRPDFAFunctions.getResult(pdf, "chapter.pdf");
+    }
+
+    @Test
+    public void pathsOutsideOfTheDerivateAreRejected() {
+        MCRPDFAReportStore store = obtainStore();
+        assertThrows(IllegalArgumentException.class, () -> store.getReportFile(derivateId(), "../escaped.pdf"));
+    }
+
+    private static MCRObjectID derivateId() {
+        return MCRObjectID.getInstance(DERIVATE);
+    }
+
+    private MCRPDFAReportStore obtainStore() {
+        return MCRPDFAReportStore.obtainInstance(derivateId());
+    }
+
+    @Override
+    protected Map<String, String> getTestProperties() {
+        Map<String, String> properties = super.getTestProperties();
+        properties.put("MCR.PDFA.Report.BaseDir", junitFolder.getRoot().toPath().resolve("verapdf").toString());
+        return properties;
+    }
+}

--- a/mycore-validation/src/test/java/org/mycore/validation/pdfa/MCRPDFAReportStoreTest.java
+++ b/mycore-validation/src/test/java/org/mycore/validation/pdfa/MCRPDFAReportStoreTest.java
@@ -56,15 +56,21 @@ public class MCRPDFAReportStoreTest extends MCRTestCase {
     public void reportIsNamedAfterItsPdfFile() {
         MCRPDFAReportStore store = obtainStore();
         Path directory = store.getReportDirectory(derivateId());
-        assertEquals("chapter.xml", directory.relativize(store.getReportFile(derivateId(), "chapter.pdf")).toString());
-        assertEquals(Path.of("sub", "chapter.xml"),
+        assertEquals("chapter.pdf.xml",
+            directory.relativize(store.getReportFile(derivateId(), "chapter.pdf")).toString());
+        assertEquals(Path.of("sub", "chapter.pdf.xml"),
             directory.relativize(store.getReportFile(derivateId(), "sub/chapter.pdf")));
-        assertEquals(Path.of("other", "chapter.xml"),
+        assertEquals(Path.of("other", "chapter.pdf.xml"),
             directory.relativize(store.getReportFile(derivateId(), "/other/chapter.pdf")));
-        assertEquals("mcrdata.xml", directory.relativize(store.getReportFile(derivateId(), "mcrdata.pdf")).toString());
-        assertEquals("CHAPTER.xml", directory.relativize(store.getReportFile(derivateId(), "CHAPTER.PDF")).toString());
-        assertEquals("no-extension.xml",
-            directory.relativize(store.getReportFile(derivateId(), "no-extension")).toString());
+        assertEquals("mcrdata.pdf.xml",
+            directory.relativize(store.getReportFile(derivateId(), "mcrdata.pdf")).toString());
+    }
+
+    @Test
+    public void caseVariantsOfThePdfSuffixGetTheirOwnReport() {
+        MCRPDFAReportStore store = obtainStore();
+        assertNotEquals(store.getReportFile(derivateId(), "chapter.pdf"),
+            store.getReportFile(derivateId(), "chapter.PDF"));
     }
 
     @Test


### PR DESCRIPTION
Validation moved into a mycore-jobqueue job that stores one report per PDF file in an MCRStore below %MCR.datadir%/verapdf. A report is reused while it still records the file's last modification and the veraPDF version in use, and is (re)scheduled on file changes or when it is missing. Reports are only kept for derivates whose parent object is not in an excluded state (published, blocked, deleted by default) and are removed on state change or deletion.

The new resolver pdfAReport:{derivateId} returns those reports and marks files without a current one as pending, so page rendering never parses a PDF.

Deprecates MCRPDFAValidatorResolver (pdfAValidator:{derivateId}), which validates every PDF while the page is transformed and can take long enough for a proxy to time out the request.

[Link to jira](https://mycore.atlassian.net/browse/MCR-3833).

# Pull Request Checklist (Author)

Please go through the following checklist before assigning the PR for review:

## Ticket & Documentation
- [x] The issue in the ticket is clearly described and the solution is documented.
- [x] Design decisions (if any) are explained.
- [x] The ticket references the correct source and target branches.
- [x] The `fixed-version` is correctly set in the ticket and matches the PR's target branch (`main`).

## Feature & Improvement Specific Checks
- [ ] Instructions on how to test or use the feature are included or linked (e.g. to documentation).
- [ ] For UI changes: before & after screenshots are attached.
- [ ] New features or migrations are documented.
- [ ] Does this change affect existing applications, data, or configurations?
  - [ ] Yes: Is a migration required? If yes, describe it.
  - [ ] Breaking change is marked in the **commit message**.

## Bugfix-Specific Checks
- [x] Affected version is listed in the ticket.
- [x] Minimal code changes were made (no refactoring).
- [x] This PR truly fixes **only** the reported bug.
- [x] No breaking changes are introduced.
- [ ] A relevant test was added (if feasible).

## Testing
- [x] I have tested the changes locally.
- [x] The feature behaves as described in the ticket.
- [ ] Were existing tests modified?
  - [ ] Yes: explain the changes for reviewers.

## MCR Conventions & Metadata
- [x] [MCR naming conventions](https://www.mycore.de/documentation/developer/conventions/) are followed
- [x] If the **public API** has changed:
  - [x] Old API is deprecated or a migration is documented.
  - [ ] If not, no action needed.
- [ ] Java license headers are added where necessary.
- [ ] Javadoc is written for non-self-explanatory classes/methods (Clean Code).
- [ ] All configuration options are documented in Javadoc and `mycore.properties`.
- [ ] No default properties are hardcoded — all set via `mycore.properties`.

## Multi-Repo Considerations
- [ ] Is an equivalent PR in `MIR` required?
  - [ ] If yes, is it already created?
